### PR TITLE
Enhance Pool example to show garbage collector getting array

### DIFF
--- a/examples/Pooling.php
+++ b/examples/Pooling.php
@@ -45,7 +45,35 @@ class WebWork extends Threaded {
 			$logger->log("%s has PDO in Thread #%lu", 
 				__CLASS__, $this->worker->getThreadId());
 		}
+
+		$this->setData(array(
+			'class' => __CLASS__,
+			'threadId' => $this->worker->getThreadId()
+		));
 	}
+
+	/**
+	 * Here you can use to set some variable be recovered in collector.
+	 * When you set an array in the \Thread without casting, it will be
+	 * transformed into a Volatile object and will not be possible to recover
+	 * the variable by collector. You can test it removing the cast and running
+	 * the example.
+	 *
+	 * @see https://github.com/krakjoe/pthreads/issues/610.
+	 *
+	 * @param array $data Any data you need to recover by collector.
+	 */
+	public function setData($data)
+	{
+		if (is_array($data)) {
+			$this->data = (array) $data;
+			return;
+		}
+
+		$this->data = $data;
+	}
+
+	public $data;
 }
 
 class SafeLog extends Threaded {
@@ -71,22 +99,19 @@ $logger = new SafeLog();
 $pool = new Pool(8, 'WebWorker', [$logger, ["sqlite:example.db"]]);
 
 /*
+* Work count will be used to get all results
+*/
+$workCount = 14;
+
+/*
 * Only when there is work to do are threads created
 */
-$pool->submit(new WebWork());
-$pool->submit(new WebWork());
-$pool->submit(new WebWork());
-$pool->submit(new WebWork());
-$pool->submit(new WebWork());
-$pool->submit(new WebWork());
-$pool->submit(new WebWork());
-$pool->submit(new WebWork());
-$pool->submit(new WebWork());
-$pool->submit(new WebWork());
-$pool->submit(new WebWork());
-$pool->submit(new WebWork());
-$pool->submit(new WebWork());
-$pool->submit(new WebWork());
+for ($i=0; $i < $workCount; $i++) {
+	$pool->submit(new WebWork());
+}
+
+/** @var array It will be populated by collect callback */
+$garbage = array();
 
 /*
 * The Workers in the Pool retain references to the WebWork objects submitted
@@ -99,23 +124,36 @@ $pool->submit(new WebWork());
 * The Closure must return true if the Collectable can be removed from the garbage list.
 *
 * Worker::collect returns the size of the garbage list, Pool::collect returns the sum of the size of
-* the garbage list of all Workers in the Pool. 
+* the garbage list of all Workers in the Pool.
+* The second rule that will be checked is that the garbage must be full with
+* the same count of submited workers.
 *
 * Collecting in a continuous loop will cause the garbage list to be emptied.
 */
-while ($pool->collect(function($work) {
+while ($pool->collect(function($work) use (&$garbage) {
+	if ($work->isGarbage()) {
+		$garbage[] = $work->data;
+	}
+
 	return $work->isGarbage();
-})) continue;
+}) || count($garbage) < $workCount) continue;
 
 /*
 * We could submit more stuff here, the Pool is still waiting for Collectables
 */
 $logger->log(function($pool) {
 	var_dump($pool);
-}, $pool);
+}, 'Printing pool before shutdown', $pool);
 
 /*
 * Shutdown Pools at the appropriate time, don't leave it to chance !
 */
 $pool->shutdown();
+
+/*
+* The garbage could be accessed after pool shutdown.
+*/
+$logger->log(function($garbage) {
+	var_dump($garbage);
+}, 'Printing the garbage:', $garbage);
 ?>


### PR DESCRIPTION
This is a complement to be more easy to see the needed of casting the
``\Thread`` class variable to array to be possible recover by collector.

@krakjoe, sorry for posting some error in another user's thread. I discovered my problem and here I put some contribution to Pool example.
This was possible because of this issue: https://github.com/krakjoe/pthreads/issues/610.
Thank you!