### PR TITLE
fixed #812 - missing reference on copied functions

### DIFF
--- a/src/copy.h
+++ b/src/copy.h
@@ -392,6 +392,7 @@ static zend_function* pthreads_copy_function(zend_function *function) {
 		copy = pthreads_copy_internal_function(function);
 	}
 
+	function_add_ref(copy);
 	return zend_hash_index_update_ptr(&PTHREADS_ZG(resolve), (zend_ulong) function, copy);
 } /* }}} */
 #endif


### PR DESCRIPTION
since these are inserted into the resolve HT for later reuse, the refcount should reflect that. Without this fix the refcount only accounts for the reference returned, and not the one stored in the HT.

This fixes #812.