### PR TITLE
Fix #391 for PHP 5.x

### DIFF
--- a/src/copy.h
+++ b/src/copy.h
@@ -41,7 +41,7 @@ static HashTable* pthreads_copy_statics(HashTable *old) {
 		) {
 			zend_hash_get_current_key_ex(old, &key_str, &key_str_length, &num_index, 0, &pos);
 
-			if (Z_TYPE_P(*value) != IS_OBJECT && Z_TYPE_P(*value) != IS_RESOURCE) {
+			if (Z_TYPE_PP(value) != IS_ARRAY && Z_TYPE_PP(value) != IS_OBJECT && Z_TYPE_PP(value) != IS_RESOURCE) {
 				zval *copy;
 				ALLOC_ZVAL(copy);
 				MAKE_COPY_ZVAL(value, copy);

--- a/src/copy.h
+++ b/src/copy.h
@@ -21,20 +21,36 @@
 /* {{{ */
 static HashTable* pthreads_copy_statics(HashTable *old) {
 	HashTable *statics = NULL;
-	
+
 	if (old) {
-		zval *tmp;
-	
+		HashPosition pos;
+		zval **value;
+
+		char *key_str;
+		uint key_str_length;
+		ulong num_index;
+
 		ALLOC_HASHTABLE(statics);
 		zend_hash_init(statics,
-			zend_hash_num_elements(old), 
+			zend_hash_num_elements(old),
 			NULL, ZVAL_PTR_DTOR, 0);
-		zend_hash_copy(
-			statics, 
-			old, (copy_ctor_func_t) zval_add_ref, 
-			(void*)&tmp, sizeof(zval*));
+
+		for (zend_hash_internal_pointer_reset_ex(old, &pos);
+			 zend_hash_get_current_data_ex(old, (void **) &value, &pos) == SUCCESS;
+			 zend_hash_move_forward_ex(old, &pos)
+		) {
+			zend_hash_get_current_key_ex(old, &key_str, &key_str_length, &num_index, 0, &pos);
+
+			if (Z_TYPE_P(*value) != IS_OBJECT && Z_TYPE_P(*value) != IS_RESOURCE) {
+				zval *copy;
+				ALLOC_ZVAL(copy);
+				MAKE_COPY_ZVAL(value, copy);
+
+				zend_hash_add(statics, key_str, key_str_length, &copy, sizeof(zval *), NULL);
+			}
+		}
 	}
-	
+
 	return statics;
 } /* }}} */
 
@@ -42,39 +58,39 @@ static HashTable* pthreads_copy_statics(HashTable *old) {
 static zend_compiled_variable* pthreads_copy_variables(zend_compiled_variable *old, int end) {
 	zend_compiled_variable *variables = safe_emalloc(end, sizeof(zend_compiled_variable), 0);
 	int it = 0;
-	
+
 	while (it < end) {
 		variables[it] = old[it];
 		variables[it].name = estrndup(
-			variables[it].name, 
+			variables[it].name,
 			variables[it].name_len);
 		it++;
 	}
-	
+
 	return variables;
 } /* }}} */
 
 /* {{{ */
-static zend_try_catch_element* pthreads_copy_try(zend_try_catch_element *old, int end) {	
+static zend_try_catch_element* pthreads_copy_try(zend_try_catch_element *old, int end) {
 	zend_try_catch_element *try_catch = safe_emalloc(end, sizeof(zend_try_catch_element), 0);
-	
+
 	memcpy(
-		try_catch, 
+		try_catch,
 		old,
 		sizeof(zend_try_catch_element) * end);
-	
+
 	return try_catch;
 } /* }}} */
 
 /* {{{ */
 static zend_brk_cont_element* pthreads_copy_brk(zend_brk_cont_element *old, int end) {
 	zend_brk_cont_element *brk_cont = safe_emalloc(end, sizeof(zend_brk_cont_element), 0);
-	
+
 	memcpy(
 		brk_cont,
-		old, 
+		old,
 		sizeof(zend_brk_cont_element) * end);
-	
+
 	return brk_cont;
 } /* }}} */
 
@@ -83,13 +99,13 @@ static zend_brk_cont_element* pthreads_copy_brk(zend_brk_cont_element *old, int 
 static zend_literal* pthreads_copy_literals(zend_literal *old, int end) {
 	zend_literal *literals = safe_emalloc(end, sizeof(zend_literal), 0);
 	int it = 0;
-	
+
 	while (it < end) {
 		literals[it] = old[it];
 		zval_copy_ctor(&literals[it].constant);
 		it++;
 	}
-	
+
 	return literals;
 } /* }}} */
 #endif
@@ -103,15 +119,15 @@ static zend_op* pthreads_copy_opcodes(zend_op_array *op_array) {
 #endif
 	zend_uint it = 0;
 	zend_op *copy = safe_emalloc(op_array->last, sizeof(zend_op), 0);
-	
+
 	while (it < op_array->last) {
 		copy[it] = op_array->opcodes[it];
 
 #if PHP_VERSION_ID >= 50400
 		if (copy[it].op1_type == IS_CONST) {
-			literal = 
+			literal =
 				(zend_literal*)(op_array->opcodes[it].op1.zv);
-			copy[it].op1.zv = 
+			copy[it].op1.zv =
 				&op_array->literals[literal - literals].constant;
 #else
 		if (copy[it].op1.op_type == IS_CONST) {
@@ -125,10 +141,10 @@ static zend_op* pthreads_copy_opcodes(zend_op_array *op_array) {
 				case ZEND_FAST_CALL:
 #endif
 #if PHP_VERSION_ID >= 50400
-					copy[it].op1.jmp_addr = copy + 
+					copy[it].op1.jmp_addr = copy +
 						(op_array->opcodes[it].op1.jmp_addr - op_array->opcodes);
 #else
-					copy[it].op1.u.jmp_addr = copy + 
+					copy[it].op1.u.jmp_addr = copy +
 						(op_array->opcodes[it].op1.u.jmp_addr - op_array->opcodes);
 #endif
 				break;
@@ -137,9 +153,9 @@ static zend_op* pthreads_copy_opcodes(zend_op_array *op_array) {
 
 #if PHP_VERSION_ID >= 50400
 		if (copy[it].op2_type == IS_CONST) {
-			literal = 
+			literal =
 				(zend_literal*)(op_array->opcodes[it].op2.zv);
-			copy[it].op2.zv = 
+			copy[it].op2.zv =
 				&op_array->literals[literal - literals].constant;
 #else
         if (copy[it].op2.op_type == IS_CONST) {
@@ -175,8 +191,8 @@ static zend_op* pthreads_copy_opcodes(zend_op_array *op_array) {
 /* {{{ */
 static zend_arg_info* pthreads_copy_arginfo(zend_arg_info *old, zend_uint end) {
 	zend_arg_info *info = safe_emalloc(end, sizeof(zend_arg_info), 0);
-	zend_uint it = 0;	
-	
+	zend_uint it = 0;
+
 	while (it < end) {
 		info[it] = old[it];
 		info[it].name = estrndup(
@@ -187,7 +203,7 @@ static zend_arg_info* pthreads_copy_arginfo(zend_arg_info *old, zend_uint end) {
 		}
 		it++;
 	}
-	
+
 	return info;
 } /* }}} */
 
@@ -196,14 +212,14 @@ static void pthreads_copy_function(zend_function *function) {
 	if (function->type == ZEND_USER_FUNCTION) {
 		zend_function copy = *function;
 		zend_function *copied = NULL;
-		
+
 		zend_op_array *op_array = &copy.op_array;
 		zend_compiled_variable *variables = op_array->vars;
 #if PHP_VERSION_ID >= 50400
 		zend_literal  *literals = op_array->literals;
 #endif
 		zend_arg_info *arg_info = op_array->arg_info;
-		
+
 		op_array->function_name = estrdup(op_array->function_name);
 		op_array->refcount = emalloc(sizeof(zend_uint));
 		(*op_array->refcount) = 1;
@@ -211,12 +227,12 @@ static void pthreads_copy_function(zend_function *function) {
 #if PHP_VERSION_ID >= 50400
 		op_array->run_time_cache = NULL;
 #endif
-		
+
 		if (op_array->doc_comment) {
 			op_array->doc_comment = estrndup
 				(op_array->doc_comment, op_array->doc_comment_len);
 		}
-		
+
 		op_array->static_variables = pthreads_copy_statics(op_array->static_variables);
 		op_array->vars = pthreads_copy_variables(variables, op_array->last_var);
 #if PHP_VERSION_ID >= 50400
@@ -230,10 +246,8 @@ static void pthreads_copy_function(zend_function *function) {
 #endif
 		op_array->try_catch_array = pthreads_copy_try(op_array->try_catch_array, op_array->last_try_catch);
 		op_array->brk_cont_array = pthreads_copy_brk(op_array->brk_cont_array, op_array->last_brk_cont);
-		
+
 		*function = copy;
 	}
 } /* }}} */
 #endif
-
-

--- a/tests/static-variables.phpt
+++ b/tests/static-variables.phpt
@@ -1,0 +1,56 @@
+--TEST--
+Test static scoped variables (bug 391)
+--DESCRIPTION--
+This test verifies that statically scoped variables in functions made outside of threads are available inside threads without error excluding objects and resources
+--FILE--
+<?php
+function funcWithStaticVar($set = null)
+{
+    static $var;
+
+    if ($set !== null) {
+        $var = $set;
+    }
+
+    return $var;
+}
+
+class TestThread extends Thread
+{
+    public function run()
+    {
+        var_dump(funcWithStaticVar());
+    }
+}
+
+// Test with an int, which should be copied.
+funcWithStaticVar(42);
+$thread = new TestThread();
+$thread->start();
+$thread->join();
+
+// Test with a string, which should be copied.
+funcWithStaticVar("pthreads rocks!");
+$thread = new TestThread();
+$thread->start();
+$thread->join();
+
+// Test with an object, which should be nullified.
+funcWithStaticVar(new stdClass);
+$thread = new TestThread();
+$thread->start();
+$thread->join();
+
+// Test with a resource, which should be nullified.
+$fp = fopen(__FILE__, 'r');
+funcWithStaticVar($fp);
+$thread = new TestThread();
+$thread->start();
+$thread->join();
+fclose($fp);
+?>
+--EXPECT--
+int(42)
+string(15) "pthreads rocks!"
+NULL
+NULL

--- a/tests/static-variables.phpt
+++ b/tests/static-variables.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Test static scoped variables (bug 391)
 --DESCRIPTION--
-This test verifies that statically scoped variables in functions made outside of threads are available inside threads without error excluding objects and resources
+This test verifies that statically scoped variables in functions made outside of threads are available inside threads without error excluding arrays, objects, and resources
 --FILE--
 <?php
 function funcWithStaticVar($set = null)
@@ -35,6 +35,14 @@ $thread = new TestThread();
 $thread->start();
 $thread->join();
 
+// Test with an array, which should be nullified.
+funcWithStaticVar([
+    "pthreads", "rocks", 4, "real!"
+]);
+$thread = new TestThread();
+$thread->start();
+$thread->join();
+
 // Test with an object, which should be nullified.
 funcWithStaticVar(new stdClass);
 $thread = new TestThread();
@@ -52,5 +60,6 @@ fclose($fp);
 --EXPECT--
 int(42)
 string(15) "pthreads rocks!"
+NULL
 NULL
 NULL


### PR DESCRIPTION
An attempt at fixing #391 for PHP versions 5.x.

As per the pthreads 2.0.x docs, resources and objects should be nullified inside static variables, so now `pthreads_copy_statics()` skips over those types of values when copying lexical statics by simple type checking. The entry for the variable will instead be empty, which will return a fresh `NULL` after copy to a child thread. Normal zvals are copied and their refcounts incremented.