### PR TITLE
Fix possible race condition in tests/binding.phpt as seen in #424

### DIFF
--- a/tests/binding.phpt
+++ b/tests/binding.phpt
@@ -12,8 +12,10 @@ class ThreadTesting extends Thread {
 		$this->other = $other;
 	}
 	public function run(){
-		$this->done = true;
-		$this->notify();
+		$this->synchronized(function($that) {
+			$that->done = true;
+			$that->notify();
+		}, $this);
 	}
 }
 
@@ -25,8 +27,10 @@ class ThreadTest extends Thread {
 		$this->other = $other;
 	}
 	public function run(){
-		$this->done = true;
-		$this->notify();
+		$this->synchronized(function($that) {
+			$that->done = true;
+			$that->notify();
+		}, $this);
 	}
 }
 


### PR DESCRIPTION
`::notify()` calls were not synchronized and so in the following code:

```php
foreach($threads as $thread) {
	$thread->synchronized(function() use($thread){
		if (!$thread->done)
			var_dump($thread->wait());
		else var_dump($thread->done);
	});
}
```

`$thread->done()` could be set to true just between the `if` and the `::wait()` if the treads are started faster than usual as is expected with #424.