### PR TITLE
Fail AppVeyor build if any tests fail

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -75,7 +75,10 @@ build_script:
 
     php -m
 test_script:
-- cmd: php.exe /projects/php-src/run-tests.php /projects/php-src/ext/pthreads -q --show-diff
+- cmd: >-
+    set REPORT_EXIT_STATUS=1
+
+    php.exe /projects/php-src/run-tests.php /projects/php-src/ext/pthreads -q --show-diff
 artifacts:
   - path: bin
     name: master


### PR DESCRIPTION
Prior to this, AppVeyor builds would still be marked as "succeeded" even if tests failed.