### PR TITLE
Rework of Socket::connect

### DIFF
--- a/classes/socket.h
+++ b/classes/socket.h
@@ -69,7 +69,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(Socket_listen, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, backlog, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(Socket_connect, 0, 2, _IS_BOOL, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(Socket_connect, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, host, IS_STRING, 0)
 	ZEND_ARG_TYPE_INFO(0, port, IS_LONG, 0)
 ZEND_END_ARG_INFO()
@@ -236,16 +236,17 @@ PHP_METHOD(Socket, accept) {
 	pthreads_socket_accept(getThis(), ce, return_value);
 } /* }}} */
 
-/* {{{ proto bool Socket::connect(string host, int port) */
+/* {{{ proto bool Socket::connect(string host[, int port]) */
 PHP_METHOD(Socket, connect) {
 	zend_string *host = NULL;
 	zend_long port = 0;
+	int argc = ZEND_NUM_ARGS();
 
-	if (zend_parse_parameters(ZEND_NUM_ARGS(), "Sl", &host, &port) != SUCCESS) {
-		return;
+	if (zend_parse_parameters(argc, "S|l", &host, &port) != SUCCESS) {
+		RETURN_FALSE;
 	}
 
-	pthreads_socket_connect(getThis(), host, port, return_value);
+	pthreads_socket_connect(getThis(), argc, host, port, return_value);
 } /* }}} */
 
 /* {{{ proto int|bool Socket::select(array &read, array &write, array &except [, int sec = 0 [, int usec = 0 [, int &error]]]) */

--- a/examples/stub.php
+++ b/examples/stub.php
@@ -676,7 +676,7 @@ class Socket extends \Threaded
 
 	public function accept($class = self::class){}
 
-	public function connect(string $host, int $port) : bool{}
+	public function connect(string $host, int $port = 0) : bool{}
 
 	public static function select(array &$read, array &$write, array &$except, int $sec = 0, int $usec = 0, int &$error = null){}
 

--- a/src/socket.c
+++ b/src/socket.c
@@ -357,7 +357,7 @@ void pthreads_socket_accept(zval *object, zend_class_entry *ce, zval *return_val
 	accepted->store.sock->domain = ((struct sockaddr*) &sa)->sa_family;
 }
 
-void pthreads_socket_connect(zval *object, zend_string *address, zend_long port, zval *return_value) {
+void pthreads_socket_connect(zval *object, int argc, zend_string *address, zend_long port, zval *return_value) {
 	pthreads_object_t *threaded =
 		PTHREADS_FETCH_FROM(Z_OBJ_P(object));
 
@@ -367,6 +367,11 @@ void pthreads_socket_connect(zval *object, zend_string *address, zend_long port,
 #if HAVE_IPV6
 		case AF_INET6: {
 			struct sockaddr_in6 sin6 = {0};
+
+			if (argc != 2) {
+				zend_throw_exception_ex(spl_ce_RuntimeException, 0, "Socket of type AF_INET6 requires 2 arguments");
+				return;
+			}
 
 			memset(&sin6, 0, sizeof(struct sockaddr_in6));
 
@@ -392,6 +397,11 @@ void pthreads_socket_connect(zval *object, zend_string *address, zend_long port,
 		case AF_INET: {
 			struct sockaddr_in sin = {0};
 
+			if (argc != 2) {
+				zend_throw_exception_ex(spl_ce_RuntimeException, 0, "Socket of type AF_INET requires 2 arguments");
+				return;
+			}
+
 			sin.sin_family = AF_INET;
 			sin.sin_port   = htons((unsigned short int)port);
 			
@@ -415,7 +425,7 @@ void pthreads_socket_connect(zval *object, zend_string *address, zend_long port,
 			struct sockaddr_un s_un = {0};
 
 			if (ZSTR_LEN(address) >= sizeof(s_un.sun_path)) {
-				/* throw */
+				zend_throw_exception_ex(spl_ce_RuntimeException, 0, "Path too long");
 				return;
 			}
 

--- a/src/socket.h
+++ b/src/socket.h
@@ -38,7 +38,7 @@ void pthreads_socket_get_option(zval *object, zend_long level, zend_long name, z
 void pthreads_socket_bind(zval *object, zend_string *address, zend_long port, zval *return_value);
 void pthreads_socket_listen(zval *object, zend_long backlog, zval *return_value);
 void pthreads_socket_accept(zval *object, zend_class_entry *ce, zval *return_value);
-void pthreads_socket_connect(zval *object, zend_string *address, zend_long port, zval *return_value);
+void pthreads_socket_connect(zval *object, int argc, zend_string *address, zend_long port, zval *return_value);
 void pthreads_socket_read(zval *object, zend_long length, zend_long flags, zval *return_value);
 void pthreads_socket_write(zval *object, zend_string *buf, zend_long length, zval *return_value);
 void pthreads_socket_send(zval *object, zend_string *buf, zend_long length, zend_long flags, zval *return_value);

--- a/tests/socket-connect-params-af-inet.phpt
+++ b/tests/socket-connect-params-af-inet.phpt
@@ -1,0 +1,21 @@
+--TEST--
+Socket::connect() - AF_INET - test with empty parameters
+--FILE--
+<?php
+    $rand = rand(1,999);
+    $socket = new \Socket(\Socket::AF_INET, \Socket::SOCK_DGRAM, 0);
+    $socket->bind('0.0.0.0');
+    // wrong parameter count
+    $socket->connect();
+    try {
+        $socket->connect('0.0.0.0');
+    } catch(Exception $exception) {
+        var_dump($exception->getMessage());
+    }
+    $socket->connect('127.0.0.1', 31330+$rand);
+    $socket->close();
+?>
+--EXPECTF--
+
+Warning: Socket::connect() expects at least 1 parameter, 0 given in %s on line %i
+string(43) "Socket of type AF_INET requires 2 arguments"

--- a/tests/socket-connect-params-af-unix.phpt
+++ b/tests/socket-connect-params-af-unix.phpt
@@ -1,0 +1,32 @@
+--TEST--
+Socket::connect() - AF_UNIX - test with empty parameters
+--SKIPIF--
+<?php
+if (substr(PHP_OS, 0, 3) == 'WIN') {
+	die('skip.. Not valid for Windows');
+}
+--FILE--
+<?php
+    $rand = rand(1,999);
+    $socket = new \Socket(\Socket::AF_UNIX,\Socket::SOCK_DGRAM, 0);
+
+    if (!$socket->setBlocking(false)) {
+        die('Unable to set nonblocking mode for socket');
+    }
+    $address = sprintf("/tmp/%s.sock", uniqid());
+
+    if (file_exists($address))
+        die('Temporary file socket already exists.');
+
+    if (!$socket->bind($address)) {
+        die("Unable to bind to $address");
+    }
+    $socket->connect();
+    $socket->connect($address);
+    $socket->connect($address, 31330+$rand);
+
+    $socket->close();
+?>
+--EXPECTF--
+
+Warning: Socket::connect() expects at least 1 parameter, 0 given in %s on line %i


### PR DESCRIPTION
- Parameter `port` can be optional on AF_UNIX sockets
- Added some tests
