### PR TITLE
Fixed some issues with stub method signatures

### DIFF
--- a/examples/stub.php
+++ b/examples/stub.php
@@ -3,7 +3,7 @@
  * pthreads extension stub file for code completion purposes
  *
  * @author Lisachenko Alexander <lisachenko.it@gmail.com>
- * @version 2.0.0
+ * @version 3.0.0
  */
 
 /**
@@ -74,11 +74,12 @@ class Threaded implements Traversable, Countable, ArrayAccess, Collectable
      * Fetches a chunk of the objects properties table of the given size
      *
      * @param int $size The number of items to fetch
+     * @param bool $preserve Preserve the keys of members
      *
      * @link http://www.php.net/manual/en/threaded.chunk.php
      * @return array An array of items from the objects member table
      */
-    public function chunk($size) {}
+    public function chunk($size, $preserve = false) {}
 
     /**
      * {@inheritdoc}
@@ -110,7 +111,7 @@ class Threaded implements Traversable, Countable, ArrayAccess, Collectable
      *
      * @return bool(true) The referenced object can be destroyed
      */
-    public function isGarbage() {}
+    public function isGarbage() : bool{}
 
     /**
      * Tell if the referenced object is executing
@@ -132,7 +133,7 @@ class Threaded implements Traversable, Countable, ArrayAccess, Collectable
      * Merges data into the current object
      *
      * @param mixed $from The data to merge
-     * @param bool $overwrite Overwrite existing keys flag, by default true
+     * @param bool $overwrite Overwrite existing keys flag
      *
      * @link http://www.php.net/manual/en/threaded.merge.php
      * @return bool A boolean indication of success
@@ -207,7 +208,7 @@ class Threaded implements Traversable, Countable, ArrayAccess, Collectable
      * @link http://www.php.net/manual/en/threaded.synchronized.php
      * @return mixed The return value from the block
      */
-    public function synchronized(\Closure $function, $args = null) {}
+    public function synchronized(\Closure $function, ...$args) {}
 
     /**
      * Waits for notification from the Stackable
@@ -217,7 +218,7 @@ class Threaded implements Traversable, Countable, ArrayAccess, Collectable
      * @link http://www.php.net/manual/en/threaded.wait.php
      * @return bool A boolean indication of success
      */
-    public function wait($timeout = 0) {}
+    public function wait(int $timeout = 0) {}
 }
 
 /**
@@ -243,7 +244,6 @@ class Volatile extends Threaded{
  */
 class Thread extends Threaded
 {
-
     /**
      * Will return the identity of the Thread that created the referenced Thread
      *
@@ -307,7 +307,7 @@ class Thread extends Threaded
      * @link http://www.php.net/manual/en/thread.start.php
      * @return bool A boolean indication of success
      */
-    public function start($options = PTHREADS_INHERIT_ALL) {}
+    public function start(int $options = PTHREADS_INHERIT_ALL) {}
 }
 
 /**
@@ -327,22 +327,21 @@ class Thread extends Threaded
  */
 class Worker extends Thread
 {
-
     /**
      * Executes the optional collector on each of the tasks, removing the task if true is returned
      *
-     * @param callable $collector The collector to be executed upon each task
+     * @param callable $function The collector to be executed upon each task
      * @return int The number of tasks left to be collected
      */
-    public function collect($collector = null) {}
+    public function collect(callable $function = null) {}
 
     /**
      * Executes the collector on the collectable object passed
      *
-     * @param callable $collectable The collectable object to run the collector on
+     * @param Collectable $collectable The collectable object to run the collector on
      * @return bool The referenced object can be destroyed
      */
-    public function collector($collectable) {}
+    public function collector(Collectable $collectable) {}
 
     /**
      * Returns the number of threaded tasks waiting to be executed by the referenced Worker
@@ -376,17 +375,15 @@ class Worker extends Thread
      * @link http://www.php.net/manual/en/worker.stack.php
      * @return int The new length of the stack
      */
-    public function stack(Threaded &$work) {}
+    public function stack(Threaded $work) {}
 
     /**
-     * Removes the referenced object ( or all objects if parameter is null ) from stack of the referenced Worker
-     *
-     * @param Threaded $work Threaded object previously stacked onto Worker
+     * Removes the first task (the oldest one) in the stack.
      *
      * @link http://www.php.net/manual/en/worker.unstack.php
-     * @return int The new length of the stack
+     * @return Collectable|null The item removed from the stack
      */
-    public function unstack(Threaded &$work = null) {}
+    public function unstack() {}
 }
 
 /**
@@ -444,14 +441,7 @@ class Pool
      *
      * @link http://www.php.net/manual/en/pool.__construct.php
      */
-    public function __construct($size, $class, array $ctor = array()) {}
-
-    /**
-     * Shuts down all Workers, and collect all Stackables, finally destroys the Pool
-     *
-     * @link http://www.php.net/manual/en/pool.__destruct.php
-     */
-    public function __destruct() {}
+    public function __construct(int $size, string $class = Worker::class, array $ctor = array()) {}
 
     /**
      * Collect references to completed tasks
@@ -471,7 +461,7 @@ class Pool
      *
      * @link http://www.php.net/manual/en/pool.resize.php
      */
-    public function resize($size) {}
+    public function resize(int $size) {}
 
     /**
      * Shutdown all Workers in this Pool
@@ -497,7 +487,7 @@ class Pool
      *
      * @return int the identifier of the Worker that accepted the object
      */
-    public function submitTo($worker, Threaded $task) {}
+    public function submitTo(int $worker, Threaded $task) {}
 }
 
 /**

--- a/examples/stub.php
+++ b/examples/stub.php
@@ -499,196 +499,196 @@ class Pool
  */
 interface Collectable
 {
-	/**
-	 * Determine whether an object is ready to be destroyed
-	 *
-	 * @return bool Whether the referenced object can be destroyed
-	 */
-	public function isGarbage() : bool;
+    /**
+     * Determine whether an object is ready to be destroyed
+     *
+     * @return bool Whether the referenced object can be destroyed
+     */
+    public function isGarbage() : bool;
 }
 
 class Socket extends \Threaded
 {
-	public const AF_UNIX = 1;
-	public const AF_INET = 2;
-	public const AF_INET6 = 10;
-	public const SOCK_STREAM = 1;
-	public const SOCK_DGRAM = 2;
-	public const SOCK_RAW = 3;
-	public const SOCK_SEQPACKET = 5;
-	public const SOCK_RDM = 4;
-	public const SO_DEBUG = 1;
-	public const SO_REUSEADDR = 2;
-	public const SO_REUSEPORT = 15;
-	public const SO_KEEPALIVE = 9;
-	public const SO_DONTROUTE = 5;
-	public const SO_LINGER = 13;
-	public const SO_BROADCAST = 6;
-	public const SO_OOBINLINE = 10;
-	public const SO_SNDBUF = 7;
-	public const SO_RCVBUF = 8;
-	public const SO_SNDLOWAT = 19;
-	public const SO_RCVLOWAT = 18;
-	public const SO_SNDTIMEO = 21;
-	public const SO_RCVTIMEO = 20;
-	public const SO_TYPE = 3;
-	public const SO_ERROR = 4;
-	public const SO_BINDTODEVICE = 25;
-	public const SOMAXCONN = 128;
-	public const TCP_NODELAY = 1;
-	public const SOL_SOCKET = 1;
-	public const SOL_TCP = 6;
-	public const SOL_UDP = 17;
-	public const MSG_OOB = 1;
-	public const MSG_WAITALL = 256;
-	public const MSG_CTRUNC = 8;
-	public const MSG_TRUNC = 32;
-	public const MSG_PEEK = 2;
-	public const MSG_DONTROUTE = 4;
-	public const MSG_EOR = 128;
-	public const MSG_CONFIRM = 2048;
-	public const MSG_ERRQUEUE = 8192;
-	public const MSG_NOSIGNAL = 16384;
-	public const MSG_MORE = 32768;
-	public const MSG_WAITFORONE = 65536;
-	public const MSG_CMSG_CLOEXEC = 1073741824;
-	public const EPERM = 1;
-	public const ENOENT = 2;
-	public const EINTR = 4;
-	public const EIO = 5;
-	public const ENXIO = 6;
-	public const E2BIG = 7;
-	public const EBADF = 9;
-	public const EAGAIN = 11;
-	public const ENOMEM = 12;
-	public const EACCES = 13;
-	public const EFAULT = 14;
-	public const ENOTBLK = 15;
-	public const EBUSY = 16;
-	public const EEXIST = 17;
-	public const EXDEV = 18;
-	public const ENODEV = 19;
-	public const ENOTDIR = 20;
-	public const EISDIR = 21;
-	public const EINVAL = 22;
-	public const ENFILE = 23;
-	public const EMFILE = 24;
-	public const ENOTTY = 25;
-	public const ENOSPC = 28;
-	public const ESPIPE = 29;
-	public const EROFS = 30;
-	public const EMLINK = 31;
-	public const EPIPE = 32;
-	public const ENAMETOOLONG = 36;
-	public const ENOLCK = 37;
-	public const ENOSYS = 38;
-	public const ENOTEMPTY = 39;
-	public const ELOOP = 40;
-	public const EWOULDBLOCK = 11;
-	public const ENOMSG = 42;
-	public const EIDRM = 43;
-	public const ECHRNG = 44;
-	public const EL2NSYNC = 45;
-	public const EL3HLT = 46;
-	public const EL3RST = 47;
-	public const ELNRNG = 48;
-	public const EUNATCH = 49;
-	public const ENOCSI = 50;
-	public const EL2HLT = 51;
-	public const EBADE = 52;
-	public const EBADR = 53;
-	public const EXFULL = 54;
-	public const ENOANO = 55;
-	public const EBADRQC = 56;
-	public const EBADSLT = 57;
-	public const ENOSTR = 60;
-	public const ENODATA = 61;
-	public const ETIME = 62;
-	public const ENOSR = 63;
-	public const ENONET = 64;
-	public const EREMOTE = 66;
-	public const ENOLINK = 67;
-	public const EADV = 68;
-	public const ESRMNT = 69;
-	public const ECOMM = 70;
-	public const EPROTO = 71;
-	public const EMULTIHOP = 72;
-	public const EBADMSG = 74;
-	public const ENOTUNIQ = 76;
-	public const EBADFD = 77;
-	public const EREMCHG = 78;
-	public const ERESTART = 85;
-	public const ESTRPIPE = 86;
-	public const EUSERS = 87;
-	public const ENOTSOCK = 88;
-	public const EDESTADDRREQ = 89;
-	public const EMSGSIZE = 90;
-	public const EPROTOTYPE = 91;
-	public const ENOPROTOOPT = 92;
-	public const EPROTONOSUPPORT = 93;
-	public const ESOCKTNOSUPPORT = 94;
-	public const EOPNOTSUPP = 95;
-	public const EPFNOSUPPORT = 96;
-	public const EAFNOSUPPORT = 97;
-	public const EADDRINUSE = 98;
-	public const EADDRNOTAVAIL = 99;
-	public const ENETDOWN = 100;
-	public const ENETUNREACH = 101;
-	public const ENETRESET = 102;
-	public const ECONNABORTED = 103;
-	public const ECONNRESET = 104;
-	public const ENOBUFS = 105;
-	public const EISCONN = 106;
-	public const ENOTCONN = 107;
-	public const ESHUTDOWN = 108;
-	public const ETOOMANYREFS = 109;
-	public const ETIMEDOUT = 110;
-	public const ECONNREFUSED = 111;
-	public const EHOSTDOWN = 112;
-	public const EHOSTUNREACH = 113;
-	public const EALREADY = 114;
-	public const EINPROGRESS = 115;
-	public const EISNAM = 120;
-	public const EREMOTEIO = 121;
-	public const EDQUOT = 122;
-	public const ENOMEDIUM = 123;
-	public const EMEDIUMTYPE = 124;
+    public const AF_UNIX = 1;
+    public const AF_INET = 2;
+    public const AF_INET6 = 10;
+    public const SOCK_STREAM = 1;
+    public const SOCK_DGRAM = 2;
+    public const SOCK_RAW = 3;
+    public const SOCK_SEQPACKET = 5;
+    public const SOCK_RDM = 4;
+    public const SO_DEBUG = 1;
+    public const SO_REUSEADDR = 2;
+    public const SO_REUSEPORT = 15;
+    public const SO_KEEPALIVE = 9;
+    public const SO_DONTROUTE = 5;
+    public const SO_LINGER = 13;
+    public const SO_BROADCAST = 6;
+    public const SO_OOBINLINE = 10;
+    public const SO_SNDBUF = 7;
+    public const SO_RCVBUF = 8;
+    public const SO_SNDLOWAT = 19;
+    public const SO_RCVLOWAT = 18;
+    public const SO_SNDTIMEO = 21;
+    public const SO_RCVTIMEO = 20;
+    public const SO_TYPE = 3;
+    public const SO_ERROR = 4;
+    public const SO_BINDTODEVICE = 25;
+    public const SOMAXCONN = 128;
+    public const TCP_NODELAY = 1;
+    public const SOL_SOCKET = 1;
+    public const SOL_TCP = 6;
+    public const SOL_UDP = 17;
+    public const MSG_OOB = 1;
+    public const MSG_WAITALL = 256;
+    public const MSG_CTRUNC = 8;
+    public const MSG_TRUNC = 32;
+    public const MSG_PEEK = 2;
+    public const MSG_DONTROUTE = 4;
+    public const MSG_EOR = 128;
+    public const MSG_CONFIRM = 2048;
+    public const MSG_ERRQUEUE = 8192;
+    public const MSG_NOSIGNAL = 16384;
+    public const MSG_MORE = 32768;
+    public const MSG_WAITFORONE = 65536;
+    public const MSG_CMSG_CLOEXEC = 1073741824;
+    public const EPERM = 1;
+    public const ENOENT = 2;
+    public const EINTR = 4;
+    public const EIO = 5;
+    public const ENXIO = 6;
+    public const E2BIG = 7;
+    public const EBADF = 9;
+    public const EAGAIN = 11;
+    public const ENOMEM = 12;
+    public const EACCES = 13;
+    public const EFAULT = 14;
+    public const ENOTBLK = 15;
+    public const EBUSY = 16;
+    public const EEXIST = 17;
+    public const EXDEV = 18;
+    public const ENODEV = 19;
+    public const ENOTDIR = 20;
+    public const EISDIR = 21;
+    public const EINVAL = 22;
+    public const ENFILE = 23;
+    public const EMFILE = 24;
+    public const ENOTTY = 25;
+    public const ENOSPC = 28;
+    public const ESPIPE = 29;
+    public const EROFS = 30;
+    public const EMLINK = 31;
+    public const EPIPE = 32;
+    public const ENAMETOOLONG = 36;
+    public const ENOLCK = 37;
+    public const ENOSYS = 38;
+    public const ENOTEMPTY = 39;
+    public const ELOOP = 40;
+    public const EWOULDBLOCK = 11;
+    public const ENOMSG = 42;
+    public const EIDRM = 43;
+    public const ECHRNG = 44;
+    public const EL2NSYNC = 45;
+    public const EL3HLT = 46;
+    public const EL3RST = 47;
+    public const ELNRNG = 48;
+    public const EUNATCH = 49;
+    public const ENOCSI = 50;
+    public const EL2HLT = 51;
+    public const EBADE = 52;
+    public const EBADR = 53;
+    public const EXFULL = 54;
+    public const ENOANO = 55;
+    public const EBADRQC = 56;
+    public const EBADSLT = 57;
+    public const ENOSTR = 60;
+    public const ENODATA = 61;
+    public const ETIME = 62;
+    public const ENOSR = 63;
+    public const ENONET = 64;
+    public const EREMOTE = 66;
+    public const ENOLINK = 67;
+    public const EADV = 68;
+    public const ESRMNT = 69;
+    public const ECOMM = 70;
+    public const EPROTO = 71;
+    public const EMULTIHOP = 72;
+    public const EBADMSG = 74;
+    public const ENOTUNIQ = 76;
+    public const EBADFD = 77;
+    public const EREMCHG = 78;
+    public const ERESTART = 85;
+    public const ESTRPIPE = 86;
+    public const EUSERS = 87;
+    public const ENOTSOCK = 88;
+    public const EDESTADDRREQ = 89;
+    public const EMSGSIZE = 90;
+    public const EPROTOTYPE = 91;
+    public const ENOPROTOOPT = 92;
+    public const EPROTONOSUPPORT = 93;
+    public const ESOCKTNOSUPPORT = 94;
+    public const EOPNOTSUPP = 95;
+    public const EPFNOSUPPORT = 96;
+    public const EAFNOSUPPORT = 97;
+    public const EADDRINUSE = 98;
+    public const EADDRNOTAVAIL = 99;
+    public const ENETDOWN = 100;
+    public const ENETUNREACH = 101;
+    public const ENETRESET = 102;
+    public const ECONNABORTED = 103;
+    public const ECONNRESET = 104;
+    public const ENOBUFS = 105;
+    public const EISCONN = 106;
+    public const ENOTCONN = 107;
+    public const ESHUTDOWN = 108;
+    public const ETOOMANYREFS = 109;
+    public const ETIMEDOUT = 110;
+    public const ECONNREFUSED = 111;
+    public const EHOSTDOWN = 112;
+    public const EHOSTUNREACH = 113;
+    public const EALREADY = 114;
+    public const EINPROGRESS = 115;
+    public const EISNAM = 120;
+    public const EREMOTEIO = 121;
+    public const EDQUOT = 122;
+    public const ENOMEDIUM = 123;
+    public const EMEDIUMTYPE = 124;
 
-	public function __construct(int $domain, int $type, int $protocol){}
+    public function __construct(int $domain, int $type, int $protocol){}
 
-	public function setOption(int $level, int $name, int $value) : bool{}
+    public function setOption(int $level, int $name, int $value) : bool{}
 
-	public function getOption(int $level, int $name) : int{}
+    public function getOption(int $level, int $name) : int{}
 
-	public function bind(string $host, int $port = 0) : bool{}
+    public function bind(string $host, int $port = 0) : bool{}
 
-	public function listen(int $backlog) : bool{}
+    public function listen(int $backlog) : bool{}
 
-	public function accept($class = self::class){}
+    public function accept($class = self::class){}
 
-	public function connect(string $host, int $port = 0) : bool{}
+    public function connect(string $host, int $port = 0) : bool{}
 
-	public static function select(array &$read, array &$write, array &$except, int $sec = 0, int $usec = 0, int &$error = null){}
+    public static function select(array &$read, array &$write, array &$except, int $sec = 0, int $usec = 0, int &$error = null){}
 
-	public function read(int $length, int $flags = 0){}
+    public function read(int $length, int $flags = 0){}
 
-	public function write(string $buffer, int $length = 0){}
+    public function write(string $buffer, int $length = 0){}
 
-	public function send(string $buffer, int $length, int $flags){}
+    public function send(string $buffer, int $length, int $flags){}
 
-	public function recvfrom(string &$buffer, int $length, int $flags, string &$name, int &$port = null){}
+    public function recvfrom(string &$buffer, int $length, int $flags, string &$name, int &$port = null){}
 
-	public function sendto(string $buffer, int $length, int $flags, string $addr, int $port = 0){}
+    public function sendto(string $buffer, int $length, int $flags, string $addr, int $port = 0){}
 
-	public function setBlocking(bool $blocking) : bool{}
+    public function setBlocking(bool $blocking) : bool{}
 
-	public function getPeerName(bool $port = true) : array{}
+    public function getPeerName(bool $port = true) : array{}
 
-	public function getSockName(bool $port = true) : array{}
+    public function getSockName(bool $port = true) : array{}
 
-	public function close(){}
+    public function close(){}
 
-	public function getLastError(bool $clear = false){}
+    public function getLastError(bool $clear = false){}
 
-	public function clearError(){}
+    public function clearError(){}
 }


### PR DESCRIPTION
This updates the stub to match pthreads v3 properly, as per the arginfo of the extension. Some issues were discovered in the process (see #835 and #836), so method signatures have been adjusted to match the documentation where there are mismatches.

The formatting in this file is very inconsistent, I went to great pains to avoid reformatting it to avoid polluting the diff. If it's desirable to have a reformat in this PR, let me know, but please don't squash-merge. :)