### PR TITLE
add config.h

### DIFF
--- a/php_pthreads.h
+++ b/php_pthreads.h
@@ -20,6 +20,10 @@
 #define PHP_PTHREADS_EXTNAME "pthreads"
 #define PHP_PTHREADS_VERSION "0.21"
 
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
 PHP_MINIT_FUNCTION(pthreads);							/* Initialize class entries and default attributes */
 PHP_MSHUTDOWN_FUNCTION(pthreads);						/* Destroy default attributes */
 


### PR DESCRIPTION
can't install pthreads ext as a shared extension.

`COMPILE_DL_PTHREADS` constant defined at `config.h` so 
below block always skip current settings.

```
#if COMPILE_DL_PTHREADS
ZEND_GET_MODULE(pthreads)
#endif
```
