### PR TITLE
Fixed infinite iteration on Threaded objects in PHP 7.3

### DIFF
--- a/src/store.c
+++ b/src/store.c
@@ -1030,6 +1030,9 @@ void pthreads_store_reset(zval *object, HashPosition *position) {
 
 	if (pthreads_monitor_lock(threaded->monitor)) {
 		zend_hash_internal_pointer_reset_ex(threaded->store.props, position);
+		if (zend_hash_has_more_elements_ex(threaded->store.props, position) == FAILURE) { //empty
+			*position = HT_INVALID_IDX;
+		}
 		pthreads_monitor_unlock(threaded->monitor);
 	}
 }
@@ -1064,6 +1067,9 @@ void pthreads_store_forward(zval *object, HashPosition *position) {
 	if (pthreads_monitor_lock(threaded->monitor)) {
 		zend_hash_move_forward_ex(
 			threaded->store.props, position);
+		if (zend_hash_has_more_elements_ex(threaded->store.props, position) == FAILURE) {
+			*position = HT_INVALID_IDX;
+		}
 		pthreads_monitor_unlock(threaded->monitor);
 	}
 } /* }}} */

--- a/tests/iterator-basic.phpt
+++ b/tests/iterator-basic.phpt
@@ -1,0 +1,34 @@
+--TEST--
+Test iterating on Threaded
+--DESCRIPTION--
+Regression test for bugs introduced with Threaded iteration in PHP 7.3
+--FILE--
+<?php
+$threaded = new Threaded();
+
+var_dump($threaded->count());
+foreach($threaded as $k => $prop){
+	var_dump("should not happen");
+}
+
+for($i = 0; $i < 5; ++$i){
+	$threaded[] = "value$i";
+}
+
+foreach($threaded as $i => $prop){
+	var_dump($i, $prop);
+}
+?>
+--EXPECTF--
+int(0)
+int(0)
+string(6) "value0"
+int(1)
+string(6) "value1"
+int(2)
+string(6) "value2"
+int(3)
+string(6) "value3"
+int(4)
+string(6) "value4"
+


### PR DESCRIPTION
This bug was caused by changes made in https://github.com/php/php-src/commit/d7f2dc4ec651628e10213625db6aee3559e214a9 .
`zend_hash_move_forward_ex()` no longer sets the given `HashPosition` to `HT_INVALID_IDX` when it reaches the end of the HT, which causes [this](https://github.com/krakjoe/pthreads/blob/99a86fab88ede56a7ae0bd3e70249425caf5ad05/src/object.c#L5) to always be true.

There are probably better solutions for this, but this was the simplest and least invasive fix I could come up with. It is also backwards-compatible with PHP 7.2.