### PR TITLE
class preparation revision

### DIFF
--- a/src/object.c
+++ b/src/object.c
@@ -512,11 +512,7 @@ static void * pthreads_routine(pthreads_routine_arg_t *routine) {
 				while (pthreads_stack_next(thread->stack, &stacked, thread->running) != PTHREADS_MONITOR_JOINED) {
 					zval that;
 					pthreads_object_t* work = PTHREADS_FETCH_FROM(Z_OBJ(stacked));
-					zend_class_entry *ce = pthreads_prepared_entry_internal(thread, work->std.ce, 0);
-
-					pthreads_prepared_entry_late_bindings(thread, work->std.ce, ce);
-
-					object_init_ex(&that, ce);
+					object_init_ex(&that, pthreads_prepared_entry(thread, work->std.ce));
 					pthreads_routine_run_function(work, PTHREADS_FETCH_FROM(Z_OBJ(that)), &that);
 					zval_ptr_dtor(&that);
 				}

--- a/src/prepare.c
+++ b/src/prepare.c
@@ -48,13 +48,62 @@ static  zend_trait_method_reference * pthreads_preparation_copy_trait_method_ref
 static void pthreads_prepared_resource_dtor(zval *zv); /* }}} */
 
 /* {{{ */
-static void pthreads_prepared_entry_static_members(pthreads_object_t* thread, zend_class_entry *candidate, zend_class_entry *prepared) {
+static void prepare_class_constants(pthreads_object_t* thread, zend_class_entry *candidate, zend_class_entry *prepared) {
+
+	zend_string *key;
+	zval *value;
+
+	ZEND_HASH_FOREACH_STR_KEY_VAL(&candidate->constants_table, key, value) {
+		zend_string *name;
+		zval separated;
+
+		if (zend_hash_exists(&prepared->constants_table, key)) {
+			continue;
+		}
+
+		switch (Z_TYPE_P(value)) {
+			case IS_PTR: {
+				zend_class_constant *zc = Z_PTR_P(value), rc;
+
+				memcpy(&rc, zc, sizeof(zend_class_constant));
+
+				if (pthreads_store_separate(&zc->value, &rc.value, 1) == SUCCESS) {
+					if (zc->doc_comment != NULL) {
+						rc.doc_comment = zend_string_new(zc->doc_comment);
+					}
+					rc.ce = pthreads_prepared_entry(thread, zc->ce);
+
+					name = zend_string_new(key);
+					zend_hash_add_mem(&prepared->constants_table, name, &rc, sizeof(zend_class_constant));
+					zend_string_release(name);
+				}
+				continue;
+			}
+
+			case IS_STRING:
+			case IS_ARRAY: {
+				if (pthreads_store_separate(value, &separated, 1) != SUCCESS) {
+					continue;
+				}
+			} break;
+
+			default: ZVAL_COPY(&separated, value);
+		}
+
+		name = zend_string_new(key);
+		zend_hash_update(&prepared->constants_table, name, &separated);
+		zend_string_release(name);
+	} ZEND_HASH_FOREACH_END();
+} /* }}} */
+
+/* {{{ */
+static void prepare_class_statics(pthreads_object_t* thread, zend_class_entry *candidate, zend_class_entry *prepared) {
 	if (candidate->default_static_members_count) {
 		int i;
 
-                if(prepared->default_static_members_table != NULL) {
-                        efree(prepared->default_static_members_table);
-                }
+		if(prepared->default_static_members_table != NULL) {
+			efree(prepared->default_static_members_table);
+		}
 		prepared->default_static_members_table = (zval*) ecalloc(
 			sizeof(zval), candidate->default_static_members_count);
 		prepared->default_static_members_count = candidate->default_static_members_count;
@@ -69,56 +118,11 @@ static void pthreads_prepared_entry_static_members(pthreads_object_t* thread, ze
 		}	
 		prepared->static_members_table = prepared->default_static_members_table;
 	} else prepared->default_static_members_count = 0;
-	
-	{
-		zend_string *key;
-		zval *value;
-
-		ZEND_HASH_FOREACH_STR_KEY_VAL(&candidate->constants_table, key, value) {
-			zend_string *name;
-			zval separated;
-
-			if (zend_hash_exists(&prepared->constants_table, key)) {
-				continue;
-			}
-
-			switch (Z_TYPE_P(value)) {
-				case IS_PTR: {
-					zend_class_constant *zc = Z_PTR_P(value), rc;
-
-					memcpy(&rc, zc, sizeof(zend_class_constant));
-
-					if (pthreads_store_separate(&zc->value, &rc.value, 1) == SUCCESS) {
-						if (zc->doc_comment != NULL) {
-							rc.doc_comment = zend_string_new(zc->doc_comment);
-						}
-						rc.ce = pthreads_prepared_entry_internal(thread, zc->ce, 0);
-
-						name = zend_string_new(key);
-						zend_hash_add_mem(&prepared->constants_table, name, &rc, sizeof(zend_class_constant));
-						zend_string_release(name);
-					}
-					continue;
-				}
-
-				case IS_STRING:
-				case IS_ARRAY: {
-					if (pthreads_store_separate(value, &separated, 1) != SUCCESS) {
-						continue;
-					}
-				} break;
-
-				default: ZVAL_COPY(&separated, value);
-			}
-
-			name = zend_string_new(key);
-			zend_hash_update(&prepared->constants_table, name, &separated);
-			zend_string_release(name);
-		} ZEND_HASH_FOREACH_END();
-	}
 } /* }}} */
 
+/* {{{ */
 static void prepare_class_function_table(zend_class_entry *candidate, zend_class_entry *prepared) {
+
 	zend_string *key;
 	zend_function *value;
 
@@ -131,118 +135,100 @@ static void prepare_class_function_table(zend_class_entry *candidate, zend_class
 			zend_string_release(name);
 		}
 	} ZEND_HASH_FOREACH_END();
-}
+} /* }}} */
 
 /* {{{ */
-static zend_class_entry* pthreads_complete_entry(pthreads_object_t* thread, zend_class_entry *candidate, zend_class_entry *prepared, zend_bool prepare_static_members) {
-    
-	if (candidate->parent) {
-		if (zend_hash_index_exists(&PTHREADS_ZG(resolve), (zend_ulong) candidate->parent)) {
-			prepared->parent = zend_hash_index_find_ptr(&PTHREADS_ZG(resolve), (zend_ulong) candidate->parent);
-		} else prepared->parent = pthreads_prepared_entry_internal(thread, candidate->parent, prepare_static_members);
-	}
+static void prepare_class_property_table(pthreads_object_t* thread, zend_class_entry *candidate, zend_class_entry *prepared) {
 
-	if (candidate->num_interfaces) {
-		uint interface;
-		prepared->interfaces = emalloc(sizeof(zend_class_entry*) * candidate->num_interfaces);
-		for(interface=0; interface<candidate->num_interfaces; interface++)
-			prepared->interfaces[interface] = pthreads_prepared_entry_internal(thread, candidate->interfaces[interface], prepare_static_members);
-		prepared->num_interfaces = candidate->num_interfaces;
-	} else prepared->num_interfaces = 0;
+	zend_property_info *info;
+	zend_string *name;
+	ZEND_HASH_FOREACH_STR_KEY_PTR(&candidate->properties_info, name, info) {
+		zend_property_info dup = *info;
+		if (info->doc_comment) {
+			if (thread->options & PTHREADS_INHERIT_COMMENTS) {
+				dup.doc_comment = zend_string_new(info->doc_comment);
+			} else dup.doc_comment = NULL;
+		}
 
-	if (candidate->num_traits) {
-		uint trait;
-		prepared->traits = emalloc(sizeof(zend_class_entry*) * candidate->num_traits);
-		for (trait=0; trait<candidate->num_traits; trait++)
-			prepared->traits[trait] = pthreads_prepared_entry(thread, candidate->traits[trait]);
-		prepared->num_traits = candidate->num_traits;
-		
-		if (candidate->trait_aliases) {
-			size_t alias = 0;
+		if (info->ce) {
+			if (info->ce == candidate) {
+				dup.ce = prepared;
+			} else dup.ce = pthreads_prepared_entry(thread, info->ce);
+		}
 
-			while (candidate->trait_aliases[alias]) {
-				alias++;
+		if (!zend_hash_str_add_mem(&prepared->properties_info, name->val, name->len, &dup, sizeof(zend_property_info))) {
+			if (dup.doc_comment)
+				zend_string_release(dup.doc_comment);
+		}
+	} ZEND_HASH_FOREACH_END();
+
+	if (candidate->default_properties_count) {
+		int i;
+
+		if(prepared->default_properties_table != NULL) {
+			efree(prepared->default_properties_table);
+		}
+		prepared->default_properties_table = emalloc(
+			sizeof(zval) * candidate->default_properties_count);
+
+		memcpy(
+			prepared->default_properties_table,
+			candidate->default_properties_table,
+			sizeof(zval) * candidate->default_properties_count);
+
+		for (i=0; i<candidate->default_properties_count; i++) {
+			if (Z_REFCOUNTED(prepared->default_properties_table[i])) {
+				pthreads_store_separate(
+					&candidate->default_properties_table[i],
+					&prepared->default_properties_table[i], 1);
 			}
-			prepared->trait_aliases = emalloc(sizeof(zend_trait_alias*) * (alias+1));
-			alias = 0;
+		}
+		prepared->default_properties_count = candidate->default_properties_count;
+	} else prepared->default_properties_count = 0;
+} /* }}} */
 
-			while (candidate->trait_aliases[alias]) {
-				prepared->trait_aliases[alias] = pthreads_preparation_copy_trait_alias(
-					thread, candidate->trait_aliases[alias]
-				);
-				alias++;
+/* {{{ */
+static void prepare_class_handlers(zend_class_entry *candidate, zend_class_entry *prepared) {
+	uint umethod = 0;
+	void *usources[6] = {
+		candidate->create_object,
+		candidate->serialize,
+		candidate->unserialize,
+		candidate->get_iterator,
+		candidate->interface_gets_implemented,
+		candidate->get_static_method
+	};
+
+	do {
+		if (usources[umethod]) {
+			switch(umethod){
+				case 0: prepared->create_object = candidate->create_object; break;
+				case 1: prepared->serialize = candidate->serialize; break;
+				case 2: prepared->unserialize = candidate->unserialize; break;
+				case 3: {
+					prepared->get_iterator = candidate->get_iterator;
+					prepared->iterator_funcs = candidate->iterator_funcs;
+				} break;
+				case 4: prepared->interface_gets_implemented = candidate->interface_gets_implemented; break;
+				case 5: prepared->get_static_method = candidate->get_static_method; break;
 			}
-			prepared->trait_aliases[alias]=NULL;
-		} else prepared->trait_aliases = NULL;
-		
-		if (candidate->trait_precedences) {
-			size_t precedence = 0;
-			            
-            while (candidate->trait_precedences[precedence]) {
-                precedence++;
-            }
-            prepared->trait_precedences = emalloc(sizeof(zend_trait_precedence*) * (precedence+1));
-            precedence = 0;
-            
-            while (candidate->trait_precedences[precedence]) {
-	            prepared->trait_precedences[precedence] = pthreads_preparation_copy_trait_precedence(
-		            thread, candidate->trait_precedences[precedence]
-	            );
-	            precedence++;
-            }
-			prepared->trait_precedences[precedence]=NULL;
-		} else prepared->trait_precedences = NULL;
-	} else {
-		prepared->num_traits = 0;
-		prepared->trait_aliases = 0;
-		prepared->trait_precedences = 0;
-	}
+		}
+	} while(++umethod < 6);
+} /* }}} */
 
-	{
-		uint umethod = 0;
-		void *usources[6] = {
-			candidate->create_object,
-			candidate->serialize,
-			candidate->unserialize,
-			candidate->get_iterator,
-			candidate->interface_gets_implemented,
-			candidate->get_static_method
-		};
-		
-		do {
-			if (usources[umethod]) {
-				switch(umethod){
-					case 0: prepared->create_object = candidate->create_object; break;
-					case 1: prepared->serialize = candidate->serialize; break;
-					case 2: prepared->unserialize = candidate->unserialize; break;
-					case 3: {
-						prepared->get_iterator = candidate->get_iterator;
-						prepared->iterator_funcs = candidate->iterator_funcs;
-					} break;
-					case 4: prepared->interface_gets_implemented = candidate->interface_gets_implemented; break;
-					case 5: prepared->get_static_method = candidate->get_static_method; break;
-				}
-			}
-		} while(++umethod < 6);
-	}
+static void prepare_class_interceptors(zend_class_entry *candidate, zend_class_entry *prepared) {
+	zend_function *func;
 
-	// if this is an unbound anonymous class, then this will be the second copy,
-	// where all inherited functions will be copied
-	prepare_class_function_table(candidate, prepared);
-
-	{
-	    zend_function *func;
-
-	    if (!prepared->constructor && zend_hash_num_elements(&prepared->function_table)) {
-	        if ((func = zend_hash_str_find_ptr(&prepared->function_table, "__construct", sizeof("__construct")-1))) {
-	            prepared->constructor = func;
-	        } else {
+	if (!prepared->constructor && zend_hash_num_elements(&prepared->function_table)) {
+		if ((func = zend_hash_str_find_ptr(&prepared->function_table, "__construct", sizeof("__construct")-1))) {
+			prepared->constructor = func;
+		} else {
 			if ((func = zend_hash_find_ptr(&prepared->function_table, prepared->name))) {
 				prepared->constructor = func;
 			}
 		}
-	    }
-	    
+	}
+
 #define FIND_AND_SET(f, n) do {\
     if (!prepared->f && zend_hash_num_elements(&prepared->function_table)) { \
         if ((func = zend_hash_str_find_ptr(&prepared->function_table, n, sizeof(n)-1))) { \
@@ -252,19 +238,18 @@ static zend_class_entry* pthreads_complete_entry(pthreads_object_t* thread, zend
 } \
 while(0)
         
-        FIND_AND_SET(clone, "__clone");
-        FIND_AND_SET(__get, "__get");
-        FIND_AND_SET(__set, "__set");
-        FIND_AND_SET(__unset, "__unset");
-        FIND_AND_SET(__isset, "__isset");
-        FIND_AND_SET(__call, "__call");
-        FIND_AND_SET(__callstatic, "__callstatic");
-        FIND_AND_SET(serialize_func, "serialize");
-        FIND_AND_SET(unserialize_func, "unserialize");
-        FIND_AND_SET(__tostring, "__tostring");
-        FIND_AND_SET(destructor, "__destruct");
+	FIND_AND_SET(clone, "__clone");
+	FIND_AND_SET(__get, "__get");
+	FIND_AND_SET(__set, "__set");
+	FIND_AND_SET(__unset, "__unset");
+	FIND_AND_SET(__isset, "__isset");
+	FIND_AND_SET(__call, "__call");
+	FIND_AND_SET(__callstatic, "__callstatic");
+	FIND_AND_SET(serialize_func, "serialize");
+	FIND_AND_SET(unserialize_func, "unserialize");
+	FIND_AND_SET(__tostring, "__tostring");
+	FIND_AND_SET(destructor, "__destruct");
 #undef FIND_AND_SET
-	}
 
 #define SET_ITERATOR_FUNC(f) do { \
 	if (candidate->iterator_funcs.f) { \
@@ -283,12 +268,92 @@ while(0)
 	SET_ITERATOR_FUNC(zf_rewind);
 
 #undef SET_ITERATOR_FUNC
+} /* }}} */
+
+/* {{{ */
+static void prepare_class_traits(pthreads_object_t* thread, zend_class_entry *candidate, zend_class_entry *prepared) {
+
+	if (candidate->num_traits) {
+		uint trait;
+		prepared->traits = emalloc(sizeof(zend_class_entry*) * candidate->num_traits);
+		for (trait=0; trait<candidate->num_traits; trait++)
+			prepared->traits[trait] = pthreads_prepared_entry(thread, candidate->traits[trait]);
+		prepared->num_traits = candidate->num_traits;
+
+		if (candidate->trait_aliases) {
+			size_t alias = 0;
+
+			while (candidate->trait_aliases[alias]) {
+				alias++;
+			}
+			prepared->trait_aliases = emalloc(sizeof(zend_trait_alias*) * (alias+1));
+			alias = 0;
+
+			while (candidate->trait_aliases[alias]) {
+				prepared->trait_aliases[alias] = pthreads_preparation_copy_trait_alias(
+					thread, candidate->trait_aliases[alias]
+				);
+				alias++;
+			}
+			prepared->trait_aliases[alias]=NULL;
+		} else prepared->trait_aliases = NULL;
+
+		if (candidate->trait_precedences) {
+			size_t precedence = 0;
+
+            while (candidate->trait_precedences[precedence]) {
+                precedence++;
+            }
+            prepared->trait_precedences = emalloc(sizeof(zend_trait_precedence*) * (precedence+1));
+            precedence = 0;
+
+            while (candidate->trait_precedences[precedence]) {
+	            prepared->trait_precedences[precedence] = pthreads_preparation_copy_trait_precedence(
+		            thread, candidate->trait_precedences[precedence]
+	            );
+	            precedence++;
+            }
+			prepared->trait_precedences[precedence]=NULL;
+		} else prepared->trait_precedences = NULL;
+	} else {
+		prepared->num_traits = 0;
+		prepared->trait_aliases = 0;
+		prepared->trait_precedences = 0;
+	}
+} /* }}} */
+
+/* {{{ */
+static zend_class_entry* pthreads_complete_entry(pthreads_object_t* thread, zend_class_entry *candidate, zend_class_entry *prepared) {
+
+	if (candidate->parent) {
+		if (zend_hash_index_exists(&PTHREADS_ZG(resolve), (zend_ulong) candidate->parent)) {
+			prepared->parent = zend_hash_index_find_ptr(&PTHREADS_ZG(resolve), (zend_ulong) candidate->parent);
+		} else prepared->parent = pthreads_prepared_entry(thread, candidate->parent);
+	}
+
+	if (candidate->num_interfaces) {
+		uint interface;
+		prepared->interfaces = emalloc(sizeof(zend_class_entry*) * candidate->num_interfaces);
+		for(interface=0; interface<candidate->num_interfaces; interface++)
+			prepared->interfaces[interface] = pthreads_prepared_entry(thread, candidate->interfaces[interface]);
+		prepared->num_interfaces = candidate->num_interfaces;
+	} else prepared->num_interfaces = 0;
+
+	prepare_class_traits(thread, candidate, prepared);
+
+	prepare_class_handlers(candidate, prepared);
+
+	// if this is an unbound anonymous class, then this will be the second copy,
+	// where all inherited functions will be copied
+	prepare_class_function_table(candidate, prepared);
+
+	prepare_class_interceptors(candidate, prepared);
 
 	return prepared;
 } /* }}} */
 
 /* {{{ */
-static zend_class_entry* pthreads_copy_entry(pthreads_object_t* thread, zend_class_entry *candidate, zend_bool prepare_static_members) {
+static zend_class_entry* pthreads_copy_entry(pthreads_object_t* thread, zend_class_entry *candidate) {
 	zend_class_entry *prepared;
 
 	prepared = zend_arena_alloc(&CG(arena), sizeof(zend_class_entry));
@@ -296,8 +361,6 @@ static zend_class_entry* pthreads_copy_entry(pthreads_object_t* thread, zend_cla
 	prepared->type = candidate->type;
 
 	zend_initialize_class_data(prepared, 1);
-
-	zend_hash_index_update_ptr(&PTHREADS_ZG(resolve), (zend_ulong) candidate, prepared);
 
 	prepared->ce_flags = candidate->ce_flags;
 	prepared->refcount = 1;
@@ -312,68 +375,19 @@ static zend_class_entry* pthreads_copy_entry(pthreads_object_t* thread, zend_cla
 	if (prepared->info.user.filename) {
 		prepared->info.user.filename = zend_string_new(candidate->info.user.filename);
 	}
-
-	{
-		zend_property_info *info;
-		zend_string *name;
-		ZEND_HASH_FOREACH_STR_KEY_PTR(&candidate->properties_info, name, info) {
-			zend_property_info dup = *info;
-			
-			if (info->doc_comment) {
-				if (thread->options & PTHREADS_INHERIT_COMMENTS) {
-					dup.doc_comment = zend_string_new(info->doc_comment);
-				} else dup.doc_comment = NULL;
-			}
-
-			if (info->ce) {
-				if (info->ce == candidate) {
-					dup.ce = prepared;
-				} else dup.ce = pthreads_prepared_entry_internal(thread, info->ce, prepare_static_members);
-			}
-			
-			if (!zend_hash_str_add_mem(&prepared->properties_info, name->val, name->len, &dup, sizeof(zend_property_info))) {		
-				if (dup.doc_comment)
-					zend_string_release(dup.doc_comment);
-			}
-		} ZEND_HASH_FOREACH_END();
-	}
-	
-	if (candidate->default_properties_count) {
-		int i;
-                
-                if(prepared->default_properties_table != NULL) {
-                        efree(prepared->default_properties_table);
-                }
-		prepared->default_properties_table = emalloc(
-			sizeof(zval) * candidate->default_properties_count);
-
-		memcpy(
-			prepared->default_properties_table,
-			candidate->default_properties_table,
-			sizeof(zval) * candidate->default_properties_count);
-
-		for (i=0; i<candidate->default_properties_count; i++) {
-			if (Z_REFCOUNTED(prepared->default_properties_table[i])) {
-				pthreads_store_separate(
-					&candidate->default_properties_table[i],
-					&prepared->default_properties_table[i], 1);
-			}
-		}
-		prepared->default_properties_count = candidate->default_properties_count;
-	} else prepared->default_properties_count = 0;
-
-	if (prepare_static_members) {
-		pthreads_prepared_entry_static_members(thread, candidate, prepared);
-	}
+	prepare_class_property_table(thread, candidate, prepared);
 
 	if (candidate->ce_flags & ZEND_ACC_ANON_CLASS && !(prepared->ce_flags & ZEND_ACC_ANON_BOUND)) {
+
 		// this first copy will copy all declared functions on the unbound anonymous class
 		prepare_class_function_table(candidate, prepared);
+		//prepare_class_handlers(candidate, prepared);
+		prepare_class_interceptors(candidate, prepared);
 
 		return prepared;
 	}
 
-	return pthreads_complete_entry(thread, candidate, prepared, prepare_static_members);
+	return pthreads_complete_entry(thread, candidate, prepared);
 } /* }}} */
 
 /* {{{ */
@@ -434,11 +448,11 @@ static inline void pthreads_prepare_closures(pthreads_object_t *thread) {
 
 /* {{{ */
 zend_class_entry* pthreads_prepared_entry(pthreads_object_t* thread, zend_class_entry *candidate) {
-	return pthreads_prepared_entry_internal(thread, candidate, 1);
+	return pthreads_create_entry(thread, candidate, 1);
 } /* }}} */
 
 /* {{{ */
-zend_class_entry* pthreads_prepared_entry_internal(pthreads_object_t* thread, zend_class_entry *candidate, zend_bool prepare_static_members) {
+zend_class_entry* pthreads_create_entry(pthreads_object_t* thread, zend_class_entry *candidate, int do_late_bindings) {
 	zend_class_entry *prepared = NULL;
 	zend_string *lookup = NULL;
 
@@ -456,14 +470,19 @@ zend_class_entry* pthreads_prepared_entry_internal(pthreads_object_t* thread, ze
 	    zend_string_release(lookup);
 		
 		if(prepared->create_object == NULL && candidate->create_object != NULL) {
-			return pthreads_complete_entry(thread, candidate, prepared, prepare_static_members);
+			return pthreads_complete_entry(thread, candidate, prepared);
 		}
 		return prepared;
 	}
 
-	if (!(prepared = pthreads_copy_entry(thread, candidate, prepare_static_members))) {
+	if (!(prepared = pthreads_copy_entry(thread, candidate))) {
 		zend_string_release(lookup);
 		return NULL;
+	}
+	zend_hash_update_ptr(EG(class_table), lookup, prepared);
+
+	if(do_late_bindings) {
+		pthreads_prepared_entry_late_bindings(thread, candidate, prepared);
 	}
 	pthreads_prepare_closures(thread);
 
@@ -472,8 +491,6 @@ zend_class_entry* pthreads_prepared_entry_internal(pthreads_object_t* thread, ze
 		pthreads_prepared_entry_function_prepare, 
 		3, thread, prepared, candidate);	
 	
-	zend_hash_update_ptr(EG(class_table), lookup, prepared);
-
 	zend_string_release(lookup);
 
 	return prepared;
@@ -481,8 +498,22 @@ zend_class_entry* pthreads_prepared_entry_internal(pthreads_object_t* thread, ze
 
 /* {{{ */
 void pthreads_prepared_entry_late_bindings(pthreads_object_t* thread, zend_class_entry *candidate, zend_class_entry *prepared) {
-	pthreads_prepared_entry_static_members(thread, candidate, prepared);
+	prepare_class_statics(thread, candidate, prepared);
+	prepare_class_constants(thread, candidate, prepared);
 } /* }}} */
+
+
+/* {{{ */
+void pthreads_context_late_bindings(pthreads_object_t* thread) {
+	zend_class_entry *entry;
+	zend_string *name;
+
+	ZEND_HASH_FOREACH_STR_KEY_PTR(PTHREADS_CG(thread->local.ls, class_table), name, entry) {
+		if (entry->type != ZEND_INTERNAL_CLASS) {
+			pthreads_prepared_entry_late_bindings(thread, zend_hash_find_ptr(PTHREADS_CG(thread->creator.ls, class_table), name), entry);
+		}
+	} ZEND_HASH_FOREACH_END();
+}
 
 /* {{{ */
 static inline zend_bool pthreads_constant_exists(zend_string *name) {
@@ -620,18 +651,14 @@ static inline void pthreads_prepare_functions(pthreads_object_t* thread) {
 static inline void pthreads_prepare_classes(pthreads_object_t* thread) {
 	zend_class_entry *entry;
 	zend_string *name;
-	
+
 	ZEND_HASH_FOREACH_STR_KEY_PTR(PTHREADS_CG(thread->creator.ls, class_table), name, entry) {
 		if (!zend_hash_exists(PTHREADS_CG(thread->local.ls, class_table), name) && ZSTR_VAL(name)[0] != '\0') {
-			pthreads_prepared_entry_internal(thread, entry, 0);
+			pthreads_create_entry(thread, entry, 0);
 		}
 	} ZEND_HASH_FOREACH_END();
 
-	ZEND_HASH_FOREACH_STR_KEY_PTR(PTHREADS_CG(thread->local.ls, class_table), name, entry) {
-		if (entry->type != ZEND_INTERNAL_CLASS) {
-			pthreads_prepared_entry_static_members(thread, zend_hash_find_ptr(PTHREADS_CG(thread->creator.ls, class_table), name), entry);
-		}
-	} ZEND_HASH_FOREACH_END();
+	pthreads_context_late_bindings(thread);
 } /* }}} */
 
 /* {{{ */
@@ -731,16 +758,8 @@ int pthreads_prepared_startup(pthreads_object_t* thread, pthreads_monitor_t *rea
 		if (thread->options & PTHREADS_INHERIT_CLASSES) {
 			pthreads_prepare_classes(thread);
 		} else {
-			pthreads_prepared_entry_internal(thread, thread->std.ce, 0);
-
-			zend_class_entry *entry;
-			zend_string *name;
-
-			ZEND_HASH_FOREACH_STR_KEY_PTR(PTHREADS_CG(thread->local.ls, class_table), name, entry) {
-				if (entry->type != ZEND_INTERNAL_CLASS) {
-					pthreads_prepared_entry_static_members(thread, zend_hash_find_ptr(PTHREADS_CG(thread->creator.ls, class_table), name), entry);
-				}
-			} ZEND_HASH_FOREACH_END();
+			pthreads_create_entry(thread, thread->std.ce, 0);
+			pthreads_context_late_bindings(thread);
 		}
 
 		if (thread->options & PTHREADS_INHERIT_INCLUDES)

--- a/src/prepare.c
+++ b/src/prepare.c
@@ -189,31 +189,13 @@ static void prepare_class_property_table(pthreads_object_t* thread, zend_class_e
 
 /* {{{ */
 static void prepare_class_handlers(zend_class_entry *candidate, zend_class_entry *prepared) {
-	uint umethod = 0;
-	void *usources[6] = {
-		candidate->create_object,
-		candidate->serialize,
-		candidate->unserialize,
-		candidate->get_iterator,
-		candidate->interface_gets_implemented,
-		candidate->get_static_method
-	};
-
-	do {
-		if (usources[umethod]) {
-			switch(umethod){
-				case 0: prepared->create_object = candidate->create_object; break;
-				case 1: prepared->serialize = candidate->serialize; break;
-				case 2: prepared->unserialize = candidate->unserialize; break;
-				case 3: {
-					prepared->get_iterator = candidate->get_iterator;
-					prepared->iterator_funcs = candidate->iterator_funcs;
-				} break;
-				case 4: prepared->interface_gets_implemented = candidate->interface_gets_implemented; break;
-				case 5: prepared->get_static_method = candidate->get_static_method; break;
-			}
-		}
-	} while(++umethod < 6);
+	prepared->create_object = candidate->create_object;
+	prepared->serialize = candidate->serialize;
+	prepared->unserialize = candidate->unserialize;
+	prepared->get_iterator = candidate->get_iterator;
+	prepared->iterator_funcs = candidate->iterator_funcs;
+	prepared->interface_gets_implemented = candidate->interface_gets_implemented;
+	prepared->get_static_method = candidate->get_static_method;
 } /* }}} */
 
 static void prepare_class_interceptors(zend_class_entry *candidate, zend_class_entry *prepared) {
@@ -326,9 +308,7 @@ static void prepare_class_traits(pthreads_object_t* thread, zend_class_entry *ca
 static zend_class_entry* pthreads_complete_entry(pthreads_object_t* thread, zend_class_entry *candidate, zend_class_entry *prepared) {
 
 	if (candidate->parent) {
-		if (zend_hash_index_exists(&PTHREADS_ZG(resolve), (zend_ulong) candidate->parent)) {
-			prepared->parent = zend_hash_index_find_ptr(&PTHREADS_ZG(resolve), (zend_ulong) candidate->parent);
-		} else prepared->parent = pthreads_prepared_entry(thread, candidate->parent);
+		prepared->parent = pthreads_prepared_entry(thread, candidate->parent);
 	}
 
 	if (candidate->num_interfaces) {
@@ -381,7 +361,6 @@ static zend_class_entry* pthreads_copy_entry(pthreads_object_t* thread, zend_cla
 
 		// this first copy will copy all declared functions on the unbound anonymous class
 		prepare_class_function_table(candidate, prepared);
-		//prepare_class_handlers(candidate, prepared);
 		prepare_class_interceptors(candidate, prepared);
 
 		return prepared;

--- a/src/prepare.h
+++ b/src/prepare.h
@@ -25,11 +25,14 @@
 /* {{{ fetch prepared class entry */
 zend_class_entry* pthreads_prepared_entry(pthreads_object_t* thread, zend_class_entry *candidate); /* }}} */
 
-/* {{{ fetch prepared class entry */
-zend_class_entry* pthreads_prepared_entry_internal(pthreads_object_t* thread, zend_class_entry *candidate, zend_bool prepare_static_members); /* }}} */
+/* {{{ */
+zend_class_entry* pthreads_create_entry(pthreads_object_t* thread, zend_class_entry *candidate, int do_late_bindings); /* }}} */
 
 /* {{{ */
 void pthreads_prepared_entry_late_bindings(pthreads_object_t* thread, zend_class_entry *candidate, zend_class_entry *prepared); /* }}} */
+
+/* {{{ */
+void pthreads_context_late_bindings(pthreads_object_t* thread); /* }}} */
 
 /* {{{ */
 void pthreads_prepare_parent(pthreads_object_t *thread); /* }}} */

--- a/tests/anon-interceptors.phpt
+++ b/tests/anon-interceptors.phpt
@@ -1,0 +1,57 @@
+--TEST--
+Test interceptors of anonymous classes
+--DESCRIPTION--
+This test verifies that interceptors of anonymous Thread objects work as expected
+--FILE--
+<?php
+class Foo extends Threaded {
+    public $bar;
+
+    public function __construct() {
+        var_dump(__METHOD__);
+
+        $this->bar = new class extends Threaded {
+            private $buzz;
+
+            public function __construct() {
+                var_dump('Bar::__construct');
+            }
+            public function __destruct() {
+                var_dump('Bar::__destruct');
+            }
+            public function __set($name, $value) {
+                var_dump($name, $value);
+                $this->buzz = $value;
+            }
+            public function __get($name) {
+                return $this->buzz;
+            }
+        };
+        $this->bar->buzz = 'hello world';
+        var_dump($this->bar->buzz);
+    }
+    public function __destruct() {
+        var_dump(__METHOD__);
+    }
+}
+
+class Test extends \Thread {
+    public function run() {
+        $foo = new Foo();
+        var_dump($foo->bar);
+    }
+}
+$thread = new Test();
+$thread->start() && $thread->join();
+--EXPECT--
+string(16) "Foo::__construct"
+string(16) "Bar::__construct"
+string(4) "buzz"
+string(11) "hello world"
+string(11) "hello world"
+object(class@anonymous)#3 (1) {
+  ["buzz"]=>
+  string(11) "hello world"
+}
+string(15) "Foo::__destruct"
+string(15) "Bar::__destruct"


### PR DESCRIPTION
I've splitted up the functions ```pthreads_prepared_entry_static_members``` and ```pthreads_complete_entry``` to smaller ones. New (partially prepared) classes will get inserted into the ```EG(class_table)``` HT and not into the ```resolve``` HT anymore. I'm quite not happy with the wording of function ```pthreads_prepared_entry_late_bindings```, suggestions are welcome. Your opinions, of course, too.