### PR TITLE
706 - Socket::read() adds Socket::PHP_NORMAL_READ and Socket::PHP_BINARY_READ

### DIFF
--- a/classes/socket.h
+++ b/classes/socket.h
@@ -77,6 +77,7 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_INFO_EX(Socket_read, 0, 0, 1)
 	ZEND_ARG_TYPE_INFO(0, length, IS_LONG, 0)
 	ZEND_ARG_TYPE_INFO(0, flags, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, type, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(Socket_write, 0, 0, 1)
@@ -260,16 +261,17 @@ PHP_METHOD(Socket, select) {
 	pthreads_socket_select(read, write, except, sec, usec, errorno, return_value);
 } /* }}} */
 
-/* {{{ proto string|bool Socket::read(int length [, int flags = 0]) */
+/* {{{ proto string|bool Socket::read(int length [, int flags = 0 [, int type = PHP_BINARY_READ]]) */
 PHP_METHOD(Socket, read) {
 	zend_long length = 0;
 	zend_long flags = 0;
+	zend_long type = PHP_BINARY_READ;
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "l|l", &length, &flags) != SUCCESS) {
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "l|ll", &length, &flags, &type) != SUCCESS) {
 		return;
 	}
 
-	pthreads_socket_read(getThis(), length, flags, return_value);
+	pthreads_socket_read(getThis(), length, flags, type, return_value);
 } /* }}} */
 
 /* {{{ proto int|bool Socket::write(string buffer [, int length]) */

--- a/classes/socket.h
+++ b/classes/socket.h
@@ -261,7 +261,7 @@ PHP_METHOD(Socket, select) {
 	pthreads_socket_select(read, write, except, sec, usec, errorno, return_value);
 } /* }}} */
 
-/* {{{ proto string|bool Socket::read(int length [, int flags = 0 [, int type = PTHREADS_BINARY_READ]]) */
+/* {{{ proto string|bool Socket::read(int length [, int flags = 0 [, int type = Socket::BINARY_READ]]) */
 PHP_METHOD(Socket, read) {
 	zend_long length = 0;
 	zend_long flags = 0;

--- a/classes/socket.h
+++ b/classes/socket.h
@@ -261,11 +261,11 @@ PHP_METHOD(Socket, select) {
 	pthreads_socket_select(read, write, except, sec, usec, errorno, return_value);
 } /* }}} */
 
-/* {{{ proto string|bool Socket::read(int length [, int flags = 0 [, int type = PHP_BINARY_READ]]) */
+/* {{{ proto string|bool Socket::read(int length [, int flags = 0 [, int type = PTHREADS_BINARY_READ]]) */
 PHP_METHOD(Socket, read) {
 	zend_long length = 0;
 	zend_long flags = 0;
-	zend_long type = PHP_BINARY_READ;
+	zend_long type = PTHREADS_BINARY_READ;
 
 	if (zend_parse_parameters(ZEND_NUM_ARGS(), "l|ll", &length, &flags, &type) != SUCCESS) {
 		return;

--- a/examples/stub.php
+++ b/examples/stub.php
@@ -653,8 +653,8 @@ class Socket extends \Threaded
     public const EDQUOT = 122;
     public const ENOMEDIUM = 123;
     public const EMEDIUMTYPE = 124;
-    public const PHP_NORMAL_READ = 1;
-    public const PHP_BINARY_READ = 2;
+    public const NORMAL_READ = 1;
+    public const BINARY_READ = 2;
 
     public function __construct(int $domain, int $type, int $protocol){}
 
@@ -672,7 +672,7 @@ class Socket extends \Threaded
 
     public static function select(array &$read, array &$write, array &$except, ?int $sec, int $usec = 0, int &$error = null){}
 
-    public function read(int $length, int $flags = 0, int $type = self::PHP_BINARY_READ){}
+    public function read(int $length, int $flags = 0, int $type = self::BINARY_READ){}
 
     public function write(string $buffer, int $length = 0){}
 

--- a/examples/stub.php
+++ b/examples/stub.php
@@ -653,6 +653,8 @@ class Socket extends \Threaded
     public const EDQUOT = 122;
     public const ENOMEDIUM = 123;
     public const EMEDIUMTYPE = 124;
+    public const PHP_NORMAL_READ = 1;
+    public const PHP_BINARY_READ = 2;
 
     public function __construct(int $domain, int $type, int $protocol){}
 
@@ -670,7 +672,7 @@ class Socket extends \Threaded
 
     public static function select(array &$read, array &$write, array &$except, ?int $sec, int $usec = 0, int &$error = null){}
 
-    public function read(int $length, int $flags = 0){}
+    public function read(int $length, int $flags = 0, int $type = self::PHP_BINARY_READ){}
 
     public function write(string $buffer, int $length = 0){}
 

--- a/php_pthreads.c
+++ b/php_pthreads.c
@@ -347,8 +347,8 @@ PHP_MINIT_FUNCTION(pthreads)
 #ifdef TCP_NODELAY
 	zend_declare_class_constant_long(pthreads_socket_entry, ZEND_STRL("TCP_NODELAY"), TCP_NODELAY);
 #endif
-	zend_declare_class_constant_long(pthreads_socket_entry, ZEND_STRL("PHP_NORMAL_READ"), PHP_NORMAL_READ);
-	zend_declare_class_constant_long(pthreads_socket_entry, ZEND_STRL("PHP_BINARY_READ"), PHP_BINARY_READ);
+	zend_declare_class_constant_long(pthreads_socket_entry, ZEND_STRL("PTHREADS_NORMAL_READ"), PTHREADS_NORMAL_READ);
+	zend_declare_class_constant_long(pthreads_socket_entry, ZEND_STRL("PTHREADS_BINARY_READ"), PTHREADS_BINARY_READ);
 
 	zend_declare_class_constant_long(pthreads_socket_entry, ZEND_STRL("SOL_SOCKET"), SOL_SOCKET);
 	zend_declare_class_constant_long(pthreads_socket_entry, ZEND_STRL("SOL_TCP"), IPPROTO_TCP);

--- a/php_pthreads.c
+++ b/php_pthreads.c
@@ -347,6 +347,8 @@ PHP_MINIT_FUNCTION(pthreads)
 #ifdef TCP_NODELAY
 	zend_declare_class_constant_long(pthreads_socket_entry, ZEND_STRL("TCP_NODELAY"), TCP_NODELAY);
 #endif
+	zend_declare_class_constant_long(pthreads_socket_entry, ZEND_STRL("PHP_NORMAL_READ"), PHP_NORMAL_READ);
+	zend_declare_class_constant_long(pthreads_socket_entry, ZEND_STRL("PHP_BINARY_READ"), PHP_BINARY_READ);
 
 	zend_declare_class_constant_long(pthreads_socket_entry, ZEND_STRL("SOL_SOCKET"), SOL_SOCKET);
 	zend_declare_class_constant_long(pthreads_socket_entry, ZEND_STRL("SOL_TCP"), IPPROTO_TCP);

--- a/php_pthreads.c
+++ b/php_pthreads.c
@@ -347,8 +347,8 @@ PHP_MINIT_FUNCTION(pthreads)
 #ifdef TCP_NODELAY
 	zend_declare_class_constant_long(pthreads_socket_entry, ZEND_STRL("TCP_NODELAY"), TCP_NODELAY);
 #endif
-	zend_declare_class_constant_long(pthreads_socket_entry, ZEND_STRL("PTHREADS_NORMAL_READ"), PTHREADS_NORMAL_READ);
-	zend_declare_class_constant_long(pthreads_socket_entry, ZEND_STRL("PTHREADS_BINARY_READ"), PTHREADS_BINARY_READ);
+	zend_declare_class_constant_long(pthreads_socket_entry, ZEND_STRL("NORMAL_READ"), PTHREADS_NORMAL_READ);
+	zend_declare_class_constant_long(pthreads_socket_entry, ZEND_STRL("BINARY_READ"), PTHREADS_BINARY_READ);
 
 	zend_declare_class_constant_long(pthreads_socket_entry, ZEND_STRL("SOL_SOCKET"), SOL_SOCKET);
 	zend_declare_class_constant_long(pthreads_socket_entry, ZEND_STRL("SOL_TCP"), IPPROTO_TCP);

--- a/src/socket.c
+++ b/src/socket.c
@@ -507,7 +507,7 @@ void pthreads_socket_read(zval *object, zend_long length, zend_long flags, zend_
 
 	buf = zend_string_alloc(length, 0);
 
-	if (type == PHP_NORMAL_READ) {
+	if (type == PTHREADS_NORMAL_READ) {
 		bytes = pthreads_normal_read(threaded, ZSTR_VAL(buf), length, flags);
 	} else {
 		bytes = recv(threaded->store.sock->fd, ZSTR_VAL(buf), length, flags);

--- a/src/socket.c
+++ b/src/socket.c
@@ -30,6 +30,8 @@
 # include "sockets/windows_common.h"
 # define SOCK_EINVAL WSAEINVAL
 #else
+# include <fcntl.h>
+# include <errno.h>
 # define set_errno(a) (errno = a)
 # define SOCK_EINVAL EINVAL
 #endif
@@ -426,7 +428,72 @@ void pthreads_socket_connect(zval *object, int argc, zend_string *address, zend_
 	RETURN_TRUE;
 }
 
-void pthreads_socket_read(zval *object, zend_long length, zend_long flags, zval *return_value) {
+static int pthreads_normal_read(pthreads_object_t *threaded, void *buf, size_t maxlen, int flags) /* {{{ */
+{
+	int m = 0;
+	size_t n = 0;
+	int no_read = 0;
+	int nonblock = 0;
+	char *t = (char *) buf;
+
+	PTHREADS_SOCKET_CHECK_EX(threaded->store.sock, -1);
+
+#ifndef PHP_WIN32
+	m = fcntl(threaded->store.sock->fd, F_GETFL);
+	if (m < 0) {
+		return m;
+	}
+	nonblock = (m & O_NONBLOCK);
+	m = 0;
+#else
+	nonblock = !threaded->store.sock->blocking;
+#endif
+	set_errno(0);
+
+	*t = '\0';
+	while (*t != '\n' && *t != '\r' && n < maxlen) {
+		if (m > 0) {
+			t++;
+			n++;
+		} else if (m == 0) {
+			no_read++;
+			if (nonblock && no_read >= 2) {
+				return n;
+				/* The first pass, m always is 0, so no_read becomes 1
+				 * in the first pass. no_read becomes 2 in the second pass,
+				 * and if this is nonblocking, we should return.. */
+			}
+
+			if (no_read > 200) {
+				set_errno(ECONNRESET);
+				return -1;
+			}
+		}
+
+		if (n < maxlen) {
+			m = recv(threaded->store.sock->fd, (void *) t, 1, flags);
+		}
+
+		if (errno != 0 && errno != ESPIPE && errno != EAGAIN) {
+			return -1;
+		}
+
+		set_errno(0);
+	}
+
+	if (n < maxlen) {
+		n++;
+		/* The only reasons it makes it to here is
+		 * if '\n' or '\r' are encountered. So, increase
+		 * the return by 1 to make up for the lack of the
+		 * '\n' or '\r' in the count (since read() takes
+		 * place at the end of the loop..) */
+	}
+
+	return n;
+}
+
+void pthreads_socket_read(zval *object, zend_long length, zend_long flags, zend_long type, zval *return_value) {
 	pthreads_object_t *threaded =
 		PTHREADS_FETCH_FROM(Z_OBJ_P(object));
 	zend_string *buf;
@@ -439,7 +506,12 @@ void pthreads_socket_read(zval *object, zend_long length, zend_long flags, zval 
 	}
 
 	buf = zend_string_alloc(length, 0);
-	bytes = recv(threaded->store.sock->fd, ZSTR_VAL(buf), length, flags);
+
+	if (type == PHP_NORMAL_READ) {
+		bytes = pthreads_normal_read(threaded, ZSTR_VAL(buf), length, flags);
+	} else {
+		bytes = recv(threaded->store.sock->fd, ZSTR_VAL(buf), length, flags);
+	}
 
 	if (bytes == -1) {
 		zend_string_free(buf);

--- a/src/socket.h
+++ b/src/socket.h
@@ -31,8 +31,8 @@ typedef struct _pthreads_socket_t {
 	zend_bool blocking;
 } pthreads_socket_t;
 
-#define PHP_NORMAL_READ 0x0001
-#define PHP_BINARY_READ 0x0002
+#define PTHREADS_NORMAL_READ 0x0001
+#define PTHREADS_BINARY_READ 0x0002
 
 pthreads_socket_t* pthreads_socket_alloc(void);
 void pthreads_socket_construct(zval *object, zend_long domain, zend_long type, zend_long protocol);

--- a/src/socket.h
+++ b/src/socket.h
@@ -31,6 +31,9 @@ typedef struct _pthreads_socket_t {
 	zend_bool blocking;
 } pthreads_socket_t;
 
+#define PHP_NORMAL_READ 0x0001
+#define PHP_BINARY_READ 0x0002
+
 pthreads_socket_t* pthreads_socket_alloc(void);
 void pthreads_socket_construct(zval *object, zend_long domain, zend_long type, zend_long protocol);
 void pthreads_socket_set_option(zval *object, zend_long level, zend_long name, zend_long value, zval *return_value);
@@ -39,7 +42,7 @@ void pthreads_socket_bind(zval *object, zend_string *address, zend_long port, zv
 void pthreads_socket_listen(zval *object, zend_long backlog, zval *return_value);
 void pthreads_socket_accept(zval *object, zend_class_entry *ce, zval *return_value);
 void pthreads_socket_connect(zval *object, int argc, zend_string *address, zend_long port, zval *return_value);
-void pthreads_socket_read(zval *object, zend_long length, zend_long flags, zval *return_value);
+void pthreads_socket_read(zval *object, zend_long length, zend_long flags, zend_long type, zval *return_value);
 void pthreads_socket_write(zval *object, zend_string *buf, zend_long length, zval *return_value);
 void pthreads_socket_send(zval *object, zend_string *buf, zend_long length, zend_long flags, zval *return_value);
 void pthreads_socket_close(zval *object, zval *return_value);

--- a/tests/socket-ipv4loop.phpt
+++ b/tests/socket-ipv4loop.phpt
@@ -43,7 +43,7 @@ IPv4 Loopback test
 
     $client->write("ABCdef123\n");
 
-    $data = $socket->read(10, 0, \Socket::PHP_BINARY_READ);
+    $data = $socket->read(10, 0, \Socket::BINARY_READ);
     var_dump($data);
 
     $client->close();

--- a/tests/socket-ipv4loop.phpt
+++ b/tests/socket-ipv4loop.phpt
@@ -8,12 +8,16 @@ IPv4 Loopback test
         die('Unable to create AF_INET socket [server]');
     }
     $bound = false;
+
     for($port = 31337; $port < 31357; ++$port) {
-        if ($server->bind('127.0.0.1', $port)) {
-            $bound = true;
-            break;
-        }
+        try {
+            if ($server->bind('127.0.0.1', $port)) {
+                $bound = true;
+                break;
+            }
+        } catch (RuntimeException $re) {}
     }
+	    
     if (!$bound) {
         die("Unable to bind to 127.0.0.1");
     }

--- a/tests/socket-ipv4loop.phpt
+++ b/tests/socket-ipv4loop.phpt
@@ -1,0 +1,51 @@
+--TEST--
+IPv4 Loopback test
+--FILE--
+<?php
+	/* Setup socket server */
+    $server = new Socket(\Socket::AF_INET, \Socket::SOCK_STREAM, getprotobyname('tcp'));
+    if (!$server) {
+        die('Unable to create AF_INET socket [server]');
+    }
+    $bound = false;
+    for($port = 31337; $port < 31357; ++$port) {
+        if ($server->bind('127.0.0.1', $port)) {
+            $bound = true;
+            break;
+        }
+    }
+    if (!$bound) {
+        die("Unable to bind to 127.0.0.1");
+    }
+    if (!$server->listen(2)) {
+        die('Unable to listen on socket');
+    }
+
+    /* Connect to it */
+    $client = new Socket(\Socket::AF_INET, \Socket::SOCK_STREAM, getprotobyname('tcp'));
+    if (!$client) {
+        die('Unable to create AF_INET socket [client]');
+    }
+    if (!$client->connect('127.0.0.1', $port)) {
+        die('Unable to connect to server socket');
+    }
+
+    /* Accept that connection */
+    /** @var Socket $socket */
+    $socket = $server->accept(\Socket::class);
+    if (!$socket) {
+        die('Unable to accept connection');
+    }
+
+    $client->write("ABCdef123\n");
+
+    $data = $socket->read(10, 0, \Socket::PHP_BINARY_READ);
+    var_dump($data);
+
+    $client->close();
+    $socket->close();
+    $server->close();
+?>
+--EXPECT--
+string(10) "ABCdef123
+"

--- a/tests/socket-ipv6loop.phpt
+++ b/tests/socket-ipv6loop.phpt
@@ -1,0 +1,55 @@
+--TEST--
+IPv6 Loopback test
+--SKIPIF--
+<?php
+	require 'ipv6_skipif.inc';
+?>
+--FILE--
+<?php
+	/* Setup socket server */
+    $server = new Socket(\Socket::AF_INET6, \Socket::SOCK_STREAM, getprotobyname('tcp'));
+    if (!$server) {
+        die('Unable to create AF_INET6 socket [server]');
+    }
+    $bound = false;
+    for($port = 31337; $port < 31357; ++$port) {
+        if ($server->bind('::1', $port)) {
+            $bound = true;
+            break;
+        }
+    }
+    if (!$bound) {
+        die("Unable to bind to ['::1']:$port");
+    }
+    if (!$server->listen(2)) {
+        die('Unable to listen on socket');
+    }
+
+    /* Connect to it */
+    $client = new Socket(\Socket::AF_INET6, \Socket::SOCK_STREAM, getprotobyname('tcp'));
+    if (!$client) {
+        die('Unable to create AF_INET6 socket [client]');
+    }
+    if (!$client->connect('::1', $port)) {
+        die('Unable to connect to server socket');
+    }
+
+    /* Accept that connection */
+    /** @var Socket $socket */
+    $socket = $server->accept(\Socket::class);
+    if (!$socket) {
+        die('Unable to accept connection');
+    }
+
+    $client->write("ABCdef123\n");
+
+    $data = $socket->read(10, 0, \Socket::PHP_BINARY_READ);
+    var_dump($data);
+
+    $client->close();
+    $socket->close();
+    $server->close();
+?>
+--EXPECT--
+string(10) "ABCdef123
+"

--- a/tests/socket-ipv6loop.phpt
+++ b/tests/socket-ipv6loop.phpt
@@ -15,7 +15,7 @@ IPv6 Loopback test
 
     for($port = 31337; $port < 31357; ++$port) {
         try {
-            if ($server->bind('127.0.0.1', $port)) {
+            if ($server->bind('::1', $port)) {
                 $bound = true;
                 break;
             }
@@ -47,7 +47,7 @@ IPv6 Loopback test
 
     $client->write("ABCdef123\n");
 
-    $data = $socket->read(10, 0, \Socket::PHP_BINARY_READ);
+    $data = $socket->read(10, 0, \Socket::BINARY_READ);
     var_dump($data);
 
     $client->close();

--- a/tests/socket-ipv6loop.phpt
+++ b/tests/socket-ipv6loop.phpt
@@ -12,12 +12,16 @@ IPv6 Loopback test
         die('Unable to create AF_INET6 socket [server]');
     }
     $bound = false;
+
     for($port = 31337; $port < 31357; ++$port) {
-        if ($server->bind('::1', $port)) {
-            $bound = true;
-            break;
-        }
+        try {
+            if ($server->bind('127.0.0.1', $port)) {
+                $bound = true;
+                break;
+            }
+        } catch (RuntimeException $re) {}
     }
+    
     if (!$bound) {
         die("Unable to bind to ['::1']:$port");
     }

--- a/tests/socket-read-type.phpt
+++ b/tests/socket-read-type.phpt
@@ -8,12 +8,16 @@ Test of Socket::read() - testing type \Socket::PHP_NORMAL_READ and \Socket::PHP_
         die('Unable to create AF_INET socket [server]');
     }
     $bound = false;
+
     for($port = 31337; $port < 31357; ++$port) {
-        if ($server->bind('127.0.0.1', $port)) {
-            $bound = true;
-            break;
-        }
+        try {
+            if ($server->bind('127.0.0.1', $port)) {
+                $bound = true;
+                break;
+            }
+        } catch (RuntimeException $re) {}
     }
+    
     if (!$bound) {
         die("Unable to bind to 127.0.0.1");
     }

--- a/tests/socket-read-type.phpt
+++ b/tests/socket-read-type.phpt
@@ -1,0 +1,63 @@
+--TEST--
+Test of Socket::read() - testing type \Socket::PHP_NORMAL_READ and \Socket::PHP_BINARY_READ
+--FILE--
+<?php
+	/* Setup socket server */
+    $server = new Socket(\Socket::AF_INET, \Socket::SOCK_STREAM, getprotobyname('tcp'));
+    if (!$server) {
+        die('Unable to create AF_INET socket [server]');
+    }
+    $bound = false;
+    for($port = 31337; $port < 31357; ++$port) {
+        if ($server->bind('127.0.0.1', $port)) {
+            $bound = true;
+            break;
+        }
+    }
+    if (!$bound) {
+        die("Unable to bind to 127.0.0.1");
+    }
+    if (!$server->listen(2)) {
+        die('Unable to listen on socket');
+    }
+
+    /* Connect to it */
+    $client = new Socket(\Socket::AF_INET, \Socket::SOCK_STREAM, getprotobyname('tcp'));
+    if (!$client) {
+        die('Unable to create AF_INET socket [client]');
+    }
+    if (!$client->connect('127.0.0.1', $port)) {
+        die('Unable to connect to server socket');
+    }
+
+    /* Accept that connection */
+    /** @var Socket $socket */
+    $socket = $server->accept(\Socket::class);
+    if (!$socket) {
+        die('Unable to accept connection');
+    }
+
+    $client->write("ABCdef123\n456789");
+
+    $data = $socket->read(20, 0, \Socket::PHP_BINARY_READ);
+    var_dump($data);
+
+    $client->write("ABCdef123\n456789\n");
+
+    $data = $socket->read(20, 0, \Socket::PHP_NORMAL_READ);
+    var_dump($data);
+
+    $data = $socket->read(20, 0, \Socket::PHP_NORMAL_READ);
+    var_dump($data);
+
+    $client->close();
+    $socket->close();
+    $server->close();
+?>
+--EXPECT--
+string(16) "ABCdef123
+456789"
+string(10) "ABCdef123
+"
+string(7) "456789
+"

--- a/tests/socket-read-type.phpt
+++ b/tests/socket-read-type.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Test of Socket::read() - testing type \Socket::PHP_NORMAL_READ and \Socket::PHP_BINARY_READ
+Test of Socket::read() - testing type \Socket::NORMAL_READ and \Socket::BINARY_READ
 --FILE--
 <?php
 	/* Setup socket server */
@@ -43,15 +43,15 @@ Test of Socket::read() - testing type \Socket::PHP_NORMAL_READ and \Socket::PHP_
 
     $client->write("ABCdef123\n456789");
 
-    $data = $socket->read(20, 0, \Socket::PHP_BINARY_READ);
+    $data = $socket->read(20, 0, \Socket::BINARY_READ);
     var_dump($data);
 
     $client->write("ABCdef123\n456789\n");
 
-    $data = $socket->read(20, 0, \Socket::PHP_NORMAL_READ);
+    $data = $socket->read(20, 0, \Socket::NORMAL_READ);
     var_dump($data);
 
-    $data = $socket->read(20, 0, \Socket::PHP_NORMAL_READ);
+    $data = $socket->read(20, 0, \Socket::NORMAL_READ);
     var_dump($data);
 
     $client->close();

--- a/tests/socket-unixloop.phpt
+++ b/tests/socket-unixloop.phpt
@@ -43,7 +43,7 @@ if (substr(PHP_OS, 0, 3) == 'WIN') {
 
     $client->write("ABCdef123\n");
 
-    $data = $socket->read(10, 0, \Socket::PHP_BINARY_READ);
+    $data = $socket->read(10, 0, \Socket::BINARY_READ);
     var_dump($data);
 
     $client->close();

--- a/tests/socket-unixloop.phpt
+++ b/tests/socket-unixloop.phpt
@@ -1,0 +1,56 @@
+--TEST--
+Unix domain socket Loopback test
+--SKIPIF--
+<?php
+if (substr(PHP_OS, 0, 3) == 'WIN') {
+	die('skip.. Not valid for Windows');
+}
+?>
+--FILE--
+<?php
+	$sock_path = sprintf("/tmp/%s.sock", uniqid());
+
+    if (file_exists($sock_path))
+        die('Temporary socket already exists.');
+
+    /* Setup socket server */
+    $server = new Socket(\Socket::AF_UNIX, \Socket::SOCK_STREAM, 0);
+    if (!$server) {
+        die('Unable to create AF_UNIX socket [server]');
+    }
+    if (!$server->bind($sock_path)) {
+        die("Unable to bind to $sock_path");
+    }
+    if (!$server->listen(2)) {
+        die('Unable to listen on socket');
+    }
+
+    /* Connect to it */
+    $client = new Socket(\Socket::AF_UNIX, \Socket::SOCK_STREAM, 0);
+    if (!$client) {
+        die('Unable to create AF_UNIX socket [client]');
+    }
+    if (!$client->connect($sock_path)) {
+        die('Unable to connect to server socket');
+    }
+
+    /* Accept that connection */
+    /** @var Socket $socket */
+    $socket = $server->accept(\Socket::class);
+    if (!$socket) {
+        die('Unable to accept connection');
+    }
+
+    $client->write("ABCdef123\n");
+
+    $data = $socket->read(10, 0, \Socket::PHP_BINARY_READ);
+    var_dump($data);
+
+    $client->close();
+    $socket->close();
+    $server->close();
+    @unlink($sock_path);
+?>
+--EXPECT--
+string(10) "ABCdef123
+"


### PR DESCRIPTION
This PR adds `$type` to Socket::read() and the both constants `Socket::PHP_NORMAL_READ` as well as `Socket::PHP_BINARY_READ` to mimic php-src Sockets API. Four more tests were added.