### PR TITLE
New static method Socket::strerror()

### DIFF
--- a/classes/socket.h
+++ b/classes/socket.h
@@ -40,6 +40,7 @@ PHP_METHOD(Socket, getSockName);
 
 PHP_METHOD(Socket, getLastError);
 PHP_METHOD(Socket, clearError);
+PHP_METHOD(Socket, strerror);
 
 PHP_METHOD(Socket, close);
 
@@ -131,6 +132,10 @@ ZEND_BEGIN_ARG_INFO_EX(Socket_getLastError, 0, 0, 0)
 	ZEND_ARG_TYPE_INFO(0, clear, _IS_BOOL, 0)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(Socket_strerror, 0, 1, IS_STRING, 1)
+	ZEND_ARG_TYPE_INFO(0, error, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
 ZEND_BEGIN_ARG_INFO_EX(Socket_void, 0, 0, 0)
 ZEND_END_ARG_INFO()
 
@@ -158,6 +163,7 @@ zend_function_entry pthreads_socket_methods[] = {
 	PHP_ME(Socket, close, Socket_void, ZEND_ACC_PUBLIC)
 	PHP_ME(Socket, getLastError, Socket_getLastError, ZEND_ACC_PUBLIC)
 	PHP_ME(Socket, clearError, Socket_void, ZEND_ACC_PUBLIC)
+	PHP_ME(Socket, strerror, Socket_strerror, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
 	{NULL, NULL, NULL}
 };
 
@@ -378,6 +384,17 @@ PHP_METHOD(Socket, clearError) {
 	}
 
 	pthreads_socket_clear_error(getThis());
+} /* }}} */
+
+/* {{{ proto string|null Socket::strerror(int error) */
+PHP_METHOD(Socket, strerror) {
+	zend_long error = 0;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "l", &error) != SUCCESS) {
+		RETURN_NULL();
+	}
+
+	pthreads_socket_strerror(error, return_value);
 } /* }}} */
 
 /* {{{ proto bool Socket::close(void) */

--- a/examples/stub.php
+++ b/examples/stub.php
@@ -691,4 +691,6 @@ class Socket extends \Threaded
     public function getLastError(bool $clear = false){}
 
     public function clearError(){}
+
+    public static function strerror(int $error) : ?string{}
 }

--- a/src/socket.c
+++ b/src/socket.c
@@ -969,6 +969,15 @@ void pthreads_socket_get_last_error(zval *object, zend_bool clear, zval *return_
 	}
 }
 
+void pthreads_socket_strerror(zend_long error, zval *return_value) {
+	char *errstr;
+	errstr = php_socket_strerror(error, NULL, 0);
+
+	RETVAL_STRING(errstr);
+
+	efree(errstr);
+}
+
 void pthreads_socket_clear_error(zval *object) {
 	pthreads_object_t *threaded =
 		PTHREADS_FETCH_FROM(Z_OBJ_P(object));

--- a/src/socket.h
+++ b/src/socket.h
@@ -51,6 +51,7 @@ void pthreads_socket_free(pthreads_socket_t *socket, zend_bool closing);
 void pthreads_socket_recvfrom(zval *object, zval *buffer, zend_long len, zend_long flags, zval *name, zval *port, zval *return_value);
 void pthreads_socket_sendto(zval *object, int argc, zend_string *buf, zend_long len, zend_long flags, zend_string *addr, zend_long port, zval *return_value);
 void pthreads_socket_get_last_error(zval *object, zend_bool clear, zval *return_value);
+void pthreads_socket_strerror(zend_long error, zval *return_value);
 void pthreads_socket_clear_error(zval *object);
 
 #endif


### PR DESCRIPTION
Added missing method Socket::strerror(int $error):?string equal to php-src sockets API