### PR TITLE
Resolve bug #711 (class declaration after new thread creation)

### DIFF
--- a/src/prepare.c
+++ b/src/prepare.c
@@ -591,7 +591,7 @@ static inline void pthreads_prepare_classes(pthreads_object_t* thread) {
 	zend_string *name;
 	
 	ZEND_HASH_FOREACH_STR_KEY_PTR(PTHREADS_CG(thread->creator.ls, class_table), name, entry) {
-		if (!zend_hash_exists(PTHREADS_CG(thread->local.ls, class_table), name)) {
+		if (!zend_hash_exists(PTHREADS_CG(thread->local.ls, class_table), name) && ZSTR_VAL(name)[0] != '\0') {
 			pthreads_prepared_entry_internal(thread, entry, 0);
 		}
 	} ZEND_HASH_FOREACH_END();

--- a/tests/new-class-after-thread-creation.phpt
+++ b/tests/new-class-after-thread-creation.phpt
@@ -1,0 +1,18 @@
+--TEST--
+New class after thread creation
+--DESCRIPTION--
+Fixes bug #711. This requires a class to be declared after a new thread has been
+created, where the new class implements at least one interface
+--FILE--
+<?php
+
+$worker = new \Worker();
+$worker->start();
+
+interface A {}
+class task extends Threaded implements A {}
+
+$worker->stack(new task());
+while($worker->collect());
+$worker->shutdown();
+--EXPECT--


### PR DESCRIPTION
This fixes #711.

I'm not sure on the full ramifications of this fix quite yet, though. The basic idea is to delay the copying of certain classes (on thread creation) until they are actually used (basically, lazy copying), since the class entry seems to be incomplete at the point of thread creation. Notably, the `create_object` member of `zend_class_entry` is `NULL`, and so the new `Threaded` object is not created by pthreads' constructor, but rather the built-in constructor. This causes issues down the line when attempting to fetch the pthreads object from the allocated Zend object.

It requires the class to be implementing an interface (though I haven't figured out why that is necessary, yet).