### PR TITLE
Added sequence point in pthreads_store_chunk

### DIFF
--- a/src/store.c
+++ b/src/store.c
@@ -304,10 +304,9 @@ int pthreads_store_chunk(zval *object, long size, zend_bool preserve, zval **chu
             
             pthreads_store_convert(storage, member TSRMLS_CC);
             
-            zend_hash_del_key_or_index(
-                table, key, klen, idx, (ktype = zend_hash_get_current_key_ex(
-                    table, &key, &klen, &idx, 0, &position
-                )) == HASH_KEY_IS_STRING ? HASH_DEL_KEY : HASH_DEL_INDEX);
+            ktype = zend_hash_get_current_key_ex(table, &key, &klen, &idx, 0, &position) == HASH_KEY_IS_STRING ?
+            	HASH_DEL_KEY : HASH_DEL_INDEX;
+            zend_hash_del_key_or_index(table, key, klen, idx, ktype);
             
             if (!preserve) {
                 zend_hash_next_index_insert(


### PR DESCRIPTION
Following code snippet was causing a seg fault on my build (Apple LLVM version 5.1 (clang-503.0.40))

```
$obj = new Threaded();

for($n = 0; $n < 100; ++$n){
    $obj[] = $n;
}

var_dump($obj->chunk(10));
```

Added sequence point to prevent ambiguous param evaluation order when calling zend_hash_get_current_key_ex inline with zend_hash_del_key_or_index.
