### PR TITLE
Multiple fixes to shared resource handling/keeping

### DIFF
--- a/src/object.c
+++ b/src/object.c
@@ -1058,8 +1058,14 @@ static void * pthreads_routine(void *arg) {
 		pthreads_globals_lock(&glocked TSRMLS_CC);
 #endif
 		/* shutdown request */
-	    php_request_shutdown(TSRMLS_C);
-	    
+
+		/* TOFIX: php_request_shutdown() destroyes PTHREADS_ZG(resources)
+		 * before destroying EG(symbol_table): resources marked for keeping will
+		 * be destroyed if stored in local variables inside ::run() and not
+		 * destroyed in userland.
+		 */
+		php_request_shutdown(TSRMLS_C);
+
 #ifdef PTHREADS_PEDANTIC
 		/* release global lock */
 		pthreads_globals_unlock(glocked TSRMLS_CC);

--- a/src/prepare.c
+++ b/src/prepare.c
@@ -780,7 +780,10 @@ static void pthreads_prepared_resource_dtor(zend_rsrc_list_entry *entry) {
 		if (!pthreads_resources_kept(entry TSRMLS_CC)){
 			if (PTHREADS_G(default_resource_dtor))
 				PTHREADS_G(default_resource_dtor)(entry);
-		}
+		} else if (PTHREADS_ZG(resources)) {
+                    /* the resource was marked for keeping but we no longer have any reference to it */
+                    zend_hash_del(PTHREADS_ZG(resources), (char*)entry, sizeof(void*));
+                }
 	} zend_end_try();
 } /* }}} */
 

--- a/src/store.c
+++ b/src/store.c
@@ -569,25 +569,26 @@ static int pthreads_store_convert(pthreads_storage *storage, zval *pzval TSRMLS_
 				if (resource->ls != TSRMLS_C && zend_hash_index_find(&PTHREADS_EG(resource->ls, regular_list), storage->simple.lval, (void**)&original)==SUCCESS) {
 				
 					zend_bool found = 0;
-					int existed = 0;
+					ulong existing;
 					{
 						zend_rsrc_list_entry *search;
 						HashPosition position;
 						for(zend_hash_internal_pointer_reset_ex(&EG(regular_list), &position);
-							zend_hash_get_current_data_ex(&EG(regular_list), (void**) &search, &position)==SUCCESS;
-							zend_hash_move_forward_ex(&EG(regular_list), &position)) {			
+								zend_hash_get_current_data_ex(&EG(regular_list), (void**) &search, &position)==SUCCESS;
+								zend_hash_move_forward_ex(&EG(regular_list), &position)) {
+
 							if (search->ptr == original->ptr) {
 								found=1;
-								existed++;
+								existing = position->h;
 								break;
-							} else ++existed;
+							}
 						}
 					}
 					
 					if (!found) {
 					    zend_rsrc_list_entry create;
 					    {
-						    int created;
+						    ulong created;
 							
 						    create.type = original->type;
 						    create.ptr = original->ptr;
@@ -602,7 +603,7 @@ static int pthreads_store_convert(pthreads_storage *storage, zval *pzval TSRMLS_
 						    } else ZVAL_NULL(pzval);
 					    }
 					} else {
-						ZVAL_RESOURCE(pzval, existed);
+						ZVAL_RESOURCE(pzval, existing);
 						zend_list_addref(Z_RESVAL_P(pzval));
 					}
 				} else {


### PR DESCRIPTION
- Fix address collision in PTHREADS_ZG(resources) (8787eff)

Each time a resource created in another thread context is used, its address is added to `PTHREADS_ZG(resources)`. Until then it was never removed and since `PTHREADS_ZG(resources)` is tested on every resource destruction attempt, collisions would occur after some time (when `PTHREADS_ZG(resources)` contains a few hundred addresses) preventing unrelated resources from being destroyed and causing memory access violations.

Here is what was observed with Valgrind:
```
Thread 12:
==00:00:35:12.339 23371== Invalid read of size 8
==00:00:35:12.339 23371==    at 0x896C451: pthreads_resources_kept (resources.c:51)
==00:00:35:12.339 23371==    by 0x896809A: pthreads_prepared_resource_dtor (prepare.c:780)
==00:00:35:12.339 23371==    by 0x98AAF2: i_zend_hash_bucket_delete (zend_hash.c:182)
==00:00:35:12.339 23371==    by 0x98C3CB: zend_hash_del_key_or_index (zend_hash.c:526)
==00:00:35:12.339 23371==    by 0x98F0E2: _zend_list_delete (zend_list.c:57)
==00:00:35:12.339 23371==    by 0x8D9C12: _php_stream_free (streams.c:470)
==00:00:35:12.339 23371==    by 0x803445: zif_fclose (file.c:914)
==00:00:35:12.339 23371==    by 0x9C526F: zend_do_fcall_common_helper_SPEC (zend_vm_execute.h:558)
==00:00:35:12.339 23371==    by 0x9CBD4B: ZEND_DO_FCALL_SPEC_CONST_HANDLER (zend_vm_execute.h:2595)
==00:00:35:12.339 23371==    by 0x9C44C6: execute_ex (zend_vm_execute.h:363)
==00:00:35:12.339 23371==    by 0x9C45AB: zend_execute (zend_vm_execute.h:388)
==00:00:35:12.339 23371==    by 0x8970EE2: pthreads_routine (object.c:967)
==00:00:35:12.339 23371==    by 0x6B6DB4F: start_thread (pthread_create.c:304)
==00:00:35:12.339 23371==  Address 0x162f9378 is not stack'd, malloc'd or (recently) free'd
```

Further debugging with gdb querying PHP's internal structures proved that the zif_fclose (fclose()) call triggering this overflow was closing an unrelated local resource that could not have been added to `PTHREADS_ZG(resources)`

~~This fix resets `PTHREADS_ZG(resources)` to what it was after the initial `worker::run()` before executing any new tasks.~~
This fix removes resources from PTHREADS_ZG(resources) when their dtor is called.

While working on this fix I uncovered another bug: `php_request_shutdown()` destroys `PTHREADS_ZG(resources)` before destroying `EG(symbol_table)` which prevent resources to be kept in `::run()`'s 'local' variables when a worker is terminated.
I couldn't imagine a simple fix for that one except using a persistent global variable for `PTHREADS_ZG(resources)` so I just added a note as there might be a better way...

- Foreign resources could only be extracted from a pthreads_storage once (2468f16)

previously observed:
```php
$socket = $this->threadedSocketHolder["0"]; // a socket created in another thread
is_resource($socket); // ==> true
is_resource($this->threadedSocketHolder["0"]); // ==> false
gettype($this->threadedSocketHolder["0"]); //==> 'unknown type'
```

now correctly gives:
````php
$socket = $this->threadedSocketHolder["0"]; // a socket created in another thread
is_resource($socket); // ==> true
is_resource($this->threadedSocketHolder["0"]); // ==> true
gettype($this->threadedSocketHolder["0"]); ==> 'resource'
$socket === $this->threadedSocketHolder["0"]; ==> true
```