### PR TITLE
Fixed a crash with GC related to unstack()

### DIFF
--- a/src/stack.c
+++ b/src/stack.c
@@ -102,6 +102,7 @@ static inline void pthreads_stack_add_item(pthreads_stack_t *stack, pthreads_sta
 		item->prev = stack->tail;
 		stack->tail = item;
 	}
+	item->next = NULL;
 	stack->size++;
 }
 

--- a/tests/unstack-running.phpt
+++ b/tests/unstack-running.phpt
@@ -1,0 +1,27 @@
+--TEST--
+Test Worker::unstack while a task is currently executing
+--DESCRIPTION--
+Unstacking a task would cause it to be freed from the worker stack, but a currently-executing task would not be told not to point to the destroyed task, resulting in an attempted double-free when collecting garbage from workers
+--FILE--
+<?php
+$w = new Worker();
+$w->start();
+
+class Task extends Threaded{
+    public function run() : void{
+        sleep(1);
+    }
+}
+
+for($i = 0; $i < 2; ++$i){
+    $w->stack(new Task);
+}
+
+usleep(500000);
+$w->unstack();
+$w->shutdown();
+
+var_dump("ok");
+?>
+--EXPECTF--
+string(2) "ok"


### PR DESCRIPTION
pthreads worker stack maintains a linked-list of items to be executed. When an item is removed from the stack with unstack(), it is freed, but the item currently running on the stack does not know about this, and still has to this destroyed task in its `->next` member. This running task is then later added to the GC stack, where [this](https://github.com/krakjoe/pthreads/blob/master/src/stack.c#L84) happens. The GC-stacked item still has a ptr to the destroyed task in its `->next` member, so this loop then tries to free memory which has already been freed.

The cause of this was found by @MCMrARM, send him your love.

This fixes the described bug by NULL-ing the `->next` member of items added to the end of the stack in `pthreads_stack_add_item()`. 