### PR TITLE
Fix pool test

### DIFF
--- a/tests/pools.phpt
+++ b/tests/pools.phpt
@@ -9,7 +9,7 @@ class WebWorker extends Worker {
 		$this->logger = $logger;
 	}
 	
-	protected $loger;	
+	protected $logger;	
 }
 
 class WebWork extends Threaded {


### PR DESCRIPTION
The variable protected is incorrect and the correct logger variable is created as public.