### PR TITLE
Don't silence SOCK_EINVAL errors

### DIFF
--- a/src/socket.c
+++ b/src/socket.c
@@ -66,7 +66,7 @@
 } while(0)
 
 #define PTHREADS_HANDLE_SOCKET_ERROR(eno, msg) do { \
-	if ((eno) != EAGAIN && (eno) != EWOULDBLOCK && (eno) != EINPROGRESS && (eno) != SOCK_EINVAL) { \
+	if ((eno) != EAGAIN && (eno) != EWOULDBLOCK && (eno) != EINPROGRESS) { \
 		char *estr = (eno) != SUCCESS ? \
 			php_socket_strerror((eno), NULL, 0) : \
 			NULL; \

--- a/tests/socket-select-unix.phpt
+++ b/tests/socket-select-unix.phpt
@@ -3,11 +3,12 @@ Test parameter handling in Socket::select() on non-win32.
 --SKIPIF--
 <?php
 if (substr(PHP_OS, 0, 3) == 'WIN') {
-	die('skip.. Not valid for Windows');
+    die('skip.. Not valid for Windows');
 }
 --FILE--
 <?php
     $socket = new \Socket(\Socket::AF_INET, \Socket::SOCK_STREAM, \Socket::SOL_TCP);
+    $socket->bind("127.0.0.1", 19132);
     $socket->listen();
 
     try {
@@ -30,9 +31,12 @@ if (substr(PHP_OS, 0, 3) == 'WIN') {
 
     $read = [$socket];
 
-    // Invalid sec argument, return immediately
-    var_dump(\Socket::select($read, $write, $except, -1, 0, $errno));
-    var_dump($errno);
+    // Invalid sec argument, throws exception
+    try{
+        \Socket::select($read, $write, $except, -1, 0);
+    }catch(\RuntimeException $e){
+        var_dump($e->getCode());
+    }
 
     $socket->close();
 --EXPECTF--
@@ -41,5 +45,4 @@ Warning: Socket::select() expects at least 4 parameters, 0 given in %s on line %
 int(0)
 int(0)
 int(0)
-bool(false)
 int(22)

--- a/tests/socket-select-win32.phpt
+++ b/tests/socket-select-win32.phpt
@@ -8,6 +8,7 @@ if (substr(PHP_OS, 0, 3) != 'WIN') {
 --FILE--
 <?php
     $socket = new Socket(\Socket::AF_INET, \Socket::SOCK_STREAM, \Socket::SOL_TCP);
+    $socket->bind("127.0.0.1", 19132);
     $socket->listen();
 
     try {

--- a/tests/socket-sentto-recvfrom-ipv6-udp.phpt
+++ b/tests/socket-sentto-recvfrom-ipv6-udp.phpt
@@ -16,7 +16,12 @@ require 'ipv6_skipif.inc';
     if (!$socket->setBlocking(false)) {
         die('Unable to set nonblocking mode for socket');
     }
-    var_dump($socket->recvfrom($buf, 12, 0, $from, $port));
+
+    try{
+        $socket->recvfrom($buf, 12, 0, $from, $port);
+    }catch(\RuntimeException $e){
+        var_dump("not bound");
+    }
     $address = '::1';
     $socket->sendto('', 1, 0, $address); // cause warning
     if (!$socket->bind($address, 1223)) {
@@ -46,7 +51,7 @@ require 'ipv6_skipif.inc';
 
     $socket->close();
 --EXPECTF--
-bool(false)
+string(9) "not bound"
 
 Warning: Wrong parameter count for Socket::sendto() in %s on line %d
 


### PR DESCRIPTION
Silently returning false on invalid arguments is incredibly annoying and frustrating because it conceals bugs. This pull request changes the `PTHREADS_HANDLE_SOCKET_ERROR` macro to throw `RuntimeException` when receiving an `EINVAL` error.

This change makes several bugs in tests apparent, which will be fixed in later commits.