### PR TITLE
Fixed #761 - error output is swallowed without display_startup_errors…

### DIFF
--- a/src/prepare.c
+++ b/src/prepare.c
@@ -728,6 +728,7 @@ int pthreads_prepared_startup(pthreads_object_t* thread, pthreads_monitor_t *rea
 		PG(auto_globals_jit) = 0;
 
 		php_request_startup();
+		PG(during_request_startup) = 0;
 
 		pthreads_prepare_sapi(thread);
 	

--- a/tests/display-startup-errors-output.phpt
+++ b/tests/display-startup-errors-output.phpt
@@ -1,0 +1,43 @@
+--TEST--
+Tests that errors and uncaught exceptions on threads are correctly output
+--DESCRIPTION--
+Ensure errors and uncaught exceptions are properly displayed when display_startup_errors is not enabled (gh issue #761)
+--INI--
+display_startup_errors=0
+error_reporting=-1
+--FILE--
+<?php
+
+function throwException(){
+	throw new \Exception("Exception");
+}
+
+function undefined(){
+	if($a === true);
+}
+
+$w = new \Worker();
+$w->start();
+
+$w->stack(new class extends \Threaded{
+	public function run(){
+		throwException();
+	}
+});
+
+$w->stack(new class extends \Threaded{
+	public function run(){
+		undefined();
+	}
+});
+
+$w->shutdown();
+--EXPECTF--
+Fatal error: Uncaught Exception: Exception in %s:%d
+Stack trace:
+#0 %s(%d): throwException()
+#1 [internal function]: class@anonymous->run()
+#2 {main}
+  thrown in %s on line %d
+
+Notice: Undefined variable: a in %s on line %d


### PR DESCRIPTION
… directive

https://github.com/php/php-src/blob/a7fe2570d3ce6915d4ea85c62c0f880ddc225ba7/main/main.c#L1660-L1661
php_execute_script() does not get called on a pthreads thread, so this global is always 1 while the thread is running.