### PR TITLE
Fixed unsafe copying of exception handler

### DIFF
--- a/src/store.c
+++ b/src/store.c
@@ -38,25 +38,16 @@
 #	include <src/copy.h>
 #endif
 
-typedef struct _pthreads_storage {
-	zend_uchar 	type;
-	size_t 	length;
-	zend_bool 	exists;
-	union {
-	    zend_long   lval;
-	    double     dval;
-	} simple;
-	void    	*data;
-} pthreads_storage;
+#ifndef HAVE_PTHREADS_STORE_H
+#	include <src/store.h>
+#endif
+
 
 #define PTHREADS_STORAGE_EMPTY {0, 0, 0, 0, NULL}
 
 /* {{{ */
-static pthreads_storage* pthreads_store_create(zval *pzval, zend_bool complex);
-static int pthreads_store_convert(pthreads_storage *storage, zval *pzval);
 static int pthreads_store_tostring(zval *pzval, char **pstring, size_t *slength, zend_bool complex);
 static int pthreads_store_tozval(zval *pzval, char *pstring, size_t slength);
-static void pthreads_store_storage_dtor (pthreads_storage *element);
 /* }}} */
 
 /* {{{ */
@@ -606,7 +597,7 @@ void pthreads_store_free(pthreads_store_t *store){
 } /* }}} */
 
 /* {{{ */
-static pthreads_storage* pthreads_store_create(zval *unstore, zend_bool complex){					
+pthreads_storage* pthreads_store_create(zval *unstore, zend_bool complex){
 	pthreads_storage *storage = NULL;
 
 	if (Z_TYPE_P(unstore) == IS_INDIRECT)
@@ -677,7 +668,7 @@ static pthreads_storage* pthreads_store_create(zval *unstore, zend_bool complex)
 /* }}} */
 
 /* {{{ */
-static int pthreads_store_convert(pthreads_storage *storage, zval *pzval){
+int pthreads_store_convert(pthreads_storage *storage, zval *pzval){
 	int result = SUCCESS;
 
 	switch(storage->type) {
@@ -1007,7 +998,7 @@ next:
 
 
 /* {{{ Will free store element */
-static void pthreads_store_storage_dtor (pthreads_storage *storage){
+void pthreads_store_storage_dtor (pthreads_storage *storage){
 	if (storage) {
 		switch (storage->type) {
 			case IS_CLOSURE:

--- a/src/store.h
+++ b/src/store.h
@@ -27,6 +27,17 @@
 
 typedef HashTable pthreads_store_t;
 
+typedef struct _pthreads_storage {
+	zend_uchar 	type;
+	size_t 	length;
+	zend_bool 	exists;
+	union {
+		zend_long   lval;
+		double     dval;
+	} simple;
+	void    	*data;
+} pthreads_storage;
+
 pthreads_store_t* pthreads_store_alloc();
 void pthreads_store_sync(zval *object);
 int pthreads_store_merge(zval *destination, zval *from, zend_bool overwrite);
@@ -48,5 +59,9 @@ void pthreads_store_reset(zval *object, HashPosition *position);
 void pthreads_store_key(zval *object, zval *key, HashPosition *position);
 void pthreads_store_data(zval *object, zval *value, HashPosition *position);
 void pthreads_store_forward(zval *object, HashPosition *position); /* }}} */
+
+pthreads_storage* pthreads_store_create(zval *pzval, zend_bool complex);
+int pthreads_store_convert(pthreads_storage *storage, zval *pzval);
+void pthreads_store_storage_dtor(pthreads_storage *element);
 
 #endif

--- a/src/thread.h
+++ b/src/thread.h
@@ -30,6 +30,10 @@
 #	include <src/socket.h>
 #endif
 
+#ifndef HAVE_PTHREADS_STORE_H
+#	include <src/store.h>
+#endif
+
 typedef struct _pthreads_ident_t {
 	zend_ulong id;
 	void*** ls;
@@ -45,6 +49,7 @@ typedef struct _pthreads_object_t {
 		pthreads_store_t	*props;
 		pthreads_socket_t	*sock;
 	} store;
+	pthreads_storage    *user_exception_handler;
 	pthreads_stack_t    *stack;
 	pthreads_ident_t 	creator;
 	pthreads_ident_t	local;


### PR DESCRIPTION
This fixes #753 .

See https://github.com/krakjoe/pthreads/pull/861#issuecomment-412031461 for long explanation - the TL;DR is that serialization can cause objects to be modified on the child thread, which will cause problems.

The solution here is to serialize it in `pthreads_prepare_parent()` and then unserialize during the thread's prepared startup. A similar solution will likely be needed for statics.