### PR TITLE
fix static property circular references during class preparation

### DIFF
--- a/src/prepare.c
+++ b/src/prepare.c
@@ -77,7 +77,7 @@ static zend_class_entry* pthreads_complete_entry(pthreads_object_t* thread, zend
 	if (candidate->parent) {
 		if (zend_hash_index_exists(&PTHREADS_ZG(resolve), (zend_ulong) candidate->parent)) {
 			prepared->parent = zend_hash_index_find_ptr(&PTHREADS_ZG(resolve), (zend_ulong) candidate->parent);
-		} else prepared->parent = pthreads_prepared_entry_internal(thread, candidate->parent, prepare_static_members);
+		} else prepared->parent = pthreads_prepared_entry(thread, candidate->parent);
 	}
 
 	if (candidate->num_interfaces) {
@@ -231,7 +231,7 @@ while(0)
 			if (info->ce) {
 				if (info->ce == candidate) {
 					dup.ce = prepared;
-				} else dup.ce = pthreads_prepared_entry_internal(thread, info->ce, prepare_static_members);
+				} else dup.ce = pthreads_prepared_entry(thread, info->ce);
 			}
 			
 			if (!zend_hash_str_add_mem(&prepared->properties_info, name->val, name->len, &dup, sizeof(zend_property_info))) {		
@@ -399,11 +399,6 @@ static inline int pthreads_prepared_entry_function_prepare(zval *bucket, int arg
 
 /* {{{ */
 zend_class_entry* pthreads_prepared_entry(pthreads_object_t* thread, zend_class_entry *candidate) {
-	return pthreads_prepared_entry_internal(thread, candidate, 1);
-} /* }}} */
-
-/* {{{ */
-zend_class_entry* pthreads_prepared_entry_internal(pthreads_object_t* thread, zend_class_entry *candidate, zend_bool prepare_static_members) {
 	zend_class_entry *prepared = NULL;
 	zend_string *lookup = NULL;
 
@@ -421,12 +416,12 @@ zend_class_entry* pthreads_prepared_entry_internal(pthreads_object_t* thread, ze
 	    zend_string_release(lookup);
 		
 		if(prepared->create_object == NULL && candidate->create_object != NULL) {
-			return pthreads_complete_entry(thread, candidate, prepared, prepare_static_members);
+			return pthreads_complete_entry(thread, candidate, prepared, 1);
 		}
 		return prepared;
 	}
 	
-	if (!(prepared = pthreads_copy_entry(thread, candidate, prepare_static_members))) {
+	if (!(prepared = pthreads_copy_entry(thread, candidate, 0))) {
 		zend_string_release(lookup);
 		return NULL;
 	}
@@ -440,6 +435,9 @@ zend_class_entry* pthreads_prepared_entry_internal(pthreads_object_t* thread, ze
 
 	zend_string_release(lookup);
 
+	if(PTHREADS_ZG(prepare_static_members)) {
+		pthreads_prepared_entry_static_members(thread, candidate, prepared);
+	}
 	return prepared;
 } /* }}} */
 
@@ -603,9 +601,11 @@ static inline void pthreads_prepare_classes(pthreads_object_t* thread) {
 	zend_class_entry *entry;
 	zend_string *name;
 	
+	PTHREADS_ZG(prepare_static_members) = 0;
+        
 	ZEND_HASH_FOREACH_STR_KEY_PTR(PTHREADS_CG(thread->creator.ls, class_table), name, entry) {
 		if (!zend_hash_exists(PTHREADS_CG(thread->local.ls, class_table), name) && ZSTR_VAL(name)[0] != '\0') {
-			pthreads_prepared_entry_internal(thread, entry, 0);
+			pthreads_prepared_entry(thread, entry);
 		}
 	} ZEND_HASH_FOREACH_END();
 
@@ -614,6 +614,8 @@ static inline void pthreads_prepare_classes(pthreads_object_t* thread) {
 			pthreads_prepared_entry_static_members(thread, zend_hash_find_ptr(PTHREADS_CG(thread->creator.ls, class_table), name), entry);
 		}
 	} ZEND_HASH_FOREACH_END();
+        
+	PTHREADS_ZG(prepare_static_members) = 1;
 } /* }}} */
 
 /* {{{ */

--- a/src/prepare.h
+++ b/src/prepare.h
@@ -25,9 +25,6 @@
 /* {{{ fetch prepared class entry */
 zend_class_entry* pthreads_prepared_entry(pthreads_object_t* thread, zend_class_entry *candidate); /* }}} */
 
-/* {{{ fetch prepared class entry */
-zend_class_entry* pthreads_prepared_entry_internal(pthreads_object_t* thread, zend_class_entry *candidate, zend_bool prepare_static_members); /* }}} */
-
 /* {{{ */
 void pthreads_prepare_parent(pthreads_object_t *thread); /* }}} */
 

--- a/src/pthreads.h
+++ b/src/pthreads.h
@@ -122,6 +122,7 @@ ZEND_BEGIN_MODULE_GLOBALS(pthreads)
 	zval  this;
 	HashTable resolve;
 	HashTable *resources;
+	zend_bool prepare_static_members;
 ZEND_END_MODULE_GLOBALS(pthreads)
 #	define PTHREADS_ZG(v) TSRMG(pthreads_globals_id, zend_pthreads_globals *, v)
 #   define PTHREADS_PID() PTHREADS_ZG(pid) ? PTHREADS_ZG(pid) : (PTHREADS_ZG(pid)=getpid())


### PR DESCRIPTION
I have no further details or tests for this bug fix, sorry.