### PR TITLE
Fixed segfault with some compilers in store.c

### DIFF
--- a/src/store.c
+++ b/src/store.c
@@ -261,14 +261,12 @@ int pthreads_store_shift(zval *object, zval **member TSRMLS_DC) {
             char *key;
             uint klen;
             ulong idx;
-            
+            int flag;
+
             pthreads_store_convert(storage, *member TSRMLS_CC);
-            
-            zend_hash_del_key_or_index(
-                table, key, klen, idx, zend_hash_get_current_key_ex(
-                    table, &key, &klen, &idx, 0, &position
-                ) == HASH_KEY_IS_STRING ? HASH_DEL_KEY : HASH_DEL_INDEX);
-            
+
+            flag = zend_hash_get_current_key_ex(table, &key, &klen, &idx, 0, &position) == HASH_KEY_IS_STRING ? HASH_DEL_KEY : HASH_DEL_INDEX;
+            zend_hash_del_key_or_index(table, key, klen, idx, flag);
         } else ZVAL_NULL(*member);
         
         pthreads_store_unlock(object TSRMLS_CC);


### PR DESCRIPTION
There was no sequence point, so the compiler might first pass the value of key (which is then `((char *)bogus heap memory)`) to `zend_hash_del_key_or_index` and only then fetch the value of key via `zend_hash_get_current_key_ex`. (Assembly told me that llvm-gcc really did so...)
Separating it into two different statements inserts a sequence point there so that key is guaranteed to be a valid pointer.
