### PR TITLE
fix compile error on 7.2

### DIFF
--- a/src/globals.c
+++ b/src/globals.c
@@ -47,7 +47,7 @@ zend_bool pthreads_globals_init(){
 		    	&PTHREADS_G(objects), 64, NULL, (dtor_func_t) NULL, 1);
 		}
 
-#if PHP_VERSION_ID >= 70200
+#if PHP_VERSION_ID >= 70300
 #define INIT_STRING(n, v) do { \
 	PTHREADS_G(strings).n = zend_string_init(v, 1); \
 	GC_ADDREF(PTHREADS_G(strings).n); \


### PR DESCRIPTION
wrong version check, `GC_ADDREF` only exists in 7.3-dev. If I read correctly, https://github.com/krakjoe/pthreads/commit/edf81d3cc0f34c1fcb3f8f14435a9a122f6e482f was actually intended to fix 7.3, not 7.2.