### PR TITLE
Fixed leaking pthread_mutexattr_t on Windows, closes #822

### DIFF
--- a/src/monitor.c
+++ b/src/monitor.c
@@ -39,7 +39,9 @@ pthreads_monitor_t* pthreads_monitor_alloc() {
 #else
 	pthread_mutexattr_settype(&at, PTHREAD_MUTEX_RECURSIVE_NP);
 #endif
-	if (pthread_mutex_init(&m->mutex, &at) != 0) {
+	int ret = pthread_mutex_init(&m->mutex, &at);
+	pthread_mutexattr_destroy(&at);
+	if (ret != 0) {
 		free(m);
 		return NULL;
 	}


### PR DESCRIPTION
This bug occurs due to implementation differences in pthread-w32 vs other platforms. In glibc, [`pthread_mutexattr_destroy` is a no-op]( https://code.woboq.org/userspace/glibc/nptl/pthread_mutexattr_destroy.c.html#__pthread_mutexattr_destroy), so not calling it did no harm, but in pthread-w32 it [actually does something important](https://github.com/GerHobbelt/pthread-win32/blob/master/pthread_mutexattr_destroy.c#L47), i.e. freeing memory.

This bug was discovered using Visual Studio memory profiler. It may affect other platforms depending on the libc in use.

I haven't written tests for this because observing it from an automated standpoint to watch for leaks is tedious and takes a long time. However, this fix has been tested manually with the test script in #822 and is confirmed to fix the leak for Windows.