### PR TITLE
fix chunk() key preservation after #323

### DIFF
--- a/src/store.c
+++ b/src/store.c
@@ -303,10 +303,10 @@ int pthreads_store_chunk(zval *object, long size, zend_bool preserve, zval **chu
             ALLOC_INIT_ZVAL(member);
             
             pthreads_store_convert(storage, member TSRMLS_CC);
-            
-            ktype = zend_hash_get_current_key_ex(table, &key, &klen, &idx, 0, &position) == HASH_KEY_IS_STRING ?
-            	HASH_DEL_KEY : HASH_DEL_INDEX;
-            zend_hash_del_key_or_index(table, key, klen, idx, ktype);
+           
+            ktype = zend_hash_get_current_key_ex(table, &key, &klen, &idx, 0, &position);
+            zend_hash_del_key_or_index(table, key, klen, idx, ktype == HASH_KEY_IS_STRING ?
+            	HASH_DEL_KEY : HASH_DEL_INDEX);
             
             if (!preserve) {
                 zend_hash_next_index_insert(


### PR DESCRIPTION
ktype was no longer correctly set making chunk() key preservation option to fail.
