### PR TITLE
Allow Volatile::extend() to work as expected

### DIFF
--- a/classes/threaded.h
+++ b/classes/threaded.h
@@ -320,7 +320,7 @@ PHP_METHOD(Threaded, extend) {
     if (is_final)
         ce->ce_flags = ce->ce_flags &~ ZEND_ACC_FINAL;
 
-	parent = zend_get_executed_scope();
+	parent = zend_get_called_scope(EG(current_execute_data));
 
 	zend_do_inheritance(ce, parent);
 

--- a/tests/runtime-inheritance-volatile.phpt
+++ b/tests/runtime-inheritance-volatile.phpt
@@ -1,0 +1,23 @@
+--TEST--
+Test runtime extension of Volatile
+--DESCRIPTION--
+This test verifies that extend() applies the scope it was called in, not executed in
+--FILE--
+<?php
+class Other {}
+
+class Test extends Other {
+    public function one() {}
+}
+
+/* force zend to declare Other extends Volatile */
+Volatile::extend("Other");
+
+$test = new Test();
+
+var_dump($test instanceof Volatile,
+         $test instanceof Other);
+?>
+--EXPECT--
+bool(true)
+bool(true)


### PR DESCRIPTION
`Threaded` objects are often poorly suited for runtime class extension because of their immutability characteristics. Classes which are not `Threaded` need to be adapted to extend `Threaded` (for example, overwriting a coerced array on a runtime-extended class crashes).

Because `Volatile` descends from `Threaded`, `Volatile::extend()` exists, but does not work as might be expected - it behaves exactly the same as `Threaded::extend()`.

This PR changes `Threaded::extend()` to apply the scope it was called from, instead of always applying the `Threaded` parent.

A possible alternative to this could be to simply move `extend()` to `Volatile` completely, since as I said above `Threaded` isn't suited to code that doesn't know it's `Threaded` anymore due to immutability.