### PR TITLE
Remove remnants of PTHREADS_ALLOW_GLOBALS

### DIFF
--- a/examples/stub.php
+++ b/examples/stub.php
@@ -52,11 +52,6 @@ define('PTHREADS_INHERIT_COMMENTS', 0x100000);
 define('PTHREADS_ALLOW_HEADERS', 0x1000000);
 
 /**
- * Allow global inheritance for new threads
- */
-define('PTHREADS_ALLOW_GLOBALS', 0x10000000);
-
-/**
  * Threaded class
  *
  * Threaded objects form the basis of pthreads ability to execute user code in parallel;

--- a/src/thread.h
+++ b/src/thread.h
@@ -84,7 +84,6 @@ static inline pthreads_object_t* _pthreads_fetch_object(zend_object *object) {
 #define PTHREADS_INHERIT_INCLUDES  0x00010000
 #define PTHREADS_INHERIT_COMMENTS  0x00100000
 #define PTHREADS_INHERIT_ALL       0x00111111
-#define PTHREADS_ALLOW_GLOBALS     0x01000000
 #define PTHREADS_ALLOW_HEADERS	   0x10000000 /* }}} */
 
 /* {{{ scope constants */


### PR DESCRIPTION
This constant does not exist in pthreads v3 as of 3.1.7.