### PR TITLE
tiny fix for win32 IPv4 test

### DIFF
--- a/tests/socket-sentto-recvfrom-ipv4-udp-win32.phpt
+++ b/tests/socket-sentto-recvfrom-ipv4-udp-win32.phpt
@@ -56,6 +56,7 @@ if (substr(PHP_OS, 0, 3) != 'WIN') {
 
 Warning: Wrong parameter count for Socket::sendto() in %s on line %d
 string(%d) "Error (%d): A non-blocking socket operation could not be completed immediately.
+"
 
 Warning: Socket::recvfrom() expects at least 4 parameters, 3 given in %s on line %d
 


### PR DESCRIPTION
Windows adds newlines at the end of most socket error messages.

see https://ci.appveyor.com/project/krakjoe/pthreads/build/master.274/job/lwjo6yv8mi5vb79v#L743
