### PR TITLE
Fixed missing null terminator on serialized string

### DIFF
--- a/src/store.c
+++ b/src/store.c
@@ -824,6 +824,7 @@ static int pthreads_store_tostring(zval *pzval, char **pstring, size_t *slength,
 					memcpy(
 						(char*) *pstring, (const void*) smart.s->val, smart.s->len
 					);
+					(*pstring)[*slength] = 0;
 					result = SUCCESS;
 				}
 			} else *pstring = NULL;

--- a/src/store.c
+++ b/src/store.c
@@ -603,6 +603,7 @@ static pthreads_storage* pthreads_store_create(zval *unstore, zend_bool complex)
 			storage->data = 
 				(char*) malloc(storage->length+1);
 			memcpy(storage->data, Z_STRVAL_P(unstore), storage->length);
+			((char *)storage->data)[storage->length] = 0;
 		} break;
 
 		case IS_RESOURCE: {
@@ -917,6 +918,7 @@ int pthreads_store_merge(zval *destination, zval *from, zend_bool overwrite) {
 											break;
 										}
 										memcpy(copy->data, (const void*) storage->data, copy->length);
+										((char *)copy->data)[copy->length] = 0;
                                 	} break;
                                 }
 


### PR DESCRIPTION
https://github.com/krakjoe/pthreads/issues/816#issuecomment-362667495

This is probably harmless since a length is stored for this anyway, but still unwanted behaviour.

