### PR TITLE
fix #580 #681

### DIFF
--- a/src/store.c
+++ b/src/store.c
@@ -336,7 +336,8 @@ int pthreads_store_write(zval *object, zval *key, zval *write) {
 
 				if (zend_hash_update_ptr(threaded->store.props, keyed, storage)) {
 					result = SUCCESS;
-				} else zend_string_release(keyed);
+				}
+				zend_string_release(keyed);
 			}
 		}
 		pthreads_monitor_unlock(threaded->monitor);
@@ -351,6 +352,7 @@ int pthreads_store_write(zval *object, zval *key, zval *write) {
 				normal refcounting, we'll just never read the reference
 			*/
 			rebuild_object_properties(&threaded->std);
+
 			if (Z_TYPE(member) == IS_LONG) {
 				zend_hash_index_update(threaded->std.properties, Z_LVAL(member), write);
 			} else {
@@ -358,7 +360,8 @@ int pthreads_store_write(zval *object, zval *key, zval *write) {
 				if (zend_hash_update(
 					threaded->std.properties, keyed, write)) {
 					result = SUCCESS;
-				} else zend_string_release(keyed);
+				}
+				zend_string_release(keyed);
 			}
 			Z_ADDREF_P(write);
 		}


### PR DESCRIPTION
Cleanup on synchronized or reading a property is inconsistent, therefore cleanup should also happen on writing a property. Moreover the cleanup behavior on synchronized is misleading. 

```
class myRec extends Threaded {
	public $data1;
	public $data2;
}

class storage extends Threaded {

	private $store = array();

	public function addRecord($key,$data) {
        	$this->store->synchronized(function () use ($key, $data)
        	{
			$this->store[$key] = $data;
		});
	}

	public function delAll() {
        	$this->store->synchronized(function ()
		{
			foreach($this->store as $key => $data)
			{
				unset($this->store[$key]);
			}
        	});
	}

	public function countRecs() {
		return count($this->store);
	}
}

class myThread extends Thread
{

	private static $type;

	public function __construct($type,$storage)
	{
		self::$type = $type;
		$this->storage = $storage;
	}

	public function run()
	{

		if (self::$type === 1) {
			while (true) {

				//if($this->storage->countRecs() == 0)
				{
					@$loop++;
					for($i = 0; $i < 30000; $i++)
					{
						$r = new  myRec();
						$r->data1 = 'data' . $i;
						$this->storage->addRecord($loop . '|' . $i, $r);
					}
				}

				sleep(5);

			}
		}

		if (self::$type === 2) {
			while (true) {
				//if($this->storage->countRecs() >= 30000)
				{
					$this->storage->delAll();
				}

				sleep(1);
				print "RECS:".$this->storage->countRecs()."\n";
			}

		}
	}
}

ini_set('memory_limit', '-1');

$storage = new storage();

$threads[0] = new myThread(1,$storage);
$threads[0]->start();

$threads[1] = new myThread(2,$storage);
$threads[1]->start();
$threads[1]->join();
```
This is a fix for #681 as well.