### PR TITLE
Fixed Threaded->chunk() odd behaviour on PHP 7.3

### DIFF
--- a/src/store.c
+++ b/src/store.c
@@ -501,7 +501,7 @@ int pthreads_store_chunk(zval *object, zend_long size, zend_bool preserve, zval 
 				}
 			} else break;
 
-			zend_hash_move_forward_ex(threaded->store.props, &position);
+			zend_hash_internal_pointer_reset_ex(threaded->store.props, &position);
 		}
 		pthreads_monitor_unlock(threaded->monitor);
 


### PR DESCRIPTION
This issue is described in pmmp/pthreads#1. I think move_forward from a non existing index to an existing one is probably undefined behaviour anyway, so this PR prefers using reset, which is also backwards compatible with 7.2.