### PR TITLE
Bug/return type hanging thread

### DIFF
--- a/php_pthreads.c
+++ b/php_pthreads.c
@@ -156,11 +156,11 @@ static inline void pthreads_execute_ex(zend_execute_data *data) {
 /* {{{ */
 static inline zend_bool pthreads_verify_type(zend_execute_data *execute_data, zval *var, zend_arg_info *info) {
 	pthreads_object_t *threaded = NULL;
-
+        
 	if (!var ||
 #if PHP_VERSION_ID >= 70200
-		!ZEND_SAME_FAKE_TYPE(ZEND_TYPE_CODE(info->type), Z_TYPE_P(var)) &&
-		!ZEND_TYPE_IS_CLASS(info->type) ||
+                Z_ISNULL_P(var) ||
+                !ZEND_TYPE_IS_CLASS(info->type) ||
 #else
 		!ZEND_SAME_FAKE_TYPE(info->type_hint, Z_TYPE_P(var)) ||
 		info->type_hint != IS_OBJECT ||

--- a/tests/verify-overload-71.phpt
+++ b/tests/verify-overload-71.phpt
@@ -1,0 +1,31 @@
+--TEST--
+Test VERIFY_RETURN_TYPE overload - PHP 71 compliant
+--DESCRIPTION--
+When using the explicit cast of objects, return type hinting can be broken.
+
+The class in the current context doesn't match the class of the object.
+
+pthreads overrides ZEND_VERIFY_RETURN_TYPE to fix the problem, nothing else is affected.
+--SKIPIF--
+<?php
+if(PHP_VERSION_ID < 70100) die('skip this test is for php 7.1+');
+?>
+--FILE--
+<?php
+
+class Test extends Thread {
+        
+        public function checkOptionalNull():?Threaded {
+            return ($var = null);
+        }
+
+	public function run() {
+                var_dump($this->checkOptionalNull());
+	}
+}
+
+$test = new Test();
+$test->start() && $test->join();
+?>
+--EXPECT--
+NULL

--- a/tests/verify-overload.phpt
+++ b/tests/verify-overload.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Test VERIFY_RETURN_TYPE overload
+Test VERIFY_RETURN_TYPE overload - PHP 70 compliant
 --DESCRIPTION--
 When using the explicit cast of objects, return type hinting can be broken.
 
@@ -15,6 +15,14 @@ class Test extends Thread {
 	public function __construct(Custom $custom) {
 		$this->custom = $custom;
 	}
+        
+        public function checkReturnType():int {
+            return 1;
+        }
+
+        public function wrongReturnType():string {
+            return 1;
+        }
 
 	public function method() : Custom {
 		return (object) $this->custom;
@@ -22,6 +30,8 @@ class Test extends Thread {
 
 	public function run() {
 		var_dump($this->method());
+                var_dump($this->checkReturnType());
+                var_dump($this->wrongReturnType());
 	}
 }
 
@@ -32,8 +42,5 @@ $test->start() && $test->join();
 --EXPECT--
 object(Custom)#1 (0) {
 }
-
-
-
-
-
+int(1)
+string(1) "1"


### PR DESCRIPTION
Wrong logical operator, should be equal to the other branch. A fake typ in ```instanceof_function``` leads to a infinite loop.