### PR TITLE
Fix #273 by fixing the test

### DIFF
--- a/tests/killed-info.phpt
+++ b/tests/killed-info.phpt
@@ -6,14 +6,27 @@ This test verifies that ::kill sets state and error information
 <?php
 class TestThread extends Thread
 {
+    public $started = false;
+
     public function run()
     {
+        $this->synchronized(function($that) {
+            $that->started = true;
+            $that->notify();
+        }, $this);
+
         sleep(5);
     }
 }
 
 $t = new TestThread();
 $t->start();
+
+$t->synchronized(function($that) {
+    while (! $that->started)
+        $that->wait();
+}, $t);
+
 $t->kill();
 $t->join();
 


### PR DESCRIPTION
Wait for the thread to finish starting before killing it else the killed thread could be signalled while in pthread_cond_broadcast() triggered by pthreads_state_set(current->state, PTHREADS_ST_RUNNING TSRMLS_CC) in src/object.c:951

Bug analysis: https://github.com/krakjoe/pthreads/issues/273#issuecomment-68620832