### PR TITLE
WIP: New Concurrent class

### DIFF
--- a/php_pthreads.c
+++ b/php_pthreads.c
@@ -856,10 +856,13 @@ PHP_MINIT_FUNCTION(pthreads)
 
 	memcpy(&pthreads_concurrent_handlers, &pthreads_handlers, sizeof(zend_object_handlers));
 
+	pthreads_concurrent_handlers.get_debug_info = pthreads_concurrent_get_debug_info;
+
 	pthreads_concurrent_handlers.read_property = pthreads_concurrent_read_property;
 	pthreads_concurrent_handlers.write_property = pthreads_concurrent_write_property;
 	pthreads_concurrent_handlers.has_property = pthreads_concurrent_has_property;
 	pthreads_concurrent_handlers.unset_property = pthreads_concurrent_unset_property;
+
 	pthreads_concurrent_handlers.read_dimension = zend_handlers->read_dimension;
 	pthreads_concurrent_handlers.write_dimension = zend_handlers->write_dimension;
 	pthreads_concurrent_handlers.has_dimension = zend_handlers->has_dimension;

--- a/php_pthreads.c
+++ b/php_pthreads.c
@@ -154,7 +154,7 @@ static inline zend_op_array *pthreads_loop_postcompile_classtable() {
 	zend_class_entry *entry;
 	zend_string *name, *dup;
 
-	if (pthreads_globals_lock()) {
+	if (pthreads_compile_hook_lock()) {
 		ZEND_HASH_FOREACH_STR_KEY_PTR(CG(class_table), name, entry) {
 			if (entry->type == ZEND_USER_CLASS && !zend_hash_exists(&PTHREADS_G(postcompile), name) && ZSTR_VAL(name)[0] != '\0') {
 				dup = zend_new_interned_string(zend_string_init(ZSTR_VAL(name), ZSTR_LEN(name), GC_FLAGS(name) & IS_STR_PERSISTENT));
@@ -163,7 +163,7 @@ static inline zend_op_array *pthreads_loop_postcompile_classtable() {
 			}
 		} ZEND_HASH_FOREACH_END();
 
-		pthreads_globals_unlock();
+		pthreads_compile_hook_unlock();
 	}
 } /* }}} */
 

--- a/php_pthreads.c
+++ b/php_pthreads.c
@@ -69,6 +69,7 @@ zend_module_entry pthreads_module_entry = {
 zend_class_entry *pthreads_threaded_entry;
 zend_class_entry *pthreads_volatile_entry;
 zend_class_entry *pthreads_thread_entry;
+zend_class_entry *pthreads_concurrent_entry;
 zend_class_entry *pthreads_worker_entry;
 zend_class_entry *pthreads_collectable_entry;
 zend_class_entry *pthreads_pool_entry;
@@ -76,6 +77,7 @@ zend_class_entry *pthreads_socket_entry;
 
 zend_object_handlers pthreads_handlers;
 zend_object_handlers pthreads_socket_handlers;
+zend_object_handlers pthreads_concurrent_handlers;
 zend_object_handlers *zend_handlers;
 void ***pthreads_instance = NULL;
 
@@ -343,6 +345,10 @@ PHP_MINIT_FUNCTION(pthreads)
 	INIT_CLASS_ENTRY(ce, "Volatile", NULL);
 	pthreads_volatile_entry = zend_register_internal_class_ex(&ce, pthreads_threaded_entry);
 	
+	INIT_CLASS_ENTRY(ce, "Concurrent", NULL);
+	pthreads_concurrent_entry = zend_register_internal_class_ex(&ce, pthreads_threaded_entry);
+	pthreads_concurrent_entry->create_object = pthreads_concurrent_ctor;
+
 	INIT_CLASS_ENTRY(ce, "Thread", pthreads_thread_methods);
 	pthreads_thread_entry=zend_register_internal_class_ex(&ce, pthreads_threaded_entry);
 	pthreads_thread_entry->create_object = pthreads_thread_ctor;
@@ -847,6 +853,17 @@ PHP_MINIT_FUNCTION(pthreads)
 	pthreads_socket_handlers.write_dimension = pthreads_write_dimension_disallow;
 	pthreads_socket_handlers.has_dimension = pthreads_has_dimension_disallow;
 	pthreads_socket_handlers.unset_dimension = pthreads_unset_dimension_disallow;
+
+	memcpy(&pthreads_concurrent_handlers, &pthreads_handlers, sizeof(zend_object_handlers));
+
+	pthreads_concurrent_handlers.read_property = pthreads_concurrent_read_property;
+	pthreads_concurrent_handlers.write_property = pthreads_concurrent_write_property;
+	pthreads_concurrent_handlers.has_property = pthreads_concurrent_has_property;
+	pthreads_concurrent_handlers.unset_property = pthreads_concurrent_unset_property;
+	pthreads_concurrent_handlers.read_dimension = zend_handlers->read_dimension;
+	pthreads_concurrent_handlers.write_dimension = zend_handlers->write_dimension;
+	pthreads_concurrent_handlers.has_dimension = zend_handlers->has_dimension;
+	pthreads_concurrent_handlers.unset_dimension = zend_handlers->unset_dimension;
 
 	ZEND_INIT_MODULE_GLOBALS(pthreads, pthreads_globals_ctor, NULL);	
 

--- a/src/globals.c
+++ b/src/globals.c
@@ -38,7 +38,8 @@ extern int pthreads_connect(pthreads_object_t* source, pthreads_object_t* destin
 zend_bool pthreads_globals_init(){
 	if (!PTHREADS_G(init)&&!PTHREADS_G(failed)) {
 		PTHREADS_G(init)=1;
-		if (!(PTHREADS_G(monitor)=pthreads_monitor_alloc()))
+		if (!(PTHREADS_G(monitor)=pthreads_monitor_alloc())
+			|| !(PTHREADS_G(compile_hook_monitor)=pthreads_monitor_alloc()))
 			PTHREADS_G(failed)=1;
 		if (PTHREADS_G(failed)) {
 		    PTHREADS_G(init)=0;
@@ -81,6 +82,16 @@ zend_bool pthreads_globals_lock(){
 /* {{{ */
 void pthreads_globals_unlock() {
 	pthreads_monitor_unlock(PTHREADS_G(monitor));
+} /* }}} */
+
+/* {{{ */
+zend_bool pthreads_compile_hook_lock(){
+	return pthreads_monitor_lock(PTHREADS_G(compile_hook_monitor));
+} /* }}} */
+
+/* {{{ */
+void pthreads_compile_hook_unlock() {
+	pthreads_monitor_unlock(PTHREADS_G(compile_hook_monitor));
 } /* }}} */
 
 /* {{{ */
@@ -174,6 +185,7 @@ void pthreads_globals_shutdown() {
 		PTHREADS_G(failed)=0;
 		/* we allow proc shutdown to destroy tables, and global strings */
 		pthreads_monitor_free(PTHREADS_G(monitor));
+		pthreads_monitor_free(PTHREADS_G(compile_hook_monitor));
 	}
 } /* }}} */
 #endif

--- a/src/globals.c
+++ b/src/globals.c
@@ -43,8 +43,8 @@ zend_bool pthreads_globals_init(){
 		if (PTHREADS_G(failed)) {
 		    PTHREADS_G(init)=0;
 		} else {
-		    zend_hash_init(
-		    	&PTHREADS_G(objects), 64, NULL, (dtor_func_t) NULL, 1);
+			zend_hash_init(&PTHREADS_G(objects), 64, NULL, (dtor_func_t) NULL, 1);
+			zend_hash_init(&PTHREADS_G(postcompile), 15, NULL, (dtor_func_t) NULL, 1);
 		}
 
 #if PHP_VERSION_ID >= 70300

--- a/src/globals.c
+++ b/src/globals.c
@@ -46,6 +46,7 @@ zend_bool pthreads_globals_init(){
 		} else {
 			zend_hash_init(&PTHREADS_G(objects), 64, NULL, (dtor_func_t) NULL, 1);
 			zend_hash_init(&PTHREADS_G(postcompile), 15, NULL, (dtor_func_t) NULL, 1);
+			zend_hash_init(&PTHREADS_G(default_static_props), 15, NULL, (dtor_func_t) NULL, 1);
 		}
 
 #if PHP_VERSION_ID >= 70300

--- a/src/globals.h
+++ b/src/globals.h
@@ -60,6 +60,11 @@ struct _pthreads_globals {
 	pthreads_monitor_t *compile_hook_monitor;
 
 	/*
+	* Default static props cache
+	*/
+	HashTable default_static_props;
+
+	/*
 	* High Frequency Strings
 	*/
 	struct _strings {

--- a/src/globals.h
+++ b/src/globals.h
@@ -55,6 +55,11 @@ struct _pthreads_globals {
 	HashTable postcompile;
 	
 	/*
+	* Global compile hook Monitor
+	*/
+	pthreads_monitor_t *compile_hook_monitor;
+
+	/*
 	* High Frequency Strings
 	*/
 	struct _strings {
@@ -92,6 +97,12 @@ zend_bool pthreads_globals_lock(); /* }}} */
 
 /* {{{ release global lock */
 void pthreads_globals_unlock(); /* }}} */
+
+/* {{{ acquire compile hook lock */
+zend_bool pthreads_compile_hook_lock(); /* }}} */
+
+/* {{{ release compile hook lock */
+void pthreads_compile_hook_unlock(); /* }}} */
 
 /* {{{ copy string to globals */
 char *pthreads_global_string(char *strkey, int32_t keylen, zend_bool lower); /* }}} */

--- a/src/globals.h
+++ b/src/globals.h
@@ -48,6 +48,11 @@ struct _pthreads_globals {
 	* Objects Cache
 	*/
 	HashTable objects;
+
+	/**
+	* Global class table
+	 */
+	HashTable postcompile;
 	
 	/*
 	* High Frequency Strings

--- a/src/handlers.c
+++ b/src/handlers.c
@@ -123,7 +123,9 @@ zval * pthreads_read_property (PTHREADS_READ_PROPERTY_PASSTHRU_D) {
 
 		zend_fcall_info_args_clear(&fci, 1);
 	} else {
-		pthreads_store_read(object, member, type, rv);
+		if(pthreads_is_property_threadlocal(object, member)) {
+			zend_std_read_property(object, member, type, cache, rv);
+		} else pthreads_store_read(object, member, type, rv);
 	}
 	
 	return rv;
@@ -191,7 +193,9 @@ void pthreads_write_property(PTHREADS_WRITE_PROPERTY_PASSTHRU_D) {
 					zval_dtor(&rv);
 				zend_fcall_info_args_clear(&fci, 1);
 			} else {
-				pthreads_store_write(object, member, value);
+				if(pthreads_is_property_threadlocal(object, member)) {
+					zend_std_write_property(object, member, value, cache);
+				} else pthreads_store_write(object, member, value);
 			}
 		} break;
 	
@@ -256,7 +260,9 @@ int pthreads_has_property(PTHREADS_HAS_PROPERTY_PASSTHRU_D) {
 		}
 		zend_fcall_info_args_clear(&fci, 1);
 	} else {
-		isset = pthreads_store_isset(object, member, has_set_exists);
+		if(pthreads_is_property_threadlocal(object, member)) {
+			isset = zend_std_has_property(object, member, has_set_exists, cache);
+		} else isset = pthreads_store_isset(object, member, has_set_exists);
 	}
 
 	return isset;
@@ -313,9 +319,9 @@ void pthreads_unset_property(PTHREADS_UNSET_PROPERTY_PASSTHRU_D) {
 		}
 		zend_fcall_info_args_clear(&fci, 1);
 	} else {
-		if (pthreads_store_delete(object, member) == SUCCESS){
-			
-		}
+		if(pthreads_is_property_threadlocal(object, member)) {
+			zend_std_unset_property(object, member, cache);
+		} else pthreads_store_delete(object, member);
 	}
 }
 void pthreads_unset_dimension(PTHREADS_UNSET_DIMENSION_PASSTHRU_D) { pthreads_unset_property(PTHREADS_UNSET_DIMENSION_PASSTHRU_C); }

--- a/src/handlers.c
+++ b/src/handlers.c
@@ -123,9 +123,7 @@ zval * pthreads_read_property (PTHREADS_READ_PROPERTY_PASSTHRU_D) {
 
 		zend_fcall_info_args_clear(&fci, 1);
 	} else {
-		if(pthreads_is_property_threadlocal(object, member)) {
-			zend_std_read_property(object, member, type, cache, rv);
-		} else pthreads_store_read(object, member, type, rv);
+		pthreads_store_read(object, member, type, rv);
 	}
 	
 	return rv;
@@ -193,9 +191,7 @@ void pthreads_write_property(PTHREADS_WRITE_PROPERTY_PASSTHRU_D) {
 					zval_dtor(&rv);
 				zend_fcall_info_args_clear(&fci, 1);
 			} else {
-				if(pthreads_is_property_threadlocal(object, member)) {
-					zend_std_write_property(object, member, value, cache);
-				} else pthreads_store_write(object, member, value);
+				pthreads_store_write(object, member, value);
 			}
 		} break;
 	
@@ -260,9 +256,7 @@ int pthreads_has_property(PTHREADS_HAS_PROPERTY_PASSTHRU_D) {
 		}
 		zend_fcall_info_args_clear(&fci, 1);
 	} else {
-		if(pthreads_is_property_threadlocal(object, member)) {
-			isset = zend_std_has_property(object, member, has_set_exists, cache);
-		} else isset = pthreads_store_isset(object, member, has_set_exists);
+		isset = pthreads_store_isset(object, member, has_set_exists);
 	}
 
 	return isset;
@@ -319,9 +313,7 @@ void pthreads_unset_property(PTHREADS_UNSET_PROPERTY_PASSTHRU_D) {
 		}
 		zend_fcall_info_args_clear(&fci, 1);
 	} else {
-		if(pthreads_is_property_threadlocal(object, member)) {
-			zend_std_unset_property(object, member, cache);
-		} else pthreads_store_delete(object, member);
+		pthreads_store_delete(object, member);
 	}
 }
 void pthreads_unset_dimension(PTHREADS_UNSET_DIMENSION_PASSTHRU_D) { pthreads_unset_property(PTHREADS_UNSET_DIMENSION_PASSTHRU_C); }
@@ -383,4 +375,564 @@ int pthreads_compare_objects(PTHREADS_COMPARE_PASSTHRU_D) {
 
 	return 1;
 } /* }}} */
+
+static void pthreads_call_getter(zval *object, zval *member, zval *retval) /* {{{ */
+{
+	zend_class_entry *ce = Z_OBJCE_P(object);
+	zend_class_entry *orig_fake_scope = EG(fake_scope);
+
+	EG(fake_scope) = NULL;
+
+	/* __get handler is called with one argument:
+	      property name
+
+	   it should return whether the call was successful or not
+	*/
+	zend_call_method_with_1_params(object, ce, &ce->__get, ZEND_GET_FUNC_NAME, retval, member);
+
+	EG(fake_scope) = orig_fake_scope;
+}
+/* }}} */
+
+static void pthreads_call_issetter(zval *object, zval *member, zval *retval) /* {{{ */
+{
+	zend_class_entry *ce = Z_OBJCE_P(object);
+	zend_class_entry *orig_fake_scope = EG(fake_scope);
+
+	EG(fake_scope) = NULL;
+
+	/* __isset handler is called with one argument:
+	      property name
+
+	   it should return whether the property is set or not
+	*/
+
+	if (Z_REFCOUNTED_P(member)) Z_ADDREF_P(member);
+
+	zend_call_method_with_1_params(object, ce, &ce->__isset, ZEND_ISSET_FUNC_NAME, retval, member);
+
+	zval_ptr_dtor(member);
+
+	EG(fake_scope) = orig_fake_scope;
+}
+/* }}} */
+
+static void pthreads_call_setter(zval *object, zval *member, zval *value) /* {{{ */
+{
+	zend_class_entry *ce = Z_OBJCE_P(object);
+	zend_class_entry *orig_fake_scope = EG(fake_scope);
+
+	EG(fake_scope) = NULL;
+
+	/* __set handler is called with two arguments:
+	     property name
+	     value to be set
+	*/
+	zend_call_method_with_2_params(object, ce, &ce->__set, ZEND_SET_FUNC_NAME, NULL, member, value);
+
+	EG(fake_scope) = orig_fake_scope;
+}
+/* }}} */
+
+static void pthreads_call_unsetter(zval *object, zval *member) /* {{{ */
+{
+	zend_class_entry *ce = Z_OBJCE_P(object);
+	zend_class_entry *orig_fake_scope = EG(fake_scope);
+
+	EG(fake_scope) = NULL;
+
+	/* __unset handler is called with one argument:
+	      property name
+	*/
+
+	if (Z_REFCOUNTED_P(member)) Z_ADDREF_P(member);
+
+	zend_call_method_with_1_params(object, ce, &ce->__unset, ZEND_UNSET_FUNC_NAME, NULL, member);
+
+	zval_ptr_dtor(member);
+
+	EG(fake_scope) = orig_fake_scope;
+}
+/* }}} */
+
+/* {{{ */
+zval * pthreads_concurrent_read_property (PTHREADS_READ_PROPERTY_PASSTHRU_D) {
+	zend_guard *guard = NULL;
+	zend_object *zobj;
+	zval tmp_member, tmp_object;
+	zval *retval = NULL;
+	uint32_t property_offset = ZEND_WRONG_PROPERTY_OFFSET;
+	zend_property_info *property_info;
+	pthreads_object_t* threaded = PTHREADS_FETCH_FROM(Z_OBJ_P(object));
+
+	rebuild_object_properties(&threaded->std);
+
+	zobj = Z_OBJ_P(object);
+
+	ZVAL_UNDEF(&tmp_member);
+	if (UNEXPECTED(Z_TYPE_P(member) != IS_STRING)) {
+		ZVAL_STR(&tmp_member, zval_get_string(member));
+		member = &tmp_member;
+	}
+
+	/* make zend_get_property_info silent if we have getter - we may want to use it */
+	property_info = zend_get_property_info(zobj->ce, Z_STR_P(member), (type == BP_VAR_IS) || (zobj->ce->__get != NULL));
+
+	if(property_info == NULL) {
+		property_offset = ZEND_DYNAMIC_PROPERTY_OFFSET;
+	} else {
+		property_offset = property_info->offset;
+	}
+
+	if (EXPECTED(property_info != ZEND_WRONG_PROPERTY_INFO)) {
+		if(pthreads_is_property_threadlocal(property_info)) {
+			if (EXPECTED(property_offset != ZEND_DYNAMIC_PROPERTY_OFFSET)) {
+				retval = OBJ_PROP(zobj, property_offset);
+				if (EXPECTED(Z_TYPE_P(retval) != IS_UNDEF)) {
+					goto exit;
+				}
+			} else if (EXPECTED(zobj->properties != NULL)) {
+				retval = zend_hash_find(zobj->properties, Z_STR_P(member));
+				if (EXPECTED(retval)) goto exit;
+			}
+		} else {
+			if (EXPECTED(property_offset != ZEND_DYNAMIC_PROPERTY_OFFSET)) {
+				pthreads_store_read(object, member, type, rv);
+				retval = rv;
+				if (EXPECTED(retval)) {
+					goto exit;
+				}
+			} else if (EXPECTED(zobj->properties != NULL)) {
+				retval = zend_hash_find(zobj->properties, Z_STR_P(member));
+				if (EXPECTED(retval)) {
+					pthreads_store_read(object, member, type, rv);
+					retval = rv;
+					goto exit;
+				}
+			}
+		}
+
+	} else if (UNEXPECTED(EG(exception))) {
+		retval = &EG(uninitialized_zval);
+		goto exit;
+	}
+
+	ZVAL_UNDEF(&tmp_object);
+
+	/* magic isset */
+	if ((type == BP_VAR_IS) && zobj->ce->__isset) {
+		zval tmp_result;
+		guard = pthreads_get_guard(&threaded->std, member);
+
+		if (!((*guard) & IN_ISSET)) {
+			if (Z_TYPE(tmp_member) == IS_UNDEF) {
+				ZVAL_COPY(&tmp_member, member);
+				member = &tmp_member;
+			}
+			ZVAL_COPY(&tmp_object, object);
+			ZVAL_UNDEF(&tmp_result);
+
+			*guard |= IN_ISSET;
+			pthreads_call_issetter(&tmp_object, member, &tmp_result);
+			*guard &= ~IN_ISSET;
+
+			if (!zend_is_true(&tmp_result)) {
+				retval = &EG(uninitialized_zval);
+				zval_ptr_dtor(&tmp_object);
+				zval_ptr_dtor(&tmp_result);
+				goto exit;
+			}
+
+			zval_ptr_dtor(&tmp_result);
+		}
+	}
+
+	/* magic get */
+	if (zobj->ce->__get) {
+		if(guard == NULL) {
+			guard = pthreads_get_guard(&threaded->std, member);
+		}
+
+		if (!((*guard) & IN_GET)) {
+			/* have getter - try with it! */
+			if (Z_TYPE(tmp_object) == IS_UNDEF) {
+				ZVAL_COPY(&tmp_object, object);
+			}
+			*guard |= IN_GET; /* prevent circular getting */
+			pthreads_call_getter(&tmp_object, member, rv);
+			*guard &= ~IN_GET;
+
+			if (Z_TYPE_P(rv) != IS_UNDEF) {
+				retval = rv;
+				if (!Z_ISREF_P(rv) &&
+					(type == BP_VAR_W || type == BP_VAR_RW  || type == BP_VAR_UNSET)) {
+					SEPARATE_ZVAL(rv);
+					if (UNEXPECTED(Z_TYPE_P(rv) != IS_OBJECT)) {
+						zend_error(E_NOTICE, "Indirect modification of overloaded property %s::$%s has no effect", ZSTR_VAL(zobj->ce->name), Z_STRVAL_P(member));
+					}
+				}
+			} else {
+				retval = &EG(uninitialized_zval);
+			}
+			zval_ptr_dtor(&tmp_object);
+			goto exit;
+		} else if (Z_STRVAL_P(member)[0] == '\0' && Z_STRLEN_P(member) != 0) {
+			//zval_ptr_dtor(&tmp_object);
+			zend_throw_error(NULL, "Cannot access property started with '\\0'");
+			retval = &EG(uninitialized_zval);
+			goto exit;
+		}
+	}
+
+	zval_ptr_dtor(&tmp_object);
+
+	if ((type != BP_VAR_IS)) {
+		zend_error(E_NOTICE,"Undefined property: %s::$%s", ZSTR_VAL(zobj->ce->name), Z_STRVAL_P(member));
+	}
+	retval = &EG(uninitialized_zval);
+
+exit:
+	if (UNEXPECTED(Z_REFCOUNTED(tmp_member))) {
+		zval_ptr_dtor(&tmp_member);
+	}
+
+	return retval;
+}
+/* }}} */
+
+/* {{{ */
+void pthreads_concurrent_write_property(PTHREADS_WRITE_PROPERTY_PASSTHRU_D) {
+	zend_object *zobj;
+	zval tmp_member;
+	zval *variable_ptr;
+	uint32_t property_offset = ZEND_WRONG_PROPERTY_OFFSET;
+	zend_property_info *property_info;
+	pthreads_object_t* threaded = PTHREADS_FETCH_FROM(Z_OBJ_P(object));
+
+	rebuild_object_properties(&threaded->std);
+
+	zobj = Z_OBJ_P(object);
+
+	ZVAL_UNDEF(&tmp_member);
+	if (UNEXPECTED(Z_TYPE_P(member) != IS_STRING)) {
+		ZVAL_STR(&tmp_member, zval_get_string(member));
+		member = &tmp_member;
+	}
+	property_info = zend_get_property_info(zobj->ce, Z_STR_P(member), (zobj->ce->__set != NULL));
+
+	if(property_info == NULL) {
+		property_offset = ZEND_DYNAMIC_PROPERTY_OFFSET;
+	} else {
+		property_offset = property_info->offset;
+	}
+
+	if (EXPECTED(property_info != ZEND_WRONG_PROPERTY_INFO)) {
+		if(pthreads_is_property_threadlocal(property_info)) {
+			if (EXPECTED(property_offset != ZEND_DYNAMIC_PROPERTY_OFFSET)) {
+				variable_ptr = OBJ_PROP(zobj, property_offset);
+				if (Z_TYPE_P(variable_ptr) != IS_UNDEF) {
+					goto found;
+				}
+			} else if (EXPECTED(zobj->properties != NULL)) {
+				if (UNEXPECTED(GC_REFCOUNT(zobj->properties) > 1)) {
+					if (EXPECTED(!(GC_FLAGS(zobj->properties) & IS_ARRAY_IMMUTABLE))) {
+						GC_REFCOUNT(zobj->properties)--;
+					}
+					zobj->properties = zend_array_dup(zobj->properties);
+				}
+				if ((variable_ptr = zend_hash_find(zobj->properties, Z_STR_P(member))) != NULL) {
+found:
+					zend_assign_to_variable(variable_ptr, value, IS_CV);
+					goto exit;
+				}
+			}
+		} else {
+			switch(Z_TYPE_P(value)){
+				case IS_UNDEF:
+				case IS_STRING:
+				case IS_LONG:
+				case IS_ARRAY:
+				case IS_OBJECT:
+				case IS_NULL:
+				case IS_DOUBLE:
+				case IS_RESOURCE:
+				case IS_TRUE:
+				case IS_FALSE: {
+					if (EXPECTED(property_offset != ZEND_DYNAMIC_PROPERTY_OFFSET)) {
+						variable_ptr = OBJ_PROP(zobj, property_offset);
+						if (Z_TYPE_P(variable_ptr) != IS_UNDEF) {
+							goto found_threaded;
+						}
+					} else if (EXPECTED(zobj->properties != NULL)) {
+						if ((variable_ptr = zend_hash_find(zobj->properties, Z_STR_P(member))) != NULL) {
+found_threaded:
+							pthreads_store_write(object, member, value);
+							goto exit;
+						}
+					}
+				} break;
+
+				default: {
+					zend_throw_exception_ex(
+						spl_ce_RuntimeException, 0,
+						"pthreads detected an attempt to use unsupported data (%s) for %s::$%s",
+						zend_get_type_by_const(Z_TYPE_P(value)),
+						ZSTR_VAL(Z_OBJCE_P(object)->name), Z_STRVAL_P(member));
+				}
+			}
+			goto exit;
+		}
+
+	} else if (UNEXPECTED(EG(exception))) {
+		goto exit;
+	}
+
+	/* magic set */
+	if (zobj->ce->__set) {
+		zend_guard *guard = pthreads_get_guard(&threaded->std, member);
+
+		if (!((*guard) & IN_SET)) {
+			zval tmp_object;
+
+			ZVAL_COPY(&tmp_object, object);
+			(*guard) |= IN_SET; /* prevent circular setting */
+			pthreads_call_setter(&tmp_object, member, value);
+			(*guard) &= ~IN_SET;
+			zval_ptr_dtor(&tmp_object);
+		} else if (EXPECTED(property_offset != ZEND_WRONG_PROPERTY_OFFSET)) {
+			goto write_std_property;
+		} else {
+			if (Z_STRVAL_P(member)[0] == '\0' && Z_STRLEN_P(member) != 0) {
+				zend_throw_error(NULL, "Cannot access property started with '\\0'");
+				goto exit;
+			}
+		}
+	} else if (EXPECTED(property_offset != ZEND_WRONG_PROPERTY_OFFSET)) {
+		zval tmp;
+
+write_std_property:
+		if(pthreads_is_property_threadlocal(property_info)) {
+			if (Z_REFCOUNTED_P(value)) {
+				if (Z_ISREF_P(value)) {
+					/* if we assign referenced variable, we should separate it */
+					ZVAL_COPY(&tmp, Z_REFVAL_P(value));
+					value = &tmp;
+				} else {
+					Z_ADDREF_P(value);
+				}
+			}
+			if (EXPECTED(property_offset != ZEND_DYNAMIC_PROPERTY_OFFSET)) {
+				ZVAL_COPY_VALUE(OBJ_PROP(zobj, property_offset), value);
+			} else {
+				if (!zobj->properties) {
+					rebuild_object_properties(zobj);
+				}
+				zend_hash_add_new(zobj->properties, Z_STR_P(member), value);
+			}
+		} else {
+			pthreads_store_write(object, member, value);
+		}
+	}
+
+exit:
+	if (UNEXPECTED(Z_REFCOUNTED(tmp_member))) {
+		zval_ptr_dtor(&tmp_member);
+	}
+}
+/* }}} */
+
+/* {{{ */
+int pthreads_concurrent_has_property(PTHREADS_HAS_PROPERTY_PASSTHRU_D) {
+	zend_object *zobj;
+	int result;
+	zval *value = NULL;
+	zval tmp_member;
+	uint32_t property_offset;
+	zend_property_info *property_info;
+	pthreads_object_t* threaded = PTHREADS_FETCH_FROM(Z_OBJ_P(object));
+
+	zobj = Z_OBJ_P(object);
+
+	ZVAL_UNDEF(&tmp_member);
+	if (UNEXPECTED(Z_TYPE_P(member) != IS_STRING)) {
+		ZVAL_STR(&tmp_member, zval_get_string(member));
+		member = &tmp_member;
+	}
+
+	property_info = zend_get_property_info(zobj->ce, Z_STR_P(member), 1);
+
+	if(property_info == NULL) {
+		property_offset = ZEND_DYNAMIC_PROPERTY_OFFSET;
+	} else {
+		property_offset = property_info->offset;
+	}
+
+	if (EXPECTED(property_info != ZEND_WRONG_PROPERTY_INFO)) {
+		if(pthreads_is_property_threadlocal(property_info)) {
+			if (EXPECTED(property_offset != ZEND_DYNAMIC_PROPERTY_OFFSET)) {
+				value = OBJ_PROP(zobj, property_offset);
+				if (Z_TYPE_P(value) != IS_UNDEF) {
+					goto found;
+				}
+			} else if (EXPECTED(zobj->properties != NULL) &&
+					   (value = zend_hash_find(zobj->properties, Z_STR_P(member))) != NULL) {
+found:
+				switch (has_set_exists) {
+					case 0:
+						ZVAL_DEREF(value);
+						result = (Z_TYPE_P(value) != IS_NULL);
+						break;
+					default:
+						result = zend_is_true(value);
+						break;
+					case 2:
+						result = 1;
+						break;
+				}
+				goto exit;
+			}
+		} else {
+			result = pthreads_store_isset(object, member, has_set_exists);
+			goto exit;
+		}
+	} else if (UNEXPECTED(EG(exception))) {
+		result = 0;
+		goto exit;
+	}
+
+	result = 0;
+	if ((has_set_exists != 2) && zobj->ce->__isset) {
+		zend_guard *guard = pthreads_get_guard(&threaded->std, member);
+
+		if (!((*guard) & IN_ISSET)) {
+			zval rv;
+			zval tmp_object;
+
+			/* have issetter - try with it! */
+			if (Z_TYPE(tmp_member) == IS_UNDEF) {
+				ZVAL_COPY(&tmp_member, member);
+				member = &tmp_member;
+			}
+			ZVAL_COPY(&tmp_object, object);
+			(*guard) |= IN_ISSET; /* prevent circular getting */
+			pthreads_call_issetter(&tmp_object, member, &rv);
+			if (Z_TYPE(rv) != IS_UNDEF) {
+				result = zend_is_true(&rv);
+				zval_ptr_dtor(&rv);
+				if (has_set_exists && result) {
+					if (EXPECTED(!EG(exception)) && zobj->ce->__get && !((*guard) & IN_GET)) {
+						(*guard) |= IN_GET;
+						pthreads_call_getter(&tmp_object, member, &rv);
+						(*guard) &= ~IN_GET;
+						if (Z_TYPE(rv) != IS_UNDEF) {
+							result = i_zend_is_true(&rv);
+							zval_ptr_dtor(&rv);
+						} else {
+							result = 0;
+						}
+					} else {
+						result = 0;
+					}
+				}
+			}
+			(*guard) &= ~IN_ISSET;
+			zval_ptr_dtor(&tmp_object);
+		}
+	}
+
+exit:
+	if (UNEXPECTED(Z_REFCOUNTED(tmp_member))) {
+		zval_ptr_dtor(&tmp_member);
+	}
+	return result;
+}
+/* }}} */
+
+/* {{{ */
+void pthreads_concurrent_unset_property(PTHREADS_UNSET_PROPERTY_PASSTHRU_D) {
+	zend_object *zobj;
+	zval tmp_member;
+	uint32_t property_offset;
+	zend_property_info *property_info;
+	pthreads_object_t* threaded = PTHREADS_FETCH_FROM(Z_OBJ_P(object));
+
+	rebuild_object_properties(&threaded->std);
+
+	zobj = Z_OBJ_P(object);
+
+	ZVAL_UNDEF(&tmp_member);
+	if (UNEXPECTED(Z_TYPE_P(member) != IS_STRING)) {
+		ZVAL_STR(&tmp_member, zval_get_string(member));
+		member = &tmp_member;
+	}
+
+	property_info = zend_get_property_info(zobj->ce, Z_STR_P(member), (zobj->ce->__unset != NULL));
+
+	if(property_info == NULL) {
+		property_offset = ZEND_DYNAMIC_PROPERTY_OFFSET;
+	} else {
+		property_offset = property_info->offset;
+	}
+
+	if (EXPECTED(property_info != ZEND_WRONG_PROPERTY_INFO)) {
+		if(pthreads_is_property_threadlocal(property_info)) {
+			if (EXPECTED(property_offset != ZEND_DYNAMIC_PROPERTY_OFFSET)) {
+				zval *slot = OBJ_PROP(zobj, property_offset);
+
+				if (Z_TYPE_P(slot) != IS_UNDEF) {
+					zval_ptr_dtor(slot);
+					ZVAL_UNDEF(slot);
+					if (zobj->properties) {
+						zobj->properties->u.v.flags |= HASH_FLAG_HAS_EMPTY_IND;
+					}
+					goto exit;
+				}
+			} else if (EXPECTED(zobj->properties != NULL)) {
+				if (UNEXPECTED(GC_REFCOUNT(zobj->properties) > 1)) {
+					if (EXPECTED(!(GC_FLAGS(zobj->properties) & IS_ARRAY_IMMUTABLE))) {
+						GC_REFCOUNT(zobj->properties)--;
+					}
+					zobj->properties = zend_array_dup(zobj->properties);
+				}
+				if (EXPECTED(zend_hash_del(zobj->properties, Z_STR_P(member)) != FAILURE)) {
+					goto exit;
+				}
+			}
+		} else {
+			pthreads_store_delete(object, member);
+			goto exit;
+		}
+
+	} else if (UNEXPECTED(EG(exception))) {
+		goto exit;
+	}
+
+	/* magic unset */
+	if (zobj->ce->__unset) {
+		zend_guard *guard = pthreads_get_guard(&threaded->std, member);
+
+		if (!((*guard) & IN_UNSET)) {
+			zval tmp_object;
+
+			/* have unseter - try with it! */
+			ZVAL_COPY(&tmp_object, object);
+			(*guard) |= IN_UNSET; /* prevent circular unsetting */
+			pthreads_call_unsetter(&tmp_object, member);
+			(*guard) &= ~IN_UNSET;
+			zval_ptr_dtor(&tmp_object);
+		} else {
+			if (Z_STRVAL_P(member)[0] == '\0' && Z_STRLEN_P(member) != 0) {
+				zend_throw_error(NULL, "Cannot access property started with '\\0'");
+				goto exit;
+			}
+		}
+	}
+
+exit:
+	if (UNEXPECTED(Z_REFCOUNTED(tmp_member))) {
+		zval_ptr_dtor(&tmp_member);
+	}
+}
+/* }}} */
+
 #endif

--- a/src/handlers.h
+++ b/src/handlers.h
@@ -131,4 +131,7 @@ int pthreads_concurrent_has_property(PTHREADS_HAS_PROPERTY_PASSTHRU_D); /* }}} *
 /* {{{ */
 void pthreads_concurrent_unset_property(PTHREADS_UNSET_PROPERTY_PASSTHRU_D); /* }}} */
 
+/* {{{ */
+HashTable *pthreads_concurrent_get_debug_info(zval *object, int *is_temp); /* {{{ */
+
 #endif

--- a/src/handlers.h
+++ b/src/handlers.h
@@ -118,4 +118,17 @@ zend_object* pthreads_clone_object(PTHREADS_CLONE_PASSTHRU_D); /* }}} */
 
 /* {{{ */
 int pthreads_compare_objects(PTHREADS_COMPARE_PASSTHRU_D); /* }}} */
+
+/* {{{ */
+zval * pthreads_concurrent_read_property (PTHREADS_READ_PROPERTY_PASSTHRU_D); /* }}} */
+
+/* {{{ */
+void pthreads_concurrent_write_property(PTHREADS_WRITE_PROPERTY_PASSTHRU_D); /* }}} */
+
+/* {{{ */
+int pthreads_concurrent_has_property(PTHREADS_HAS_PROPERTY_PASSTHRU_D); /* }}} */
+
+/* {{{ */
+void pthreads_concurrent_unset_property(PTHREADS_UNSET_PROPERTY_PASSTHRU_D); /* }}} */
+
 #endif

--- a/src/object.c
+++ b/src/object.c
@@ -134,6 +134,27 @@ static void pthreads_routine_free(pthreads_routine_arg_t *r) {
 } /* }}} */
 
 /* {{{ */
+zend_bool pthreads_is_property_threadlocal(zval *object, zval *member) {
+	zend_object *zobj;
+	zval tmp_member;
+	zend_property_info *property_info;
+
+	zobj = Z_OBJ_P(object);
+
+	ZVAL_UNDEF(&tmp_member);
+	if (UNEXPECTED(Z_TYPE_P(member) != IS_STRING)) {
+		ZVAL_STR(&tmp_member, zval_get_string(member));
+		member = &tmp_member;
+	}
+	property_info = zend_get_property_info(zobj->ce, Z_STR_P(member), (zobj->ce->__set != NULL));
+
+	if (UNEXPECTED(Z_REFCOUNTED(tmp_member))) {
+		zval_ptr_dtor(&tmp_member);
+	}
+	return property_info != NULL && (property_info->flags & PTHREADS_ACC_THREADLOCAL) != 0;
+} /* }}} */
+
+/* {{{ */
 zend_object* pthreads_thread_ctor(zend_class_entry *entry) {
 	pthreads_object_t* thread = pthreads_globals_object_alloc(
 		sizeof(pthreads_object_t) + zend_object_properties_size(entry));

--- a/src/object.c
+++ b/src/object.c
@@ -134,23 +134,7 @@ static void pthreads_routine_free(pthreads_routine_arg_t *r) {
 } /* }}} */
 
 /* {{{ */
-zend_bool pthreads_is_property_threadlocal(zval *object, zval *member) {
-	zend_object *zobj;
-	zval tmp_member;
-	zend_property_info *property_info;
-
-	zobj = Z_OBJ_P(object);
-
-	ZVAL_UNDEF(&tmp_member);
-	if (UNEXPECTED(Z_TYPE_P(member) != IS_STRING)) {
-		ZVAL_STR(&tmp_member, zval_get_string(member));
-		member = &tmp_member;
-	}
-	property_info = zend_get_property_info(zobj->ce, Z_STR_P(member), (zobj->ce->__set != NULL));
-
-	if (UNEXPECTED(Z_REFCOUNTED(tmp_member))) {
-		zval_ptr_dtor(&tmp_member);
-	}
+zend_bool pthreads_is_property_threadlocal(zend_property_info *property_info) {
 	return property_info != NULL && (property_info->flags & PTHREADS_ACC_THREADLOCAL) != 0;
 } /* }}} */
 
@@ -198,6 +182,18 @@ zend_object* pthreads_socket_ctor(zend_class_entry *entry) {
 	threaded->scope = PTHREADS_SCOPE_SOCKET;
 	pthreads_base_ctor(threaded, entry);
 	threaded->std.handlers = &pthreads_socket_handlers;
+
+	return &threaded->std;
+} /* }}} */
+
+/* {{{ */
+zend_object* pthreads_concurrent_ctor(zend_class_entry *entry) {
+	pthreads_object_t* threaded = pthreads_globals_object_alloc(
+			sizeof(pthreads_object_t) + zend_object_properties_size(entry));
+
+	threaded->scope = PTHREADS_SCOPE_THREADED;
+	pthreads_base_ctor(threaded, entry);
+	threaded->std.handlers = &pthreads_concurrent_handlers;
 
 	return &threaded->std;
 } /* }}} */

--- a/src/object.h
+++ b/src/object.h
@@ -27,6 +27,7 @@
 #endif
 
 /* {{{ */
+zend_bool pthreads_is_property_threadlocal(zval *object, zval *member);
 zend_object* pthreads_threaded_ctor(zend_class_entry *entry);
 zend_object* pthreads_worker_ctor(zend_class_entry *entry);
 zend_object* pthreads_thread_ctor(zend_class_entry *entry);

--- a/src/object.h
+++ b/src/object.h
@@ -27,11 +27,12 @@
 #endif
 
 /* {{{ */
-zend_bool pthreads_is_property_threadlocal(zval *object, zval *member);
+zend_bool pthreads_is_property_threadlocal(zend_property_info *property_info);
 zend_object* pthreads_threaded_ctor(zend_class_entry *entry);
 zend_object* pthreads_worker_ctor(zend_class_entry *entry);
 zend_object* pthreads_thread_ctor(zend_class_entry *entry);
 zend_object* pthreads_socket_ctor(zend_class_entry *entry);
+zend_object* pthreads_concurrent_ctor(zend_class_entry *entry);
 void         pthreads_base_free(zend_object *object);
 zend_object* pthreads_base_clone(zval *object);
 HashTable*   pthreads_base_gc(zval *object, zval **table, int *n); /* }}} */

--- a/src/prepare.c
+++ b/src/prepare.c
@@ -441,6 +441,7 @@ void prepare_class_postcompile(zend_class_entry *candidate) {
 		if (info->doc_comment &&
 				(strstr(ZSTR_VAL(info->doc_comment), "@thread_local") || strstr(ZSTR_VAL(info->doc_comment), "@threadLocal"))) {
 			info->flags |= PTHREADS_ACC_THREADLOCAL;
+			candidate->ce_flags |= PTHREADS_ACC_HAS_THREADLOCAL_PROP;
 		}
 	} ZEND_HASH_FOREACH_END();
 }

--- a/src/prepare.c
+++ b/src/prepare.c
@@ -433,6 +433,20 @@ static inline void pthreads_prepare_closures(pthreads_object_t *thread) {
 } /* }}} */
 
 /* {{{ */
+void prepare_class_postcompile(zend_class_entry *candidate) {
+	zend_property_info *info;
+	zend_string *name;
+
+	ZEND_HASH_FOREACH_STR_KEY_PTR(&candidate->properties_info, name, info) {
+		if (info->doc_comment &&
+				(strstr(ZSTR_VAL(info->doc_comment), "@thread_local") || strstr(ZSTR_VAL(info->doc_comment), "@threadLocal"))) {
+			info->flags |= PTHREADS_ACC_THREADLOCAL;
+		}
+	} ZEND_HASH_FOREACH_END();
+}
+/* }}} */
+
+/* {{{ */
 zend_class_entry* pthreads_prepared_entry(pthreads_object_t* thread, zend_class_entry *candidate) {
 	return pthreads_create_entry(thread, candidate, 1);
 } /* }}} */

--- a/src/prepare.c
+++ b/src/prepare.c
@@ -97,30 +97,6 @@ static void prepare_class_constants(pthreads_object_t* thread, zend_class_entry 
 } /* }}} */
 
 /* {{{ */
-static void prepare_class_statics(pthreads_object_t* thread, zend_class_entry *candidate, zend_class_entry *prepared) {
-	if (candidate->default_static_members_count) {
-		int i;
-
-		if(prepared->default_static_members_table != NULL) {
-			efree(prepared->default_static_members_table);
-		}
-		prepared->default_static_members_table = (zval*) ecalloc(
-			sizeof(zval), candidate->default_static_members_count);
-		prepared->default_static_members_count = candidate->default_static_members_count;
-		memcpy(prepared->default_static_members_table,
-		       candidate->default_static_members_table,
-			sizeof(zval) * candidate->default_static_members_count);
-
-		for (i=0; i<prepared->default_static_members_count; i++) {
-			pthreads_store_separate(
-				&candidate->default_static_members_table[i],
-				&prepared->default_static_members_table[i], 0);
-		}	
-		prepared->static_members_table = prepared->default_static_members_table;
-	} else prepared->default_static_members_count = 0;
-} /* }}} */
-
-/* {{{ */
 static void prepare_class_function_table(zend_class_entry *candidate, zend_class_entry *prepared) {
 
 	zend_string *key;
@@ -139,52 +115,81 @@ static void prepare_class_function_table(zend_class_entry *candidate, zend_class
 
 /* {{{ */
 static void prepare_class_property_table(pthreads_object_t* thread, zend_class_entry *candidate, zend_class_entry *prepared) {
-
-	zend_property_info *info;
+	zend_property_info *info, *dup;
 	zend_string *name;
-	ZEND_HASH_FOREACH_STR_KEY_PTR(&candidate->properties_info, name, info) {
-		zend_property_info dup = *info;
-		if (info->doc_comment) {
-			if (thread->options & PTHREADS_INHERIT_COMMENTS) {
-				dup.doc_comment = zend_string_new(info->doc_comment);
-			} else dup.doc_comment = NULL;
-		}
-
-		if (info->ce) {
-			if (info->ce == candidate) {
-				dup.ce = prepared;
-			} else dup.ce = pthreads_prepared_entry(thread, info->ce);
-		}
-
-		if (!zend_hash_str_add_mem(&prepared->properties_info, name->val, name->len, &dup, sizeof(zend_property_info))) {
-			if (dup.doc_comment)
-				zend_string_release(dup.doc_comment);
-		}
-	} ZEND_HASH_FOREACH_END();
+	pthreads_storage *storage;
+	pthreads_def_statics_t *def_statics = zend_hash_find_ptr(&PTHREADS_G(default_static_props), candidate->name);
 
 	if (candidate->default_properties_count) {
-		int i;
-
 		if(prepared->default_properties_table != NULL) {
 			efree(prepared->default_properties_table);
 		}
 		prepared->default_properties_table = emalloc(
 			sizeof(zval) * candidate->default_properties_count);
-
+		prepared->default_properties_count = candidate->default_properties_count;
 		memcpy(
 			prepared->default_properties_table,
 			candidate->default_properties_table,
 			sizeof(zval) * candidate->default_properties_count);
+	} else prepared->default_properties_count = 0;
 
-		for (i=0; i<candidate->default_properties_count; i++) {
-			if (Z_REFCOUNTED(prepared->default_properties_table[i])) {
-				pthreads_store_separate(
-					&candidate->default_properties_table[i],
-					&prepared->default_properties_table[i], 1);
+	if (candidate->default_static_members_count) {
+		if(prepared->default_static_members_table != NULL) {
+			efree(prepared->default_static_members_table);
+		}
+		prepared->default_static_members_table = (zval*) ecalloc(
+			sizeof(zval), candidate->default_static_members_count);
+		prepared->default_static_members_count = candidate->default_static_members_count;
+		memcpy(prepared->default_static_members_table,
+			   candidate->default_static_members_table,
+			sizeof(zval) * candidate->default_static_members_count);
+
+		prepared->static_members_table = prepared->default_static_members_table;
+	} else prepared->default_static_members_count = 0;
+
+	ZEND_HASH_FOREACH_STR_KEY_PTR(&candidate->properties_info, name, info) {
+		dup = zend_arena_alloc(&CG(arena), sizeof(zend_property_info));
+		memcpy(dup, info, sizeof(zend_property_info));
+
+		if (info->doc_comment) {
+			if (thread->options & PTHREADS_INHERIT_COMMENTS) {
+				dup->doc_comment = zend_string_new(info->doc_comment);
+			} else dup->doc_comment = NULL;
+		}
+
+		if (info->ce) {
+			if (info->ce == candidate) {
+				dup->ce = prepared;
+			} else dup->ce = pthreads_prepared_entry(thread, info->ce);
+		}
+
+		if(!zend_hash_update_ptr(&prepared->properties_info, name, dup)) {
+			if (dup->doc_comment)
+				zend_string_release(dup->doc_comment);
+		} else {
+			if(info->flags & ZEND_ACC_STATIC) {
+				if(def_statics && (storage = zend_hash_find_ptr(def_statics, name)) != NULL) {
+					// restore serialized default value of static property
+					pthreads_store_convert(storage, &prepared->default_static_members_table[info->offset]);
+				} else {
+					// fallback
+					pthreads_store_separate(
+						&candidate->default_static_members_table[info->offset],
+						&prepared->default_static_members_table[info->offset], 0);
+				}
+			} else if (Z_REFCOUNTED(prepared->default_properties_table[OBJ_PROP_TO_NUM(info->offset)])) {
+				if(!(info->flags & PTHREADS_ACC_THREADLOCAL)) {
+					// duplicate non-static property as usual
+					pthreads_store_separate(
+										&candidate->default_properties_table[OBJ_PROP_TO_NUM(info->offset)],
+										&prepared->default_properties_table[OBJ_PROP_TO_NUM(info->offset)], 1);
+				} else if(def_statics && (storage = zend_hash_find_ptr(def_statics, name)) != NULL) {
+					// property is thread local - restore serialized default value
+					pthreads_store_convert(storage, &prepared->default_properties_table[OBJ_PROP_TO_NUM(info->offset)]);
+				}
 			}
 		}
-		prepared->default_properties_count = candidate->default_properties_count;
-	} else prepared->default_properties_count = 0;
+	} ZEND_HASH_FOREACH_END();
 } /* }}} */
 
 /* {{{ */
@@ -436,14 +441,44 @@ static inline void pthreads_prepare_closures(pthreads_object_t *thread) {
 void prepare_class_postcompile(zend_class_entry *candidate) {
 	zend_property_info *info;
 	zend_string *name;
+	zval *property, tmp;
+	pthreads_def_statics_t *def_statics = NULL;
+
+	if(candidate->default_static_members_count > 0 || candidate->default_properties_count > 0) {
+		def_statics = (pthreads_def_statics_t*) calloc(1, sizeof(pthreads_def_statics_t));
+		zend_hash_init(def_statics, 4, NULL, NULL, 1);
+	}
 
 	ZEND_HASH_FOREACH_STR_KEY_PTR(&candidate->properties_info, name, info) {
 		if (info->doc_comment &&
 				(strstr(ZSTR_VAL(info->doc_comment), "@thread_local") || strstr(ZSTR_VAL(info->doc_comment), "@threadLocal"))) {
+			if(info->flags & ZEND_ACC_STATIC) {
+				// exception/warning
+			}
 			info->flags |= PTHREADS_ACC_THREADLOCAL;
 			candidate->ce_flags |= PTHREADS_ACC_HAS_THREADLOCAL_PROP;
 		}
+
+		if(def_statics != NULL && !zend_hash_exists(def_statics, name)) {
+			property = NULL;
+
+			if(info->flags & ZEND_ACC_STATIC) {
+				property = &candidate->default_static_members_table[info->offset];
+			} else if(info->flags & PTHREADS_ACC_THREADLOCAL) property = &candidate->default_properties_table[OBJ_PROP_TO_NUM(info->offset)];
+
+			if(property != NULL) {
+				ZVAL_PTR(&tmp, pthreads_store_create(property, 1));
+				zend_hash_add(def_statics, name, &tmp);
+			}
+		}
 	} ZEND_HASH_FOREACH_END();
+
+	if(def_statics != NULL) {
+		ZVAL_PTR(&tmp, def_statics);
+		zend_hash_add(
+				&PTHREADS_G(default_static_props),
+				candidate->name, &tmp);
+	}
 }
 /* }}} */
 
@@ -499,7 +534,6 @@ zend_class_entry* pthreads_create_entry(pthreads_object_t* thread, zend_class_en
 
 /* {{{ */
 void pthreads_prepared_entry_late_bindings(pthreads_object_t* thread, zend_class_entry *candidate, zend_class_entry *prepared) {
-	prepare_class_statics(thread, candidate, prepared);
 	prepare_class_constants(thread, candidate, prepared);
 } /* }}} */
 

--- a/src/prepare.h
+++ b/src/prepare.h
@@ -22,6 +22,8 @@
 #	include <src/pthreads.h>
 #endif
 
+typedef HashTable pthreads_def_statics_t;
+
 /* {{{ */
 void prepare_class_postcompile(zend_class_entry *candidate); /* }}} */
 

--- a/src/prepare.h
+++ b/src/prepare.h
@@ -22,6 +22,9 @@
 #	include <src/pthreads.h>
 #endif
 
+/* {{{ */
+void prepare_class_postcompile(zend_class_entry *candidate); /* }}} */
+
 /* {{{ fetch prepared class entry */
 zend_class_entry* pthreads_prepared_entry(pthreads_object_t* thread, zend_class_entry *candidate); /* }}} */
 

--- a/src/pthreads.h
+++ b/src/pthreads.h
@@ -84,6 +84,7 @@ extern zend_class_entry *spl_ce_Countable;
 extern zend_class_entry *pthreads_threaded_entry;
 extern zend_class_entry *pthreads_volatile_entry;
 extern zend_class_entry *pthreads_thread_entry;
+extern zend_class_entry *pthreads_concurrent_entry;
 extern zend_class_entry *pthreads_worker_entry;
 extern zend_class_entry *pthreads_socket_entry;
 

--- a/src/pthreads.h
+++ b/src/pthreads.h
@@ -138,6 +138,8 @@ ZEND_END_MODULE_GLOBALS(pthreads)
 #define PTHREADS_PG(ls, v) PTHREADS_FETCH_CTX(ls, core_globals_id, php_core_globals*, v)
 #define PTHREADS_EG_ALL(ls) PTHREADS_FETCH_ALL(ls, executor_globals_id, zend_executor_globals*)
 
+#define PTHREADS_ACC_THREADLOCAL 0x10
+
 static zend_string *zend_string_new(zend_string *s)
 {
 	if (ZSTR_IS_INTERNED(s)) {

--- a/src/pthreads.h
+++ b/src/pthreads.h
@@ -102,6 +102,11 @@ extern zend_class_entry *pthreads_socket_entry;
         (Z_TYPE_P(o) == IS_OBJECT && instanceof_function(Z_OBJCE_P(o), pthreads_volatile_entry))
 #endif
 
+#ifndef IS_PTHREADS_CONCURRENT
+#define IS_PTHREADS_CONCURRENT(o)   \
+        (Z_TYPE_P(o) == IS_OBJECT && instanceof_function(Z_OBJCE_P(o), pthreads_concurrent_entry))
+#endif
+
 #ifndef IS_PTHREADS_CLOSURE
 #define IS_PTHREADS_CLOSURE(z) \
 	(Z_TYPE_P(z) == IS_OBJECT && instanceof_function(Z_OBJCE_P(z), zend_ce_closure))
@@ -109,6 +114,7 @@ extern zend_class_entry *pthreads_socket_entry;
 
 extern zend_object_handlers pthreads_handlers;
 extern zend_object_handlers pthreads_socket_handlers;
+extern zend_object_handlers pthreads_concurrent_handlers;
 extern zend_object_handlers *zend_handlers;
 
 extern struct _pthreads_globals pthreads_globals;

--- a/src/pthreads.h
+++ b/src/pthreads.h
@@ -147,6 +147,8 @@ ZEND_END_MODULE_GLOBALS(pthreads)
 
 #define PTHREADS_ACC_THREADLOCAL 0x10
 
+#define PTHREADS_ACC_HAS_THREADLOCAL_PROP 0x20000000
+
 static zend_string *zend_string_new(zend_string *s)
 {
 	if (ZSTR_IS_INTERNED(s)) {

--- a/src/store.c
+++ b/src/store.c
@@ -118,7 +118,7 @@ static inline zend_bool pthreads_store_is_immutable(zval *object, zval *key) {
 	pthreads_object_t *threaded = PTHREADS_FETCH_FROM(Z_OBJ_P(object));
 	pthreads_storage *storage;
 
-	if (IS_PTHREADS_VOLATILE(object)) {
+	if (IS_PTHREADS_VOLATILE(object) || IS_PTHREADS_CONCURRENT(object)) {
 		return 0;
 	}
 
@@ -250,7 +250,7 @@ int pthreads_store_read(zval *object, zval *key, int type, zval *read) {
 		property = zend_hash_index_find(threaded->std.properties, Z_LVAL(member));
 	} else property = zend_hash_find(threaded->std.properties, Z_STR(member));
 
-	if (property && IS_PTHREADS_VOLATILE(object)) {
+	if (property && (IS_PTHREADS_VOLATILE(object) || IS_PTHREADS_CONCURRENT(object))) {
 		if (pthreads_monitor_lock(threaded->monitor)) {
 			pthreads_storage *storage;
 
@@ -373,7 +373,7 @@ int pthreads_store_write(zval *object, zval *key, zval *write) {
 			*/
 			rebuild_object_properties(&threaded->std);
 			
-			if(IS_PTHREADS_VOLATILE(object)) {
+			if(IS_PTHREADS_VOLATILE(object) || IS_PTHREADS_CONCURRENT(object)) {
 				pthreads_store_sync(object);
 			}
 
@@ -569,7 +569,7 @@ void pthreads_store_tohash(zval *object, HashTable *hash) {
 			zend_string *rename;
 
 			/* don't overwrite pthreads objects for non volatile objects */
-			if (!IS_PTHREADS_VOLATILE(object) && storage->type == IS_PTHREADS) {
+			if (!IS_PTHREADS_VOLATILE(object) && !IS_PTHREADS_CONCURRENT(object) && storage->type == IS_PTHREADS) {
 				if (!name) {
 					if (zend_hash_index_exists(hash, idx))
 						continue;

--- a/src/store.c
+++ b/src/store.c
@@ -38,22 +38,13 @@
 #	include <src/copy.h>
 #endif
 
-typedef struct _pthreads_storage {
-	zend_uchar 	type;
-	size_t 	length;
-	zend_bool 	exists;
-	union {
-	    zend_long   lval;
-	    double     dval;
-	} simple;
-	void    	*data;
-} pthreads_storage;
+#ifndef HAVE_PTHREADS_STORE_H
+#	include <src/store.h>
+#endif
 
 #define PTHREADS_STORAGE_EMPTY {0, 0, 0, 0, NULL}
 
 /* {{{ */
-static pthreads_storage* pthreads_store_create(zval *pzval, zend_bool complex);
-static int pthreads_store_convert(pthreads_storage *storage, zval *pzval);
 static int pthreads_store_tostring(zval *pzval, char **pstring, size_t *slength, zend_bool complex);
 static int pthreads_store_tozval(zval *pzval, char *pstring, size_t slength);
 static void pthreads_store_storage_dtor (pthreads_storage *element);
@@ -606,7 +597,7 @@ void pthreads_store_free(pthreads_store_t *store){
 } /* }}} */
 
 /* {{{ */
-static pthreads_storage* pthreads_store_create(zval *unstore, zend_bool complex){					
+pthreads_storage* pthreads_store_create(zval *unstore, zend_bool complex){
 	pthreads_storage *storage = NULL;
 
 	if (Z_TYPE_P(unstore) == IS_INDIRECT)
@@ -677,7 +668,7 @@ static pthreads_storage* pthreads_store_create(zval *unstore, zend_bool complex)
 /* }}} */
 
 /* {{{ */
-static int pthreads_store_convert(pthreads_storage *storage, zval *pzval){
+int pthreads_store_convert(pthreads_storage *storage, zval *pzval){
 	int result = SUCCESS;
 
 	switch(storage->type) {

--- a/src/store.h
+++ b/src/store.h
@@ -27,6 +27,17 @@
 
 typedef HashTable pthreads_store_t;
 
+typedef struct _pthreads_storage {
+	zend_uchar 	type;
+	size_t 	length;
+	zend_bool 	exists;
+	union {
+	    zend_long   lval;
+	    double     dval;
+	} simple;
+	void    	*data;
+} pthreads_storage;
+
 pthreads_store_t* pthreads_store_alloc();
 void pthreads_store_sync(zval *object);
 int pthreads_store_merge(zval *destination, zval *from, zend_bool overwrite);
@@ -42,6 +53,8 @@ int pthreads_store_chunk(zval *object, zend_long size, zend_bool preserve, zval 
 int pthreads_store_pop(zval *object, zval *member);
 int pthreads_store_count(zval *object, zend_long *count);
 void pthreads_store_free(pthreads_store_t *store);
+pthreads_storage* pthreads_store_create(zval *unstore, zend_bool complex);
+int pthreads_store_convert(pthreads_storage *storage, zval *pzval);
 
 /* {{{ * iteration helpers */
 void pthreads_store_reset(zval *object, HashPosition *position);


### PR DESCRIPTION
Introduction of Concurrent class. This new mutable class features property visibility, a thread-local annotation(```@thread_local```), ArrayAccess callback support and proper __get/__set/__isset/__unset handling.

Additionally this PR fixes #861, however with a BC break. Copying of static properties is confined to only default values and not assigned values. 