### PR TITLE
Added Homegear to SAPI whitelist

### DIFF
--- a/php_pthreads.c
+++ b/php_pthreads.c
@@ -108,6 +108,7 @@ typedef struct _pthreads_supported_sapi_t {
 const static pthreads_supported_sapi_t whitelist[] = {
 	{ZEND_STRL("cli")},
 	{ZEND_STRL("phpdbg")}, /* not really supported, needs work */
+	{ZEND_STRL("homegear")},
 	{NULL, 0}
 };
 


### PR DESCRIPTION
Hey,

as discussed in issue #557 here is the pull request to add the open source project Homegear to your SAPI whitelist :wink:. You can find the source code here: https://github.com/Homegear/Homegear. The source code for the script engine can be found in the subdirectory src/ScriptEngine. The script engine itself runs in a seperate process for stability reasons (class ScriptEngineClient), which communicates with the main process (class ScriptEngineServer). The SAPI implementation is in php_sapi.cpp. The function reference is on https://ref.homegear.eu/php.html (only the PHP reference is complete - I'm currently working on the other parts). You can find an example PHP script using pthreads on https://github.com/Homegear/Homegear-OpenWeatherMap/blob/master/OpenWeatherMap.xml or in the reference: https://ref.homegear.eu/php.html#HomegearpollEvent.

Thank you :smiley:!

Best regards,

Sathya