### PR TITLE
Windows socket fixes

### DIFF
--- a/src/socket.c
+++ b/src/socket.c
@@ -28,8 +28,10 @@
 
 #ifndef PHP_WIN32
 #define PTHREADS_IS_INVALID_SOCKET(sock) ((sock)->fd < 0)
+#define PTHREADS_CLOSE_SOCKET_INTERNAL(sock) close((sock)->fd)
 #else
 #define PTHREADS_IS_INVALID_SOCKET(sock) ((sock)->fd == INVALID_SOCKET)
+#define PTHREADS_CLOSE_SOCKET_INTERNAL(sock) closesocket((sock)->fd)
 #endif
 
 #define PTHREADS_SOCKET_CHECK(sock) do { \
@@ -466,7 +468,7 @@ void pthreads_socket_close(zval *object, zval *return_value) {
 
 	PTHREADS_SOCKET_CHECK(threaded->store.sock);
 
-	if (close(threaded->store.sock->fd) != SUCCESS) {
+	if (PTHREADS_CLOSE_SOCKET_INTERNAL(threaded->store.sock) != SUCCESS) {
 		PTHREADS_SOCKET_ERROR();
 	}
 
@@ -697,7 +699,7 @@ void pthreads_socket_select(zval *read, zval *write, zval *except, uint32_t sec,
 void pthreads_socket_free(pthreads_socket_t *socket, zend_bool closing) {
 	if (closing) {
 		if (socket->fd)
-			close(socket->fd);
+			PTHREADS_CLOSE_SOCKET_INTERNAL(socket);
 	}
 
 	efree(socket);

--- a/src/socket.c
+++ b/src/socket.c
@@ -26,8 +26,14 @@
 #	include <src/socket.h>
 #endif
 
+#ifndef PHP_WIN32
+#define PTHREADS_IS_INVALID_SOCKET(sock) ((sock)->fd < 0)
+#else
+#define PTHREADS_IS_INVALID_SOCKET(sock) ((sock)->fd == INVALID_SOCKET)
+#endif
+
 #define PTHREADS_SOCKET_CHECK(sock) do { \
-	if ((sock)->fd < 0) { \
+	if (PTHREADS_IS_INVALID_SOCKET(sock)) { \
 		zend_throw_exception_ex(spl_ce_RuntimeException, 0, \
 			"socket found in invalid state"); \
 		return; \
@@ -35,7 +41,7 @@
 } while(0)
 
 #define PTHREADS_SOCKET_CHECK_EX(sock, retval) do { \
-	if ((sock)->fd < 0) { \
+	if (PTHREADS_IS_INVALID_SOCKET(sock)) { \
 		zend_throw_exception_ex(spl_ce_RuntimeException, 0, \
 			"socket found in invalid state"); \
 		return (retval); \
@@ -68,7 +74,7 @@ void pthreads_socket_construct(zval *object, zend_long domain, zend_long type, z
 
 	threaded->store.sock->fd = socket(domain, type, protocol);
 
-	if (threaded->store.sock->fd > -1) {
+	if (!PTHREADS_IS_INVALID_SOCKET(threaded->store.sock)) {
 		threaded->store.sock->domain = domain;
 		threaded->store.sock->type = type;
 		threaded->store.sock->protocol = protocol;

--- a/tests/socket-construct.phpt
+++ b/tests/socket-construct.phpt
@@ -1,0 +1,14 @@
+--TEST--
+Test creating and closing sockets
+--DESCRIPTION--
+Test that creating and closing sockets works as expected on all platforms (gh issue #798)
+--FILE--
+<?php
+$socket = new \Socket(\Socket::AF_INET, \Socket::SOCK_DGRAM, \Socket::SOL_UDP);
+echo "created\n";
+$socket->close();
+echo "closed\n";
+?>
+--EXPECTF--
+created
+closed


### PR DESCRIPTION
This includes a fix for #798 , a test for it, and a fix for another Windows-specific bug that broke the test.

- Socket::__construct() now works correctly on Windows.
- Socket::close() no longer raises exceptions on Windows.

These are Windows-specific issues, but the fixes have been tested on unix as well nonetheless.