### PR TITLE
fix compile with Visual Studio on windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,29 +2,45 @@ version: '{branch}.{build}'
 branches:
   only:
   - master
+
+image: Visual Studio 2017
+
+environment:
+  PHP_SDK_BINARY_TOOLS_VER: php-sdk-2.0.7
+  ARCH: x86 # maybe add x64?
+
+  matrix:
+    - PHP_VER: 7.2
+      VC_VER: vc15
 install:
 - cmd: cinst wget
 build_script:
 - cmd: >-
-    "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\bin\vcvars32.bat"
+    "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars32.bat"
 
-    wget http://windows.php.net/downloads/php-sdk/php-sdk-binary-tools-20110915.zip
+    wget https://github.com/OSTC/php-sdk-binary-tools/archive/%PHP_SDK_BINARY_TOOLS_VER%.zip --no-check-certificate -q -O php-sdk-binary-tools-%PHP_SDK_BINARY_TOOLS_VER%.zip
 
-    7z x -y php-sdk-binary-tools-20110915.zip -oC:\projects\php-sdk
+    7z x -y php-sdk-binary-tools-%PHP_SDK_BINARY_TOOLS_VER%.zip -oC:\projects
 
+    move C:\projects\php-sdk-binary-tools-%PHP_SDK_BINARY_TOOLS_VER% C:\projects\php-sdk
+    
     C:\projects\php-sdk\bin\phpsdk_setvars.bat
 
-    git clone https://github.com/php/php-src C:\projects\php-src
+    git clone https://github.com/php/php-src C:\projects\php-src -b PHP-%PHP_VER% --depth=1
 
     mkdir C:\projects\php-src\ext\pthreads
 
-    xcopy C:\projects\pthreads C:\projects\php-src\ext\pthreads /s /e /y
+    xcopy C:\projects\pthreads C:\projects\php-src\ext\pthreads /s /e /y /q
 
-    wget http://windows.php.net/downloads/php-sdk/deps-7.0-vc14-x86.7z
+    REM FIXME no PHP 7.2 deps downloads available yet - wget http://windows.php.net/downloads/php-sdk/deps-%PHP_VER%-%VC_VER%-%ARCH%.7z -q
+    
+    wget http://windows.php.net/downloads/php-sdk/deps-master-%VC_VER%-%ARCH%.7z -q
 
-    7z x -y deps-7.0-vc14-x86.7z -oC:\projects\php-src
+    REM FIXME no PHP 7.2 deps downloads available yet - 7z x -y deps-%PHP_VER%-%VC_VER%-%ARCH%.7z -oC:\projects\php-src
+    
+    7z x -y deps-master-%VC_VER%-%ARCH%.7z -oC:\projects\php-src
 
-    wget http://www.mirrorservice.org/sites/sources.redhat.com/pub/pthreads-win32/pthreads-w32-2-9-1-release.zip
+    wget http://www.mirrorservice.org/sites/sources.redhat.com/pub/pthreads-win32/pthreads-w32-2-9-1-release.zip -q
 
     7z x -y pthreads-w32-2-9-1-release.zip -oC:\projects\pthreads-w32
 
@@ -34,7 +50,7 @@ build_script:
 
     copy C:\projects\pthreads-w32\Pre-built.2\include\semaphore.h C:\projects\php-src\deps\include\semaphore.h
 
-    copy C:\projects\pthreads-w32\Pre-built.2\lib\x86\pthreadVC2.lib C:\projects\php-src\deps\lib\pthreadVC2.lib
+    copy C:\projects\pthreads-w32\Pre-built.2\lib\%ARCH%\pthreadVC2.lib C:\projects\php-src\deps\lib\pthreadVC2.lib
 
     cd C:\projects\php-src
 
@@ -52,7 +68,7 @@ build_script:
 
     echo extension=php_pthreads.dll > C:\projects\pthreads\bin\modules.d\php.ini
 
-    copy C:\projects\pthreads-w32\Pre-built.2\dll\x86\pthreadVC2.dll C:\projects\pthreads\bin\pthreadVC2.dll
+    copy C:\projects\pthreads-w32\Pre-built.2\dll\%ARCH%\pthreadVC2.dll C:\projects\pthreads\bin\pthreadVC2.dll
 test_script:
 - cmd: C:\projects\pthreads\bin\php.exe -doutput_buffering=0 run-tests.php ext\pthreads -p C:\projects\pthreads\bin\php.exe -q --show-diff
 artifacts:

--- a/src/pthreads.h
+++ b/src/pthreads.h
@@ -38,13 +38,11 @@
 #include <php_globals.h>
 #include <php_main.h>
 #include <php_network.h>
+#ifndef _WIN32
 #include <netdb.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
-#ifdef AF_UNIX
 #include <sys/un.h>
-#endif
-#ifndef _WIN32
 #	ifdef HAVE_IF_NAMETOINDEX
 #		include <net/if.h>
 #	endif

--- a/src/socket.c
+++ b/src/socket.c
@@ -206,7 +206,7 @@ void pthreads_socket_bind(zval *object, zend_string *address, zend_long port, zv
 	PTHREADS_SOCKET_CHECK(threaded->store.sock);
 
 	switch (threaded->store.sock->domain) {
-#ifdef AF_UNIX
+#ifndef _WIN32
 		case AF_UNIX: {
 			struct sockaddr_un *sa = (struct sockaddr_un *) sock_type;
 
@@ -357,7 +357,7 @@ void pthreads_socket_connect(zval *object, zend_string *address, zend_long port,
 			RETURN_TRUE;
 		} break;
 
-#ifdef AF_UNIX
+#ifndef _WIN32
 		case AF_UNIX: {
 			struct sockaddr_un s_un = {0};
 
@@ -506,12 +506,13 @@ void pthreads_socket_get_sockaddr(zval *object, zend_long port, struct sockaddr 
 				add_assoc_long(return_value, "port", htons(sin->sin_port));
 			}
 		} break;
-
+#ifndef _WIN32
 		case AF_UNIX: {
 			struct sockaddr_un  *s_un = (struct sockaddr_un *) sa;
 
 			add_assoc_string(return_value, "host", s_un->sun_path);
 		} break;
+#endif
 	}
 }
 


### PR DESCRIPTION
`AF_UNIX` is defined in `WinSock2.h` which is included by `php_network.h`, meaning `AF_UNIX` is never _not_ defined. However, Windows doesn't support Unix domain sockets.

This fixes #713 .