### PR TITLE
Allocate user class methods inherited from internal classes on arena,…

### DIFF
--- a/src/copy.h
+++ b/src/copy.h
@@ -372,7 +372,7 @@ static inline zend_function* pthreads_copy_user_function(zend_function *function
 
 /* {{{ */
 static inline zend_function* pthreads_copy_internal_function(zend_function *function) {
-	zend_function *copy = calloc(1, sizeof(zend_internal_function));
+	zend_function *copy = zend_arena_alloc(&CG(arena), sizeof(zend_internal_function));
 	memcpy(copy, function, sizeof(zend_internal_function));
 	return copy;
 } /* }}} */

--- a/src/copy.h
+++ b/src/copy.h
@@ -374,6 +374,7 @@ static inline zend_function* pthreads_copy_user_function(zend_function *function
 static inline zend_function* pthreads_copy_internal_function(zend_function *function) {
 	zend_function *copy = zend_arena_alloc(&CG(arena), sizeof(zend_internal_function));
 	memcpy(copy, function, sizeof(zend_internal_function));
+	copy->common.fn_flags |= ZEND_ACC_ARENA_ALLOCATED;
 	return copy;
 } /* }}} */
 


### PR DESCRIPTION
… fixes #881 

This is in line with how inheritance usually works (https://github.com/php/php-src/blob/master/Zend/zend_inheritance.c#L66).