### PR TITLE
Add test for crash when modifying static array after thread start

### DIFF
--- a/tests/statics-modify-copied-object-array.phpt
+++ b/tests/statics-modify-copied-object-array.phpt
@@ -1,0 +1,45 @@
+--TEST--
+Test static object arrays work correctly when modified after thread start
+--FILE--
+<?php
+
+class Test{
+	public static $array = [];
+
+	public static function init(int $i){
+		while(--$i > 0){
+			self::$array[] = new stdClass();
+		}
+	}
+}
+
+Test::init(3);
+
+$thread = new Worker;
+$thread->start(PTHREADS_INHERIT_CLASSES);
+
+var_dump(Test::$array);
+Test::$array = [];
+var_dump(Test::$array);
+
+echo "gc start\n";
+gc_collect_cycles();
+echo "gc end\n";
+$thread->shutdown();
+echo "script end\n";
+
+?>
+--EXPECTF--
+array(2) {
+  [0]=>
+  object(stdClass)#1 (0) {
+  }
+  [1]=>
+  object(stdClass)#2 (0) {
+  }
+}
+array(0) {
+}
+gc start
+gc end
+script end


### PR DESCRIPTION
I haven't been able to find the root cause of this issue yet, but it stems from pthreads' handling of copied static arrays.
When pthreads copies a static array, modifying the array on the parent thread triggers heap corruption and other nasties for reasons I am yet to fully understand.

The test case in the PR demonstrates the bug. It needs to be noted that:
- the crash does not occur unless the `PTHREADS_INHERIT_CLASSES` flag is enabled (hence, it is to do with the way static arrays are being handled)
- the crash occurs in GC when removing members of the array (`Test::$array = [];` works, also `unset(Test::$array[0]);`)
- the crash only appears to occur if `Test::$array` is modified while the thread is running (hence the use of a `Worker` to demonstrate)
- the crash does not occur if the static array is populated with scalar values or arrays, only objects.