### PR TITLE
Guard against returning uninitialized variables in switch-cases

### DIFF
--- a/src/socket.c
+++ b/src/socket.c
@@ -418,6 +418,8 @@ void pthreads_socket_connect(zval *object, int argc, zend_string *address, zend_
 					(socklen_t)(XtOffsetOf(struct sockaddr_un, sun_path) + ZSTR_LEN(address)));
 		} break;
 #endif
+		default:
+			RETURN_FALSE;
 	}
 
 	if (retval != SUCCESS) {
@@ -956,6 +958,8 @@ void pthreads_socket_recvfrom(zval *object, zval *buffer, zend_long len, zend_lo
 			ZVAL_LONG(port, ntohs(sin6.sin6_port));
 		} break;
 #endif
+		default:
+			RETURN_FALSE;
 	}
 
 	RETURN_LONG(retval);
@@ -1015,6 +1019,8 @@ void pthreads_socket_sendto(zval *object, int argc, zend_string *buf, zend_long 
 			retval = sendto(threaded->store.sock->fd, ZSTR_VAL(buf), ((size_t)len > ZSTR_LEN(buf)) ? ZSTR_LEN(buf) : (size_t)len, flags, (struct sockaddr *) &sin6, sizeof(sin6));
 		} break;
 #endif
+		default:
+			RETURN_FALSE;
 	}
 
 	if (retval == -1) {


### PR DESCRIPTION
VS2017 code analysis complains about "Using uninitialized memory 'retval'". While these cases should theoretically never get hit, they shouldn't be returning uninitialized variables anyway.