### PR TITLE
PTHREADS_ZG(resources) destroyed too early

### DIFF
--- a/php_pthreads.c
+++ b/php_pthreads.c
@@ -306,7 +306,13 @@ PHP_MSHUTDOWN_FUNCTION(pthreads)
 	if (pthreads_instance == TSRMLS_C) {
 		pthreads_globals_shutdown(TSRMLS_C);
 	}
-	
+
+	if (PTHREADS_ZG(resources)) {
+		zend_hash_destroy(PTHREADS_ZG(resources));
+		FREE_HASHTABLE(PTHREADS_ZG(resources));
+		PTHREADS_ZG(resources) = NULL;
+	}
+
 	return SUCCESS;
 }
 
@@ -326,12 +332,6 @@ PHP_RSHUTDOWN_FUNCTION(pthreads) {
 	zend_hash_destroy(PTHREADS_ZG(resolve));
 	FREE_HASHTABLE(PTHREADS_ZG(resolve));
 
-	if (PTHREADS_ZG(resources)) {
-		zend_hash_destroy(PTHREADS_ZG(resources));	
-		FREE_HASHTABLE(PTHREADS_ZG(resources));
-		PTHREADS_ZG(resources) = NULL;
-	}
-	
 	zend_hash_destroy(PTHREADS_ZG(cache));
 	FREE_HASHTABLE(PTHREADS_ZG(cache));
 }

--- a/php_pthreads.c
+++ b/php_pthreads.c
@@ -72,7 +72,9 @@ zend_module_entry pthreads_module_entry = {
   PHP_RSHUTDOWN(pthreads),
   PHP_MINFO(pthreads),
   PHP_PTHREADS_VERSION,
-  STANDARD_MODULE_PROPERTIES
+  NO_MODULE_GLOBALS,
+  ZEND_MODULE_POST_ZEND_DEACTIVATE_N(pthreads),
+  STANDARD_MODULE_PROPERTIES_EX
 };
 
 zend_class_entry *pthreads_threaded_entry;
@@ -306,6 +308,13 @@ PHP_MSHUTDOWN_FUNCTION(pthreads)
 	if (pthreads_instance == TSRMLS_C) {
 		pthreads_globals_shutdown(TSRMLS_C);
 	}
+
+	return SUCCESS;
+}
+
+ZEND_MODULE_POST_ZEND_DEACTIVATE_D(pthreads)
+{
+	TSRMLS_FETCH();
 
 	if (PTHREADS_ZG(resources)) {
 		zend_hash_destroy(PTHREADS_ZG(resources));

--- a/php_pthreads.h
+++ b/php_pthreads.h
@@ -25,6 +25,7 @@ PHP_MSHUTDOWN_FUNCTION(pthreads);
 PHP_RINIT_FUNCTION(pthreads);
 PHP_RSHUTDOWN_FUNCTION(pthreads);
 PHP_MINFO_FUNCTION(pthreads);
+ZEND_MODULE_POST_ZEND_DEACTIVATE_D(pthreads);
 
 #ifndef HAVE_PTHREADS_CLASS_THREADED_H
 #	include <classes/threaded.h>

--- a/src/object.c
+++ b/src/object.c
@@ -1058,12 +1058,6 @@ static void * pthreads_routine(void *arg) {
 		pthreads_globals_lock(&glocked TSRMLS_CC);
 #endif
 		/* shutdown request */
-
-		/* TOFIX: php_request_shutdown() destroyes PTHREADS_ZG(resources)
-		 * before destroying EG(symbol_table): resources marked for keeping will
-		 * be destroyed if stored in local variables inside ::run() and not
-		 * destroyed in userland.
-		 */
 		php_request_shutdown(TSRMLS_C);
 
 #ifdef PTHREADS_PEDANTIC

--- a/src/resources.c
+++ b/src/resources.c
@@ -31,7 +31,7 @@
 zend_bool pthreads_resources_keep(pthreads_resource data TSRMLS_DC) {
 	if (!PTHREADS_ZG(resources)) {
 		ALLOC_HASHTABLE(PTHREADS_ZG(resources));
-		zend_hash_init(PTHREADS_ZG(resources), 15, NULL, NULL, 0);
+		zend_hash_init(PTHREADS_ZG(resources), 15, NULL, NULL, 1);
 	}
 	
 	if (zend_hash_update(PTHREADS_ZG(resources),

--- a/tests/resource-keeping.phpt
+++ b/tests/resource-keeping.phpt
@@ -1,0 +1,148 @@
+--TEST--
+Test sane handling of resources from foreign contexts
+--DESCRIPTION--
+Test that resources from other thread contexts can properly be accessed and are only destroyed by their owner
+--FILE--
+<?php
+class myWorker extends Worker {
+    private $foreignResource;
+
+    public function __construct($useResource) {
+        $this->foreignResource = $useResource;
+        var_dump([
+            'Resource received and stored:',
+            is_resource($useResource),
+            is_resource($this->foreignResource),
+        ]);
+    }
+
+    public function run () {
+
+        // polute EG(regular_list) with another resource of our own
+        $localThreadFP = tmpfile();
+
+        var_dump(array(
+            'Foreign resource conversion test:',
+
+            // test conversion followed by destruction
+            // the resource shall be added and removed from
+            // PTHREADS_ZG(resources) and EG(regular_list) by the following
+            // statement:
+
+            is_resource($this->foreignResource),
+
+            // now make the resource permanently available locally to tasks by
+            // storing it in a variable. It will stay in PTHREADS_ZG(resources)
+            // and EG(regular_list) until the worker is shutdown):
+
+            is_resource($foreignResource = $this->foreignResource),
+
+            // test that we still get the correct resource when it's already in
+            // EG(regular_list)
+            $foreignResource === $this->foreignResource
+        ));
+
+        fclose($localThreadFP);
+    }
+
+}
+
+class Work extends Threaded {
+
+    public function run () {
+
+        var_dump(array(
+            'Foreign resource is accessible from task:',
+            is_resource($foreignResource),
+            $foreignResource === $this->worker->foreignResource,
+            'wrote ' . fwrite($foreignResource, '42') . ' bytes',
+        ));
+
+    }
+}
+
+$fp = tmpfile();
+
+$task = new Work();
+
+$worker = new myWorker($fp);
+$worker->start();
+$worker->stack($task);
+
+var_dump(array(
+    'Our worker is shutdown:',
+    $worker->shutdown(),
+));
+
+var_dump(array(
+    'Our resource is still valid:',
+    is_resource($fp) && rewind($fp),
+    fread($fp, 2) === "42",
+));
+
+var_dump(array(
+    'Our resource can be closed:',
+     fclose($fp),
+ ));
+
+var_dump(array(
+    'Our resource is closed:',
+    !is_resource($fp),
+));
+?>
+--EXPECT--
+array(3) {
+  [0]=>
+  string(29) "Resource received and stored:"
+  [1]=>
+  bool(true)
+  [2]=>
+  bool(true)
+}
+array(4) {
+  [0]=>
+  string(33) "Foreign resource conversion test:"
+  [1]=>
+  bool(true)
+  [2]=>
+  bool(true)
+  [3]=>
+  bool(true)
+}
+array(4) {
+  [0]=>
+  string(41) "Foreign resource is accessible from task:"
+  [1]=>
+  bool(true)
+  [2]=>
+  bool(true)
+  [3]=>
+  string(13) "wrote 2 bytes"
+}
+array(2) {
+  [0]=>
+  string(23) "Our worker is shutdown:"
+  [1]=>
+  bool(true)
+}
+array(3) {
+  [0]=>
+  string(28) "Our resource is still valid:"
+  [1]=>
+  bool(true)
+  [2]=>
+  bool(true)
+}
+array(2) {
+  [0]=>
+  string(27) "Our resource can be closed:"
+  [1]=>
+  bool(true)
+}
+array(2) {
+  [0]=>
+  string(23) "Our resource is closed:"
+  [1]=>
+  bool(true)
+}
+


### PR DESCRIPTION
Finally fixed the issue uncovered by working on #404, the fix was actually simple:

PTHREADS_ZG(resources) was destroyed before destroying EG(symbol_table): resources marked for keeping would be destroyed if stored in local variables inside ::run() and not destroyed in user-land before the end of the process.

This is fixed by declaring the PTHREADS_ZG(resources) hash-table as persistent and destroying it in ~~PHP_MSHUTDOWN_FUNCTION~~ ZEND_MODULE_POST_ZEND_DEACTIVATE_D  instead of in PHP_RSHUTDOWN_FUNCTION. Since PTHREADS_ZG(resources) is necessarily left empty at the end of a request, there is no memory waste.

I also added nice tests for this issue (3704fa9) and the previous one (2468f16).

Another thing I like to do is make Pthreads throw an exception if the user tries to explicitly close a foreign resource because doing that now will cause a segmentation fault when the resource is re-accessed in its owner...