### PR TITLE
Fixed double checking (checking checking for ZTS... configure: error: ...)

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -5,7 +5,7 @@ PHP_ARG_ENABLE(pthreads-pedantic, whether to enable pedantic locking,
 
 if test "$PHP_PTHREADS" != "no"; then
 	AC_DEFINE(HAVE_PTHREADS, 1, [Wether you have user-land threading support])
-	AC_MSG_CHECKING([checking for ZTS])   
+	AC_MSG_CHECKING([for ZTS])   
 	if test "$PHP_THREAD_SAFETY" != "no"; then
 		AC_MSG_RESULT([ok])
 	else


### PR DESCRIPTION
Otherwise produces on failed install where ZTS is not present:
checking whether to enable Threading API... yes, shared
checking whether to enable pedantic locking... no
checking checking for ZTS... configure: error: pthreads requires ZTS, please re-compile PHP with ZTS enabled
ERROR: `/var/tmp/pthreads/configure' failed
