### PR TITLE
Fix AppVeyor crashing during build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ branches:
 image: Visual Studio 2017
 
 environment:
-  PHP_SDK_BINARY_TOOLS_VER: php-sdk-2.0.9
+  PHP_SDK_BINARY_TOOLS_VER: php-sdk-2.1.1
 
   matrix:
     - ARCH: x86


### PR DESCRIPTION
```
Fatal error: Uncaught SDK\Exception: Failed to fetch supported branches in C:\projects\php-sdk\lib\php\libsdk\SDK\Config.php:155
Stack trace:
#0 C:\projects\php-sdk\lib\php\libsdk\SDK\Config.php(165): SDK\Config::getKnownBranches()
#1 C:\projects\php-sdk\bin\phpsdk_deps.php(99): SDK\Config::setCurrentBranchName('7.2')
#2 {main}
  thrown in C:\projects\php-sdk\lib\php\libsdk\SDK\Config.php on line 155
Command exited with code 255
```
Newer SDK fixes this issue (I hit the same bug on my own projects this morning).