### PR TITLE
Synchronized queue functionality

### DIFF
--- a/classes/queue.h
+++ b/classes/queue.h
@@ -1,0 +1,101 @@
+/*
+  +----------------------------------------------------------------------+
+  | pthreads                                                             |
+  +----------------------------------------------------------------------+
+  | Copyright (c) Joe Watkins 2012 - 2015                                |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | http://www.php.net/license/3_01.txt                                  |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Author: Joe Watkins <krakjoe@php.net>                                |
+  +----------------------------------------------------------------------+
+ */
+#ifndef HAVE_PTHREADS_CLASS_QUEUE_H
+#define HAVE_PTHREADS_CLASS_QUEUE_H
+PHP_METHOD(Queue, push);
+
+PHP_METHOD(Queue, pop);
+PHP_METHOD(Queue, shift);
+
+PHP_METHOD(Queue, size);
+
+ZEND_BEGIN_ARG_INFO_EX(Queue_push, 0, 0, 1)
+    ZEND_ARG_INFO(0, data)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(Queue_pop, 0, 0, 0)
+ZEND_END_ARG_INFO()
+ZEND_BEGIN_ARG_INFO_EX(Queue_shift, 0, 0, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(Queue_size, 0, 0, 0)
+ZEND_END_ARG_INFO()
+
+extern zend_function_entry pthreads_queue_methods[];
+#else
+#	ifndef HAVE_PTHREADS_CLASS_QUEUE
+#	define HAVE_PTHREADS_CLASS_QUEUE
+zend_function_entry pthreads_queue_methods[] = {
+	PHP_ME(Queue, push, Queue_push, ZEND_ACC_PUBLIC)
+	PHP_ME(Queue, pop, Queue_pop, ZEND_ACC_PUBLIC)
+	PHP_ME(Queue, shift, Queue_shift, ZEND_ACC_PUBLIC)
+	PHP_ME(Queue, size, Queue_size, ZEND_ACC_PUBLIC)
+	{NULL, NULL, NULL}
+};
+
+
+/* {{{ proto void Threaded::merge(mixed $data, [boolean $overwrite = true])
+	Push data to the queue */
+PHP_METHOD(Queue, push)
+{
+	zval *data;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "z", &data) == FAILURE) {
+		return;
+	}
+    
+	pthreads_queue_push(getThis(), data);
+} /* }}} */
+
+/* {{{ proto mixed Queue::pop()
+	Will pop the last member from the queue */
+PHP_METHOD(Queue, pop)
+{
+    if (zend_parse_parameters_none() != SUCCESS) {
+        return;
+    }
+    
+    pthreads_queue_pop(getThis(), return_value);
+} /* }}} */
+
+/* {{{ proto mixed Queue::shift()
+	Will shift the first member from the queue */
+PHP_METHOD(Queue, shift)
+{
+    if (zend_parse_parameters_none() != SUCCESS) {
+        return;
+    }
+    
+    pthreads_queue_shift(getThis(), return_value);
+} /* }}} */
+
+/* {{{ proto boolean Queue::size()
+	Will return the size of the queue */
+PHP_METHOD(Queue, size)
+{
+    if (zend_parse_parameters_none() != SUCCESS) {
+        return;
+    }
+	
+	ZVAL_LONG(return_value, 0);
+	
+	pthreads_queue_size(getThis(), &Z_LVAL_P(return_value));
+} /* }}} */
+
+#	endif
+#endif

--- a/config.m4
+++ b/config.m4
@@ -27,7 +27,7 @@ if test "$PHP_PTHREADS" != "no"; then
 		EXTRA_CFLAGS="$EXTRA_CFLAGS -DDMALLOC"
 	fi
 
-	PHP_NEW_EXTENSION(pthreads, php_pthreads.c src/monitor.c src/stack.c src/globals.c src/prepare.c src/store.c src/resources.c src/handlers.c src/object.c src/socket.c, $ext_shared,, -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1)
+	PHP_NEW_EXTENSION(pthreads, php_pthreads.c src/monitor.c src/stack.c src/globals.c src/prepare.c src/store.c src/resources.c src/handlers.c src/object.c src/socket.c src/queue.c, $ext_shared,, -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1)
 	PHP_ADD_BUILD_DIR($ext_builddir/src, 1)
 	PHP_ADD_INCLUDE($ext_builddir)
 	PHP_SUBST(PTHREADS_SHARED_LIBADD)

--- a/config.w32
+++ b/config.w32
@@ -1,5 +1,5 @@
 var PTHREADS_EXT_NAME="pthreads";
-var PTHREADS_EXT_SRC="monitor.c stack.c globals.c prepare.c store.c resources.c handlers.c object.c socket.c";
+var PTHREADS_EXT_SRC="monitor.c stack.c globals.c prepare.c store.c resources.c handlers.c object.c socket.c queue.c";
 var PTHREADS_EXT_DIR="ext/pthreads/src";
 var PTHREADS_EXT_API="php_pthreads.c";
 var PTHREADS_EXT_FLAGS="/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1 /I" + configure_module_dirname;

--- a/examples/Queue.php
+++ b/examples/Queue.php
@@ -1,0 +1,80 @@
+<?php
+
+const THREADS_NUMBER = 5;
+const REQUESTS_NUMBER = 20;
+
+//queue to push requests to process
+$requestsQueue = new Queue();
+//queue to push responses
+$responsesQueue = new Queue();
+$monitor = new class extends Threaded {
+
+    protected $done;
+
+    public function isDone()
+    {
+        return $this->synchronized(function(){
+            return $this->done;
+        });
+    }
+
+    public function setDone()
+    {
+        $this->synchronized(function(){
+            $this->done = true;
+        });
+    }
+
+};
+$threads = [];
+for ($i = 0; $i < THREADS_NUMBER; $i++) {
+    $thread = new class ($requestsQueue, $responsesQueue, $monitor) extends Thread {
+        protected $requestsQueue;
+        protected $responsesQueue;
+        protected $monitor;
+
+        public function __construct($requestsQueue, $responsesQueue, $monitor)
+        {
+            $this->requestsQueue = $requestsQueue;
+            $this->responsesQueue = $responsesQueue;
+            $this->monitor = $monitor;
+        }
+
+        public function run()
+        {
+            while (!$this->monitor->isDone()) {
+                if ($url = $this->requestsQueue->shift()) {
+                    $response = file_get_contents($url);
+                    $this->responsesQueue->push([
+                        'url' => $url,
+                        'response' => $response
+                    ]);
+                } else {
+                    usleep(100000);
+                }
+            };
+        }
+
+    };
+    $thread->start();
+    $threads[] = $thread;
+}
+
+for ($i = 0; $i < REQUESTS_NUMBER; $i++) {
+    $requestsQueue->push(sprintf("http://www.bing.com/search?q=%s", $i));
+}
+
+$collected = 0;
+while (true) {
+    if ($response = $responsesQueue->shift()) {
+        echo sprintf("$collected got response for url '%s' length is %s\n", $response['url'], strlen($response['response']));
+        $collected++;
+        if ($collected >= REQUESTS_NUMBER) {
+            $monitor->setDone();
+            echo "collected all\n";
+            exit;
+        }
+    } else {
+        usleep(100000);
+    }
+}

--- a/php_pthreads.c
+++ b/php_pthreads.c
@@ -84,6 +84,7 @@ zend_class_entry *pthreads_worker_entry;
 zend_class_entry *pthreads_collectable_entry;
 zend_class_entry *pthreads_pool_entry;
 zend_class_entry *pthreads_socket_entry;
+zend_class_entry *pthreads_queue_entry;
 
 zend_object_handlers pthreads_handlers;
 zend_object_handlers pthreads_socket_handlers;
@@ -743,6 +744,10 @@ PHP_MINIT_FUNCTION(pthreads)
 	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("NO_ADDRESS"), WSANO_ADDRESS);
 #endif
 
+	INIT_CLASS_ENTRY(ce, "Queue", pthreads_queue_methods);
+	pthreads_queue_entry = zend_register_internal_class_ex(&ce, pthreads_threaded_entry);
+	pthreads_queue_entry->create_object = pthreads_queue_ctor;
+
 	/*
 	* Setup object handlers
 	*/
@@ -900,6 +905,10 @@ PHP_MINFO_FUNCTION(pthreads)
 
 #ifndef HAVE_PTHREADS_CLASS_SOCKET
 #	include <classes/socket.h>
+#endif
+
+#ifndef HAVE_PTHREADS_CLASS_QUEUE
+#	include <classes/queue.h>
 #endif
 
 #endif

--- a/php_pthreads.h
+++ b/php_pthreads.h
@@ -51,6 +51,10 @@ ZEND_MODULE_POST_ZEND_DEACTIVATE_D(pthreads);
 #	include <classes/socket.h>
 #endif
 
+#ifndef HAVE_PTHREADS_CLASS_QUEUE_H
+#	include <classes/queue.h>
+#endif
+
 extern zend_module_entry pthreads_module_entry;
 #define phpext_pthreads_ptr &pthreads_module_entry
 

--- a/src/object.h
+++ b/src/object.h
@@ -31,6 +31,7 @@ zend_object* pthreads_threaded_ctor(zend_class_entry *entry);
 zend_object* pthreads_worker_ctor(zend_class_entry *entry);
 zend_object* pthreads_thread_ctor(zend_class_entry *entry);
 zend_object* pthreads_socket_ctor(zend_class_entry *entry);
+zend_object* pthreads_queue_ctor(zend_class_entry *entry);
 void         pthreads_base_free(zend_object *object);
 zend_object* pthreads_base_clone(zval *object);
 HashTable*   pthreads_base_gc(zval *object, zval **table, int *n); /* }}} */

--- a/src/pthreads.h
+++ b/src/pthreads.h
@@ -88,6 +88,7 @@ extern zend_class_entry *pthreads_volatile_entry;
 extern zend_class_entry *pthreads_thread_entry;
 extern zend_class_entry *pthreads_worker_entry;
 extern zend_class_entry *pthreads_socket_entry;
+extern zend_class_entry *pthreads_queue_entry;
 
 #ifndef IS_PTHREADS_CLASS
 #define IS_PTHREADS_CLASS(c) \

--- a/src/queue.c
+++ b/src/queue.c
@@ -1,0 +1,194 @@
+/*
+  +----------------------------------------------------------------------+
+  | pthreads                                                             |
+  +----------------------------------------------------------------------+
+  | Copyright (c) Joe Watkins 2012 - 2015                                |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | http://www.php.net/license/3_01.txt                                  |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Author: Joe Watkins <krakjoe@php.net>                                |
+  +----------------------------------------------------------------------+
+ */
+#ifndef HAVE_PTHREADS_QUEUE
+#define HAVE_PTHREADS_QUEUE
+
+#ifndef HAVE_PTHREADS_H
+#	include <src/pthreads.h>
+#endif
+
+/* {{{ */
+struct pthreads_queue_item_t {
+    size_t                       size;
+    char                         *data;
+	struct pthreads_queue_item_t *next;
+	struct pthreads_queue_item_t *prev;
+}; /* }}} */
+
+/* {{{ */
+struct pthreads_queue_t {
+	pthreads_monitor_t   	     *monitor;
+    struct pthreads_queue_item_t *head;
+    struct pthreads_queue_item_t *tail;
+    zend_long size;
+}; /* }}} */
+
+pthreads_queue_t* pthreads_queue_alloc(pthreads_monitor_t *monitor) {
+	pthreads_queue_t *queue = (pthreads_queue_t*) ecalloc(1, sizeof(pthreads_queue_t));
+
+	queue->monitor = monitor;
+	queue->size = 0;
+	queue->head = NULL;
+	queue->tail = NULL;
+
+	return queue;
+}
+
+void pthreads_queue_free(pthreads_queue_t *queue) {
+	if (pthreads_monitor_lock(queue->monitor)) {
+		pthreads_queue_item_t *item = queue->head;
+
+		while (item != NULL) {
+			pthreads_queue_item_t *r = item;
+			item = r->next;
+			free(r->data);
+			free(r);
+		}
+
+		efree(queue);
+		pthreads_monitor_unlock(queue->monitor);
+	}
+}
+
+/* {{{ */
+int pthreads_queue_push(zval *object, zval *data) {
+	int retval = FAILURE;
+	pthreads_queue_t *queue = PTHREADS_QUEUE_FETCH_FROM(Z_OBJ_P(object));
+	smart_str smart = {0};
+	php_serialize_data_t vars;
+
+	PHP_VAR_SERIALIZE_INIT(vars);
+	php_var_serialize(&smart, data, &vars);
+	PHP_VAR_SERIALIZE_DESTROY(vars);
+
+	pthreads_queue_item_t *item = malloc(sizeof(pthreads_queue_item_t));
+	item->data = malloc(ZSTR_LEN(smart.s));
+	item->size = ZSTR_LEN(smart.s);
+	item->next = NULL;
+
+	memcpy(item->data, ZSTR_VAL(smart.s), item->size);
+	/* free string */
+	smart_str_free(&smart);
+
+	if (pthreads_monitor_lock(queue->monitor)) {
+		if (queue->size == 0) {
+			queue->tail = item;
+			queue->head = item;
+		} else {
+			queue->tail->next = item;
+			item->prev = queue->tail;
+			queue->tail = item;
+		}
+		queue->size++;
+
+		pthreads_monitor_unlock(queue->monitor);
+		retval = SUCCESS;
+	} else {
+		free(item->data);
+		free(item);
+	}
+	return retval;
+} /* }}} */
+
+/* {{{ */
+int pthreads_queue_pop(zval *object, zval *data) {
+	int retval = FAILURE;
+	pthreads_queue_t *queue = PTHREADS_QUEUE_FETCH_FROM(Z_OBJ_P(object));
+	php_unserialize_data_t var_hash;
+
+	if (pthreads_monitor_lock(queue->monitor)) {
+		if (queue->size > 0) {
+			pthreads_queue_item_t *item = queue->tail;
+			const unsigned char* pointer = (const unsigned char*) item->data;
+
+			PHP_VAR_UNSERIALIZE_INIT(var_hash);
+			if (php_var_unserialize(data, &pointer, pointer + item->size, &var_hash) == 1) {
+				if (queue->size == 1) {
+					queue->tail = NULL;
+					queue->head = NULL;
+				} else {
+					queue->tail = item->prev;
+					queue->tail->next = NULL;
+				}
+				queue->size--;
+
+				free(item->data);
+				free(item);
+
+				retval = SUCCESS;
+			}
+			PHP_VAR_UNSERIALIZE_DESTROY(var_hash);
+		}
+		pthreads_monitor_unlock(queue->monitor);
+	}
+	if (retval == FAILURE) {
+		ZVAL_NULL(data);
+	}
+	return retval;
+} /* }}} */
+
+/* {{{ */
+int pthreads_queue_shift(zval *object, zval *data) {
+	int retval = FAILURE;
+	pthreads_queue_t *queue = PTHREADS_QUEUE_FETCH_FROM(Z_OBJ_P(object));
+	php_unserialize_data_t var_hash;
+
+	if (pthreads_monitor_lock(queue->monitor)) {
+		if (queue->size > 0) {
+			pthreads_queue_item_t *item = queue->head;
+			const unsigned char* pointer = (const unsigned char*) item->data;
+
+			PHP_VAR_UNSERIALIZE_INIT(var_hash);
+			if (php_var_unserialize(data, &pointer, pointer + item->size, &var_hash) == 1) {
+				if (queue->size == 1) {
+					queue->tail = NULL;
+					queue->head = NULL;
+				} else {
+					queue->head = item->next;
+					queue->head->prev = NULL;
+				}
+				queue->size--;
+
+				free(item->data);
+				free(item);
+
+				retval = SUCCESS;
+			}
+			PHP_VAR_UNSERIALIZE_DESTROY(var_hash);
+		}
+		pthreads_monitor_unlock(queue->monitor);
+	}
+	if (retval == FAILURE) {
+		ZVAL_NULL(data);
+	}
+	return retval;
+} /* }}} */
+
+/* {{{ */
+int pthreads_queue_size(zval *object, zend_long *count) {
+	pthreads_queue_t *queue = PTHREADS_QUEUE_FETCH_FROM(Z_OBJ_P(object));
+
+	if (pthreads_monitor_lock(queue->monitor)) {
+		(*count) = queue->size;
+		pthreads_monitor_unlock(queue->monitor);
+	} else (*count) = 0L;
+
+	return SUCCESS;
+} /* }}} */
+
+#endif

--- a/src/queue.h
+++ b/src/queue.h
@@ -1,0 +1,39 @@
+/*
+  +----------------------------------------------------------------------+
+  | pthreads                                                             |
+  +----------------------------------------------------------------------+
+  | Copyright (c) Joe Watkins 2015                                       |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | http://www.php.net/license/3_01.txt                                  |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Author: Joe Watkins <krakjoe@php.net>                                |
+  +----------------------------------------------------------------------+
+ */
+#ifndef HAVE_PTHREADS_QUEUE_H
+#define HAVE_PTHREADS_QUEUE_H
+
+#ifndef HAVE_PTHREADS_H
+#	include <src/pthreads.h>
+#endif
+
+typedef struct pthreads_queue_item_t pthreads_queue_item_t;
+typedef struct pthreads_queue_t pthreads_queue_t;
+
+/* {{{ fetches a PTHREAD from a specific object in the current context */
+#define PTHREADS_QUEUE_FETCH_FROM(object) PTHREADS_FETCH_FROM(object)->store.queue /* }}} */
+
+pthreads_queue_t* pthreads_queue_alloc(pthreads_monitor_t *monitor);
+void pthreads_queue_free(pthreads_queue_t *queue);
+int pthreads_queue_push(zval *object, zval *data);
+int pthreads_queue_pop(zval *object, zval *data);
+int pthreads_queue_shift(zval *object, zval *data);
+int pthreads_queue_size(zval *object, zend_long *count);
+
+
+#endif

--- a/src/thread.h
+++ b/src/thread.h
@@ -30,6 +30,10 @@
 #	include <src/socket.h>
 #endif
 
+#ifndef HAVE_PTHREADS_QUEUE_H
+#	include <src/queue.h>
+#endif
+
 typedef struct _pthreads_ident_t {
 	zend_ulong id;
 	void*** ls;
@@ -44,6 +48,7 @@ typedef struct _pthreads_object_t {
 	union {
 		pthreads_store_t	*props;
 		pthreads_socket_t	*sock;
+		pthreads_queue_t	*queue;
 	} store;
 	pthreads_stack_t    *stack;
 	pthreads_ident_t 	creator;
@@ -93,7 +98,8 @@ static inline pthreads_object_t* _pthreads_fetch_object(zend_object *object) {
 #define PTHREADS_SCOPE_THREAD      (1<<2)
 #define PTHREADS_SCOPE_WORKER      (1<<3)
 #define PTHREADS_SCOPE_SOCKET	   (1<<4)
-#define PTHREADS_SCOPE_CONNECTION  (1<<5) /* }}} */
+#define PTHREADS_SCOPE_CONNECTION  (1<<5)
+#define PTHREADS_SCOPE_QUEUE       (1<<6) /* }}} */
 
 /* {{{ scope macros */
 #define PTHREADS_IS_KNOWN_ENTRY(t)      ((t)->scope)
@@ -106,7 +112,9 @@ static inline pthreads_object_t* _pthreads_fetch_object(zend_object *object) {
 #define PTHREADS_IS_WORKER(t)           ((t)->scope & PTHREADS_SCOPE_WORKER)
 #define PTHREADS_IS_NOT_WORKER(t)       (!PTHREADS_IS_WORKER(t))
 #define PTHREADS_IS_THREADED(t)         ((t)->scope & PTHREADS_SCOPE_THREADED)
-#define PTHREADS_IS_NOT_THREADED(t)     (!PTHREADS_IS_THREADED(t)) /* }}} */
+#define PTHREADS_IS_NOT_THREADED(t)     (!PTHREADS_IS_THREADED(t))
+#define PTHREADS_IS_QUEUE(t)            ((t)->scope & PTHREADS_SCOPE_QUEUE)
+#define PTHREADS_IS_NOT_QUEUE(t)        (!PTHREADS_IS_QUEUE(t)) /* }}} */
 
 /* {{{ pthread_self wrapper */
 static inline ulong pthreads_self() {

--- a/tests/queue-push-pop.phpt
+++ b/tests/queue-push-pop.phpt
@@ -1,0 +1,24 @@
+--TEST--
+Queue test push and pop
+--DESCRIPTION--
+This test verifies that queue push and pop functionality are working
+--FILE--
+<?php
+
+$q = new Queue();
+$q->push('1');
+$q->push('2');
+$q->push('3');
+var_dump($q->size());
+var_dump($q->pop());
+var_dump($q->pop());
+var_dump($q->pop());
+var_dump($q->pop());
+
+?>
+--EXPECT--
+int(3)
+string(1) "3"
+string(1) "2"
+string(1) "1"
+NULL


### PR DESCRIPTION
First of all thanks you Joe for making it possible.
I've already developed an experimental application, use it on production, works great! 
But what was quite hard to implement is an ability to simply exchange the data between threads and main, or between different threads.
Mainly it is hard to maintain a refcount to the data you need to pass to the other threads and especially if you have a lot of data to exchange. Good example would be that several threads are asynchronously querying to some web service and main is processing the results (see Queue.php in examples folder).
What I was particularly missing is something similar to python's Queue https://docs.python.org/2/library/queue.html

Keeping in mind that each thread has its own memory manager and the data that thread is passed to other threads or main is allocated dynamically inside that thread, and will be gone after thread is finished or the reference is gone, I came up to the simple solution: 
- store data out of zend memory manager, in the regular heap
- serialize the data that is pushed to the queue, copy that data to the memory allocated in heap, clean up memory that was allocated in zend_mm for serialization
- unserialize data when other thread is poping it out (thus after that it is in the thread's address space), clean up memory allocated in heap
- make it thread safe, thus easy to use in userland, take care of synchronization in C code 
- on object destruction free allocated in heap heap memory if something is left

I was also trying to maintain your code style and stick to the similar design.