### PR TITLE
OSX: add static storage class for `pthreads_equal_func`

### DIFF
--- a/pthreads_thread.h
+++ b/pthreads_thread.h
@@ -90,7 +90,7 @@ int pthreads_equal(PTHREAD first, PTHREAD second) {
 } /* }}} */
 
 /* {{{ comparison callback for llists */
-inline int pthreads_equal_func(void **first, void **second){
+static inline int pthreads_equal_func(void **first, void **second){
 	return pthreads_equal((PTHREAD)*first, (PTHREAD)*second);
 } /* }}} */
 


### PR DESCRIPTION
I'm not sure why can't find `pthreads_equal_func` symbol on OSX. this PR fix the problem.

here are my research:

compile assemble file.

```
cc -I. -I/Users/chobie/src/pthreads -DPHP_ATOM_INC -I/Users/chobie/src/pthreads/include -I/Users/chobie/src/pthreads/main -I/Users/chobie/src/pthreads -I/Users/chobie/.phpenv/versions/5.4.7-thread-goto/include/php -I/Users/chobie/.phpenv/versions/5.4.7-thread-goto/include/php/main -I/Users/chobie/.phpenv/versions/5.4.7-thread-goto/include/php/TSRM -I/Users/chobie/.phpenv/versions/5.4.7-thread-goto/include/php/Zend -I/Users/chobie/.phpenv/versions/5.4.7-thread-goto/include/php/ext -I/Users/chobie/.phpenv/versions/5.4.7-thread-goto/include/php/ext/date/lib -DHAVE_CONFIG_H -g -O2 -c -S /Users/chobie/src/pthreads/php_pthreads.c  -fno-common -DPIC
```

and  assembled file looks up `pthreads_equal_func` from GOT. but there is no reference on OSX.

```
    movq    _pthreads_equal_func@GOTPCREL(%rip), %rdx
```

Thanks,
