### PR TITLE
Streams support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .project
+*.lo

--- a/classes/filestream.h
+++ b/classes/filestream.h
@@ -1,0 +1,918 @@
+/*
+  +----------------------------------------------------------------------+
+  | pthreads                                                             |
+  +----------------------------------------------------------------------+
+  | Copyright (c) Joe Watkins 2018                                       |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | http://www.php.net/license/3_01.txt                                  |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors: Bastian Schneider <b.schneider@badnoob.com>                 |
+  +----------------------------------------------------------------------+
+ */
+#ifndef HAVE_PTHREADS_CLASS_FILESTREAM_H
+#define HAVE_PTHREADS_CLASS_FILESTREAM_H
+
+// FileStream
+/* {{{ */
+static PHP_METHOD(FileStream, __construct) {
+	zend_throw_error(NULL, "Instantiation of 'FileStream' is not allowed");
+} /* }}} */
+PHP_METHOD(FileStream, lock);
+PHP_METHOD(FileStream, close);
+PHP_METHOD(FileStream, pclose);
+PHP_METHOD(FileStream, eof);
+PHP_METHOD(FileStream, gets);
+PHP_METHOD(FileStream, getc);
+PHP_METHOD(FileStream, getss);
+PHP_METHOD(FileStream, scanf);
+PHP_METHOD(FileStream, write);
+PHP_METHOD(FileStream, flush);
+PHP_METHOD(FileStream, rewind);
+PHP_METHOD(FileStream, tell);
+PHP_METHOD(FileStream, seek);
+PHP_METHOD(FileStream, passthru);
+PHP_METHOD(FileStream, truncate);
+PHP_METHOD(FileStream, stat);
+PHP_METHOD(FileStream, read);
+PHP_METHOD(FileStream, putcsv);
+PHP_METHOD(FileStream, getcsv);
+
+// File
+/* {{{ */
+static PHP_METHOD(File, __construct) {
+	zend_throw_error(NULL, "Instantiation of 'File' is not allowed");
+} /* }}} */
+PHP_METHOD(File, open);
+PHP_METHOD(File, popen);
+PHP_METHOD(File, getMetaTags);
+PHP_METHOD(File, getContents);
+PHP_METHOD(File, putContents);
+PHP_METHOD(File, file);
+PHP_METHOD(File, tempName);
+PHP_METHOD(File, tempFile);
+PHP_METHOD(File, mkdir);
+PHP_METHOD(File, rmdir);
+PHP_METHOD(File, readfile);
+PHP_METHOD(File, rename);
+PHP_METHOD(File, unlink);
+PHP_METHOD(File, copy);
+PHP_METHOD(File, sockopen);
+
+/**
+ * FileStream
+ */
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(FileStream_lock, 0, 1, _IS_BOOL, 0)
+	ZEND_ARG_TYPE_INFO(0, operation, IS_LONG, 0)
+	ZEND_ARG_INFO(1, wouldblock)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(FileStream_close, 0, 0, _IS_BOOL, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(FileStream_pclose, 0, 0, _IS_BOOL, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(FileStream_eof, 0, 0, _IS_BOOL, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(FileStream_gets, 0, 0, IS_STRING, 1)
+	ZEND_ARG_TYPE_INFO(0, length, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(FileStream_getc, 0, 0, IS_STRING, 1)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(FileStream_getss, 0, 0, IS_STRING, 1)
+	ZEND_ARG_TYPE_INFO(0, length, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, allowable_tags, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(FileStream_scanf, 0, 0, 1)
+	ZEND_ARG_TYPE_INFO(0, format, IS_STRING, 0)
+	ZEND_ARG_VARIADIC_INFO(0, args)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(FileStream_write, 0, 1, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, input, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, maxlen, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(FileStream_flush, 0, 0, _IS_BOOL, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(FileStream_rewind, 0, 0, _IS_BOOL, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(FileStream_tell, 0, 0, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(FileStream_seek, 0, 1, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, offset, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, whence, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(FileStream_passthru, 0, 0, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(FileStream_truncate, 0, 0, _IS_BOOL, 0)
+	ZEND_ARG_TYPE_INFO(0, size, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(FileStream_stat, 0, 0, IS_ARRAY, 1)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(FileStream_read, 0, 1, IS_STRING, 1)
+	ZEND_ARG_TYPE_INFO(0, length, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(FileStream_putcsv, 0, 1, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, fields, IS_ARRAY, 0)
+	ZEND_ARG_TYPE_INFO(0, delimiter, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, enclosure, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, escape_char, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(FileStream_getcsv, 0, 0, IS_ARRAY, 1)
+	ZEND_ARG_INFO(0, length)
+	ZEND_ARG_TYPE_INFO(0, delimiter, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, enclosure, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, escape_char, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
+/**
+ * File
+ */
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(File_getMetaTags, 0, 1, IS_ARRAY, 1)
+	ZEND_ARG_TYPE_INFO(0, filename, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, use_include_path, _IS_BOOL, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(File_getContents, 0, 1, IS_STRING, 1)
+	ZEND_ARG_TYPE_INFO(0, filename, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, use_include_path, _IS_BOOL, 0)
+	ZEND_ARG_OBJ_INFO(0, context, StreamContext, 1)
+	ZEND_ARG_TYPE_INFO(0, offset, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, maxlen, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(File_putContents, 0, 2, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, filename, IS_STRING, 0)
+	ZEND_ARG_INFO(0, data)
+	ZEND_ARG_TYPE_INFO(0, flags, IS_LONG, 0)
+	ZEND_ARG_OBJ_INFO(0, context, StreamContext, 1)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(File_file, 0, 1, IS_ARRAY, 1)
+	ZEND_ARG_TYPE_INFO(0, filename, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, flags, IS_LONG, 0)
+	ZEND_ARG_OBJ_INFO(0, context, StreamContext, 1)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(File_tempName, 0, 2, IS_STRING, 1)
+	ZEND_ARG_TYPE_INFO(0, dir, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, prefix, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(File_tempFile, 0, 0, FileStream, 1)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(File_open, 0, 2, FileStream, 1)
+	ZEND_ARG_TYPE_INFO(0, filename, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, mode, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, use_include_path, _IS_BOOL, 0)
+	ZEND_ARG_OBJ_INFO(0, context, StreamContext, 1)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(File_popen, 0, 2, FileStream, 1)
+	ZEND_ARG_TYPE_INFO(0, filename, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, mode, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(File_mkdir, 0, 1, _IS_BOOL, 0)
+	ZEND_ARG_TYPE_INFO(0, pathname, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, mode, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, recursive, _IS_BOOL, 0)
+	ZEND_ARG_OBJ_INFO(0, context, StreamContext, 1)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(File_rmdir, 0, 1, _IS_BOOL, 0)
+	ZEND_ARG_TYPE_INFO(0, pathname, IS_STRING, 0)
+	ZEND_ARG_OBJ_INFO(0, context, StreamContext, 1)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(File_readfile, 0, 1, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, pathname, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, use_include_path, _IS_BOOL, 0)
+	ZEND_ARG_OBJ_INFO(0, context, StreamContext, 1)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(File_rename, 0, 2, _IS_BOOL, 0)
+	ZEND_ARG_TYPE_INFO(0, old_name, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, new_name, IS_STRING, 0)
+	ZEND_ARG_OBJ_INFO(0, context, StreamContext, 1)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(File_unlink, 0, 1, _IS_BOOL, 0)
+	ZEND_ARG_TYPE_INFO(0, filename, IS_STRING, 0)
+	ZEND_ARG_OBJ_INFO(0, context, StreamContext, 1)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(File_copy, 0, 2, _IS_BOOL, 0)
+	ZEND_ARG_TYPE_INFO(0, source_file, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, destination_file, IS_STRING, 0)
+	ZEND_ARG_OBJ_INFO(0, context, StreamContext, 1)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(File_sockopen, 0, 1, FileStream, 1)
+	ZEND_ARG_TYPE_INFO(0, hostname, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, port, IS_LONG, 0)
+	ZEND_ARG_INFO(1, errno)
+	ZEND_ARG_INFO(1, errstr)
+	ZEND_ARG_TYPE_INFO(0, timeout, IS_DOUBLE, 0)
+ZEND_END_ARG_INFO()
+
+extern zend_function_entry pthreads_streams_file_stream_methods[];
+extern zend_function_entry pthreads_file_methods[];
+#else
+#	ifndef HAVE_PTHREADS_CLASS_FILESTREAM
+#	define HAVE_PTHREADS_CLASS_FILESTREAM
+
+zend_function_entry pthreads_streams_file_stream_methods[] = {
+	PHP_ME(FileStream, __construct  , NULL				    , ZEND_ACC_PRIVATE)
+	PHP_ME(FileStream, lock         , FileStream_lock       , ZEND_ACC_PUBLIC)
+	PHP_ME(FileStream, close        , FileStream_close      , ZEND_ACC_PUBLIC)
+	PHP_ME(FileStream, pclose       , FileStream_pclose     , ZEND_ACC_PUBLIC)
+	PHP_ME(FileStream, eof          , FileStream_eof        , ZEND_ACC_PUBLIC)
+	PHP_ME(FileStream, gets         , FileStream_gets       , ZEND_ACC_PUBLIC)
+	PHP_ME(FileStream, getc         , FileStream_getc       , ZEND_ACC_PUBLIC)
+	PHP_ME(FileStream, getss        , FileStream_getss      , ZEND_ACC_PUBLIC)
+	PHP_ME(FileStream, scanf        , FileStream_scanf      , ZEND_ACC_PUBLIC)
+	PHP_ME(FileStream, write        , FileStream_write      , ZEND_ACC_PUBLIC)
+	PHP_ME(FileStream, flush        , FileStream_flush      , ZEND_ACC_PUBLIC)
+	PHP_ME(FileStream, rewind       , FileStream_rewind     , ZEND_ACC_PUBLIC)
+	PHP_ME(FileStream, tell         , FileStream_tell       , ZEND_ACC_PUBLIC)
+	PHP_ME(FileStream, seek         , FileStream_seek       , ZEND_ACC_PUBLIC)
+	PHP_ME(FileStream, passthru     , FileStream_passthru   , ZEND_ACC_PUBLIC)
+	PHP_ME(FileStream, truncate     , FileStream_truncate   , ZEND_ACC_PUBLIC)
+	PHP_ME(FileStream, stat         , FileStream_stat       , ZEND_ACC_PUBLIC)
+	PHP_ME(FileStream, read         , FileStream_read       , ZEND_ACC_PUBLIC)
+	PHP_ME(FileStream, putcsv       , FileStream_putcsv     , ZEND_ACC_PUBLIC)
+	PHP_ME(FileStream, getcsv       , FileStream_getcsv     , ZEND_ACC_PUBLIC)
+	PHP_FE_END
+};
+
+zend_function_entry pthreads_file_methods[] = {
+	PHP_ME(File, __construct    , NULL                  , ZEND_ACC_PRIVATE)
+	PHP_ME(File, open           , File_open             , ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
+	PHP_ME(File, popen          , File_popen            , ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
+	PHP_ME(File, getMetaTags    , File_getMetaTags      , ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
+	PHP_ME(File, getContents    , File_getContents      , ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
+	PHP_ME(File, putContents    , File_putContents      , ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
+	PHP_ME(File, file           , File_file             , ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
+	PHP_ME(File, tempName       , File_tempName         , ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
+	PHP_ME(File, tempFile       , File_tempFile         , ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
+	PHP_ME(File, mkdir          , File_mkdir            , ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
+	PHP_ME(File, rmdir          , File_rmdir            , ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
+	PHP_ME(File, readfile       , File_readfile         , ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
+	PHP_ME(File, rename         , File_rename           , ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
+	PHP_ME(File, unlink         , File_unlink           , ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
+	PHP_ME(File, copy           , File_copy             , ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
+	PHP_ME(File, sockopen       , File_sockopen         , ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
+	PHP_FE_END
+};
+
+/**
+ *
+ * FileStream
+ *
+ */
+
+/* {{{ proto bool FileStream::lock(int operation [, int &wouldblock])
+   Portable file locking */
+PHP_METHOD(FileStream, lock) {
+	zval *wouldblock = NULL;
+	int act;
+	zend_long operation = 0;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "l|z/", &operation, &wouldblock) != SUCCESS) {
+		RETURN_FALSE;
+	}
+
+	act = operation & 3;
+	if (act < 1 || act > 3) {
+		php_error_docref(NULL, E_WARNING, "Illegal operation argument");
+		RETURN_FALSE;
+	}
+
+	pthreads_streams_api_filestream_lock(getThis(), act, operation, wouldblock, return_value);
+
+} /* }}} */
+
+/* {{{ proto bool FileStream::close(void)
+   Close an open file pointer */
+PHP_METHOD(FileStream, close) {
+
+	if (zend_parse_parameters_none() == FAILURE) {
+		RETURN_FALSE;
+	}
+
+	pthreads_streams_api_filestream_close(getThis(), return_value);
+} /* }}} */
+
+/* {{{ proto bool FileStream::pclose(void)
+   Close a file pointer opened by File::popen() */
+PHP_METHOD(FileStream, pclose) {
+
+	if (zend_parse_parameters_none() == FAILURE) {
+		RETURN_FALSE;
+	}
+
+	pthreads_streams_api_filestream_pclose(getThis(), return_value);
+} /* }}} */
+
+/* {{{ proto bool FileStream::eof(void)
+   Test for end-of-file on a file pointer */
+PHP_METHOD(FileStream, eof) {
+
+	if (zend_parse_parameters_none() == FAILURE) {
+		RETURN_FALSE;
+	}
+
+	pthreads_streams_api_filestream_eof(getThis(), return_value);
+} /* }}} */
+
+/* {{{ proto string|null FileStream::gets([int length])
+   Get a line from file pointer */
+PHP_METHOD(FileStream, gets) {
+	zend_long len = 1024;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "|l", &len) != SUCCESS) {
+		RETURN_NULL();
+	}
+
+	pthreads_streams_api_filestream_gets(getThis(), ZEND_NUM_ARGS(), len, return_value);
+} /* }}} */
+
+/* {{{ proto string|null FileStream::getc()
+   Get a character from file pointer */
+PHP_METHOD(FileStream, getc) {
+	if (zend_parse_parameters_none() == FAILURE) {
+		RETURN_NULL();
+	}
+
+	pthreads_streams_api_filestream_getc(getThis(), return_value);
+} /* }}} */
+
+/* {{{ proto string|null FileStream::fgetss([int length [, string allowable_tags]])
+   Get a line from file pointer and strip HTML tags */
+PHP_METHOD(FileStream, getss) {
+	zend_long bytes = 1024;
+	zend_string *allowed_tags;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "|lS", &bytes, &allowed_tags) != SUCCESS) {
+		RETURN_NULL();
+	}
+
+	pthreads_streams_api_filestream_getss(getThis(), ZEND_NUM_ARGS(), bytes, allowed_tags, return_value);
+} /* }}} */
+
+/* {{{ proto mixed FileStream::scanf(string format [, string ...])
+   Implements a mostly ANSI compatible fscanf() */
+PHP_METHOD(FileStream, scanf) {
+	zval *args = NULL;
+	int argc = 0;
+	zend_string *format;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "S|*", &format, &args, &argc) != SUCCESS) {
+		RETURN_NULL();
+	}
+
+	pthreads_streams_api_filestream_scanf(getThis(), format, args, argc, return_value);
+} /* }}} */
+
+/* {{{ proto int FileStream::write(string str [, int length])
+   Binary-safe file write */
+PHP_METHOD(FileStream, write) {
+	zend_long maxlen = 0;
+	zend_string *input;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "S|l", &input, &maxlen) != SUCCESS) {
+		RETURN_LONG(-1);
+	}
+
+	pthreads_streams_api_filestream_write(getThis(), ZEND_NUM_ARGS(), input, maxlen, return_value);
+} /* }}} */
+
+/* {{{ proto bool FileStream::flush()
+   Flushes output */
+PHP_METHOD(FileStream, flush) {
+	if (zend_parse_parameters_none() == FAILURE) {
+		RETURN_FALSE;
+	}
+
+	pthreads_streams_api_filestream_flush(getThis(), return_value);
+} /* }}} */
+
+/* {{{ proto bool FileStream::rewind()
+   Rewind the position of a file pointer */
+PHP_METHOD(FileStream, rewind) {
+	if (zend_parse_parameters_none() == FAILURE) {
+		RETURN_FALSE;
+	}
+
+	pthreads_streams_api_filestream_rewind(getThis(), return_value);
+} /* }}} */
+
+/* {{{ proto int FileStream::tell()
+   Get file pointer's read/write position */
+PHP_METHOD(FileStream, tell) {
+	if (zend_parse_parameters_none() == FAILURE) {
+		RETURN_LONG(-1);
+	}
+
+	pthreads_streams_api_filestream_tell(getThis(), return_value);
+} /* }}} */
+
+/* {{{ proto int FileStream::seek(int offset [, int whence])
+   Seek on a file pointer */
+PHP_METHOD(FileStream, seek) {
+	zend_long offset = 0, whence = SEEK_SET;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "l|l", &offset, &whence) != SUCCESS) {
+		RETURN_LONG(-1);
+	}
+
+	pthreads_streams_api_filestream_seek(getThis(), offset, whence, return_value);
+} /* }}} */
+
+/* {{{ proto int FileStream::passthru()
+   Output all remaining data from a file pointer */
+PHP_METHOD(FileStream, passthru) {
+	if (zend_parse_parameters_none() == FAILURE) {
+		RETURN_LONG(-1);
+	}
+
+	pthreads_streams_api_filestream_passthru(getThis(), return_value);
+} /* }}} */
+
+/* {{{ proto bool FileStream::truncate(int size)
+   Truncate file to 'size' length */
+PHP_METHOD(FileStream, truncate) {
+	zend_long size;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "l", &size) != SUCCESS) {
+		RETURN_FALSE;
+	}
+
+	if (size < 0) {
+		php_error_docref(NULL, E_WARNING, "Negative size is not supported");
+		RETURN_FALSE;
+	}
+
+	pthreads_streams_api_filestream_truncate(getThis(), size, return_value);
+} /* }}} */
+
+/* {{{ proto array|null FileStream::stat()
+   Stat() on a filehandle */
+PHP_METHOD(FileStream, stat) {
+	if (zend_parse_parameters_none() == FAILURE) {
+		RETURN_NULL();
+	}
+
+	pthreads_streams_api_filestream_stat(getThis(), return_value);
+} /* }}} */
+
+/* {{{ proto string|null FileStream::read(int length)
+   Binary-safe file read */
+PHP_METHOD(FileStream, read) {
+	zend_long length;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "l", &length) != SUCCESS) {
+		RETURN_NULL();
+	}
+
+	if (length <= 0) {
+		php_error_docref(NULL, E_WARNING, "Length parameter must be greater than 0");
+		RETURN_NULL();
+	}
+
+	pthreads_streams_api_filestream_read(getThis(), length, return_value);
+} /* }}} */
+
+/* {{{ proto int FileStream::putcsv(array fields [, string delimiter [, string enclosure [, string escape_char]]])
+   Format line as CSV and write to file pointer */
+PHP_METHOD(FileStream, putcsv) {
+
+	char delimiter = ',';	 /* allow this to be set as parameter */
+	char enclosure = '"';	 /* allow this to be set as parameter */
+	char escape_char = '\\'; /* allow this to be set as parameter */
+
+	zval *fields = NULL;
+	zend_string *delimiter_str = NULL, *enclosure_str = NULL, *escape_str = NULL;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "A|SSS", &fields, &delimiter_str, enclosure_str, escape_str) != SUCCESS) {
+		RETURN_NULL();
+	}
+
+	if (delimiter_str != NULL) {
+		/* Make sure that there is at least one character in string */
+		if (ZSTR_LEN(delimiter_str) < 1) {
+			php_error_docref(NULL, E_WARNING, "delimiter must be a character");
+			RETURN_FALSE;
+		} else if (ZSTR_LEN(delimiter_str) > 1) {
+			php_error_docref(NULL, E_NOTICE, "delimiter must be a single character");
+		}
+
+		/* use first character from string */
+		delimiter = ZSTR_VAL(delimiter_str)[0];
+	}
+
+	if (enclosure_str != NULL) {
+		if (ZSTR_LEN(enclosure_str) < 1) {
+			php_error_docref(NULL, E_WARNING, "enclosure must be a character");
+			RETURN_FALSE;
+		} else if (ZSTR_LEN(enclosure_str) > 1) {
+			php_error_docref(NULL, E_NOTICE, "enclosure must be a single character");
+		}
+		/* use first character from string */
+		enclosure = ZSTR_VAL(enclosure_str)[0];
+	}
+
+	if (escape_str != NULL) {
+		if (ZSTR_LEN(escape_str) < 1) {
+			php_error_docref(NULL, E_WARNING, "escape must be a character");
+			RETURN_FALSE;
+		} else if (ZSTR_LEN(escape_str) > 1) {
+			php_error_docref(NULL, E_NOTICE, "escape must be a single character");
+		}
+		/* use first character from string */
+		escape_char = ZSTR_VAL(escape_str)[0];
+	}
+
+	pthreads_streams_api_filestream_putcsv(getThis(), fields, delimiter, enclosure, escape_char, return_value);
+} /* }}} */
+
+/* {{{ proto array|null FileStream::getcsv([,int length [, string delimiter [, string enclosure [, string escape]]]])
+   Format line as CSV and write to file pointer */
+PHP_METHOD(FileStream, getcsv) {
+
+	char delimiter = ',';	 /* allow this to be set as parameter */
+	char enclosure = '"';	 /* allow this to be set as parameter */
+	char escape_char = '\\'; /* allow this to be set as parameter */
+
+	zend_long len = 0;
+	zval *len_zv = NULL;
+	zend_string *delimiter_str = NULL, *enclosure_str = NULL, *escape_str = NULL;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "|zSSS", &len_zv, &delimiter_str, &enclosure_str, &escape_str) != SUCCESS) {
+		RETURN_NULL();
+	}
+
+	if (delimiter_str != NULL) {
+		/* Make sure that there is at least one character in string */
+		if (ZSTR_LEN(delimiter_str) < 1) {
+			php_error_docref(NULL, E_WARNING, "delimiter must be a character");
+			RETURN_FALSE;
+		} else if (ZSTR_LEN(delimiter_str) > 1) {
+			php_error_docref(NULL, E_NOTICE, "delimiter must be a single character");
+		}
+
+		/* use first character from string */
+		delimiter = ZSTR_VAL(delimiter_str)[0];
+	}
+
+	if (enclosure_str != NULL) {
+		if (ZSTR_LEN(enclosure_str) < 1) {
+			php_error_docref(NULL, E_WARNING, "enclosure must be a character");
+			RETURN_FALSE;
+		} else if (ZSTR_LEN(enclosure_str) > 1) {
+			php_error_docref(NULL, E_NOTICE, "enclosure must be a single character");
+		}
+		/* use first character from string */
+		enclosure = ZSTR_VAL(enclosure_str)[0];
+	}
+
+	if (escape_str != NULL) {
+		if (ZSTR_LEN(escape_str) < 1) {
+			php_error_docref(NULL, E_WARNING, "escape must be a character");
+			RETURN_FALSE;
+		} else if (ZSTR_LEN(escape_str) > 1) {
+			php_error_docref(NULL, E_NOTICE, "escape must be a single character");
+		}
+		/* use first character from string */
+		escape_char = ZSTR_VAL(escape_str)[0];
+	}
+
+	if (len_zv != NULL && Z_TYPE_P(len_zv) != IS_NULL) {
+		len = zval_get_long(len_zv);
+		if (len < 0) {
+			php_error_docref(NULL, E_WARNING, "Length parameter may not be negative");
+			RETURN_FALSE;
+		} else if (len == 0) {
+			len = -1;
+		}
+	} else {
+		len = -1;
+	}
+
+	pthreads_streams_api_filestream_getcsv(getThis(), len, delimiter, enclosure, escape_char, return_value);
+}
+
+
+/**
+ *
+ * File
+ *
+ */
+
+/* {{{ proto array|null File::getMetaTags(string filename [, bool use_include_path])
+   Extracts all meta tag content attributes from a file and returns an array */
+PHP_METHOD(File, getMetaTags) {
+	zend_string *filename;
+	zend_bool use_include_path = 0;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "S|b", &filename, &use_include_path) != SUCCESS) {
+		RETURN_NULL();
+	}
+
+	pthreads_streams_api_file_get_meta_data(filename, use_include_path, return_value);
+} /* }}} */
+
+/* {{{ proto string|null File::getContents(string filename [, bool use_include_path [, StreamContext context [, int offset [, int maxlen]]]])
+   Read the entire file into a string */
+PHP_METHOD(File, getContents) {
+	zend_string *filename;
+	zend_bool use_include_path = 0;
+	zend_long offset = 0;
+	zend_long maxlen = (ssize_t) PTHREADS_STREAM_COPY_ALL;
+	zval *zcontext = NULL;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "S|bOll", &filename, &use_include_path, &zcontext, pthreads_stream_context_entry, &offset, &maxlen) != SUCCESS) {
+		RETURN_NULL();
+	}
+
+	if (zcontext != NULL && !Z_ISNULL_P(zcontext)  && !instanceof_function(Z_OBJCE_P(zcontext), pthreads_stream_context_entry)) {
+		zend_throw_exception_ex(spl_ce_RuntimeException,
+			0, "only StreamContext objects may be submitted, %s is no StreamContext",
+			ZSTR_VAL(Z_OBJCE_P(zcontext)->name));
+		RETURN_NULL();
+	}
+
+	if (ZEND_NUM_ARGS() == 5 && maxlen < 0) {
+		php_error_docref(NULL, E_WARNING, "length must be greater than or equal to zero");
+		RETURN_NULL();
+	}
+
+	pthreads_streams_api_file_get_contents(filename, use_include_path, zcontext, offset, maxlen, return_value);
+} /* }}} */
+
+/* {{{ proto int|null File::putContents(string file, mixed data [, int flags [, StreamContext context]])
+   Write/Create a file with contents data and return the number of bytes written */
+PHP_METHOD(File, putContents) {
+	zend_string *filename;
+	zval *data;
+	zend_long flags = 0;
+	zend_long maxlen = (ssize_t) PTHREADS_STREAM_COPY_ALL;
+	zval *zcontext = NULL;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "Sz|lO", &filename, &data, &flags, &zcontext, pthreads_stream_context_entry) != SUCCESS) {
+		RETURN_LONG(0);
+	}
+
+	if (zcontext != NULL && !Z_ISNULL_P(zcontext)  && !instanceof_function(Z_OBJCE_P(zcontext), pthreads_stream_context_entry)) {
+		zend_throw_exception_ex(spl_ce_RuntimeException,
+			0, "only StreamContext objects may be submitted, %s is no StreamContext",
+			ZSTR_VAL(Z_OBJCE_P(zcontext)->name));
+		RETURN_LONG(0);
+	}
+
+	pthreads_streams_api_file_put_contents(ZSTR_VAL(filename), ZSTR_LEN(filename), data, flags, zcontext, return_value);
+} /* }}} */
+
+/* {{{ proto array|null File::file(string filename [, int flags[, resource context]])
+   Read entire file into an array */
+PHP_METHOD(File, file) {
+	zend_string *filename;
+	zend_long flags = 0;
+	zval *zcontext = NULL;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "S|lO", &filename, &flags, &zcontext, pthreads_stream_context_entry) != SUCCESS) {
+		RETURN_NULL();
+	}
+
+	if (zcontext != NULL && !Z_ISNULL_P(zcontext)  && !instanceof_function(Z_OBJCE_P(zcontext), pthreads_stream_context_entry)) {
+		zend_throw_exception_ex(spl_ce_RuntimeException,
+			0, "only StreamContext objects may be submitted, %s is no StreamContext",
+			ZSTR_VAL(Z_OBJCE_P(zcontext)->name));
+		RETURN_NULL();
+	}
+
+	pthreads_streams_api_file_file(ZSTR_VAL(filename), flags, zcontext, return_value);
+} /* }}} */
+
+/* {{{ proto string|null File::tempName(string dir, string prefix)
+   Create a unique filename in a directory */
+PHP_METHOD(File, tempName) {
+	char *dir, *prefix;
+	size_t dir_len, prefix_len;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "pp", &dir, &dir_len, &prefix, &prefix_len) != SUCCESS) {
+		RETURN_NULL();
+	}
+
+	pthreads_streams_api_file_temp_name(dir, prefix, prefix_len, return_value);
+} /* }}} */
+
+/* {{{ proto FileStream|null File::tempFile(void)
+   Create a temporary file that will be deleted automatically after use */
+PHP_METHOD(File, tempFile) {
+
+	if (zend_parse_parameters_none() == FAILURE) {
+		RETURN_NULL();
+	}
+
+	pthreads_streams_api_file_temp_file(return_value);
+} /* }}} */
+
+/* {{{ proto static FileStream|null File::open(string filename, string mode [, bool use_include_path [, resource context]])
+   Open a file or a URL and return a file pointer */
+PHP_METHOD(File, open) {
+	zend_string *filename, *mode;
+	zend_bool use_include_path = 0;
+	zval *zcontext = NULL;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "SS|bO", &filename, &mode, &use_include_path, &zcontext, pthreads_stream_context_entry) != SUCCESS) {
+		RETURN_NULL();
+	}
+
+	if (zcontext != NULL && !Z_ISNULL_P(zcontext)  && !instanceof_function(Z_OBJCE_P(zcontext), pthreads_stream_context_entry)) {
+		zend_throw_exception_ex(spl_ce_RuntimeException,
+			0, "only StreamContext objects may be submitted, %s is no StreamContext",
+			ZSTR_VAL(Z_OBJCE_P(zcontext)->name));
+		RETURN_NULL();
+	}
+
+	pthreads_streams_api_file_open(filename, mode, use_include_path, zcontext, return_value);
+} /* }}} */
+
+/* {{{ proto static FileStream|null File::open(string filename, string mode)
+   Execute a command and open either a read or a write pipe to it */
+PHP_METHOD(File, popen) {
+	zend_string *filename, *mode;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "SS", &filename, &mode) != SUCCESS) {
+		RETURN_NULL();
+	}
+
+	pthreads_streams_api_file_popen(ZSTR_VAL(filename), ZSTR_VAL(mode), ZSTR_LEN(mode), return_value);
+} /* }}} */
+
+/* {{{ proto bool File::mkdir(string pathname [, int mode [, bool recursive [, resource context]]])
+   Create a directory */
+PHP_METHOD(File, mkdir) {
+	zend_string *pathname;
+	zend_long mode = 0777;
+	zend_bool *recursive = 0;
+	zval *zcontext = NULL;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "S|lbO", &pathname, &mode, &recursive, &zcontext, pthreads_stream_context_entry) != SUCCESS) {
+		RETURN_FALSE;
+	}
+
+	if (zcontext != NULL && !Z_ISNULL_P(zcontext)  && !instanceof_function(Z_OBJCE_P(zcontext), pthreads_stream_context_entry)) {
+		zend_throw_exception_ex(spl_ce_RuntimeException,
+			0, "only StreamContext objects may be submitted, %s is no StreamContext",
+			ZSTR_VAL(Z_OBJCE_P(zcontext)->name));
+		RETURN_FALSE;
+	}
+
+	pthreads_streams_api_file_mkdir(pathname, mode, recursive, zcontext, return_value);
+} /* }}} */
+
+/* {{{ proto bool File::rmdir(string pathname [, resource context])
+   Remove a directory */
+PHP_METHOD(File, rmdir) {
+	zend_string *pathname;
+	zval *zcontext = NULL;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "S|O", &pathname, &zcontext, pthreads_stream_context_entry) != SUCCESS) {
+		RETURN_FALSE;
+	}
+
+	if (zcontext != NULL && !Z_ISNULL_P(zcontext)  && !instanceof_function(Z_OBJCE_P(zcontext), pthreads_stream_context_entry)) {
+		zend_throw_exception_ex(spl_ce_RuntimeException,
+			0, "only StreamContext objects may be submitted, %s is no StreamContext",
+			ZSTR_VAL(Z_OBJCE_P(zcontext)->name));
+		RETURN_FALSE;
+	}
+
+	pthreads_streams_api_file_rmdir(pathname, zcontext, return_value);
+} /* }}} */
+
+/* {{{ proto int File::readfile(string filename [, bool use_include_path[, resource context]])
+   Output a file or a URL */
+PHP_METHOD(File, readfile) {
+	zend_string *filename;
+	zend_bool use_include_path = 0;
+	zval *zcontext = NULL;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "S|bO", &filename, &use_include_path, &zcontext, pthreads_stream_context_entry) != SUCCESS) {
+		RETURN_FALSE;
+	}
+
+	if (zcontext != NULL && !Z_ISNULL_P(zcontext)  && !instanceof_function(Z_OBJCE_P(zcontext), pthreads_stream_context_entry)) {
+		zend_throw_exception_ex(spl_ce_RuntimeException,
+			0, "only StreamContext objects may be submitted, %s is no StreamContext",
+			ZSTR_VAL(Z_OBJCE_P(zcontext)->name));
+		RETURN_FALSE;
+	}
+
+	pthreads_streams_api_file_readfile(filename, use_include_path, zcontext, return_value);
+} /* }}} */
+
+/* {{{ proto bool File::rename(string old_name, string new_name[, resource context])
+   Remove a directory */
+PHP_METHOD(File, rename) {
+	zend_string *old_name, new_name;
+	zval *zcontext = NULL;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "SS|O", &old_name, &new_name, &zcontext, pthreads_stream_context_entry) != SUCCESS) {
+		RETURN_FALSE;
+	}
+
+	if (zcontext != NULL && !Z_ISNULL_P(zcontext)  && !instanceof_function(Z_OBJCE_P(zcontext), pthreads_stream_context_entry)) {
+		zend_throw_exception_ex(spl_ce_RuntimeException,
+			0, "only StreamContext objects may be submitted, %s is no StreamContext",
+			ZSTR_VAL(Z_OBJCE_P(zcontext)->name));
+		RETURN_FALSE;
+	}
+
+	pthreads_streams_api_file_rename(old_name, new_name, zcontext, return_value);
+} /* }}} */
+
+/* {{{ proto bool File::unlink(string filename[, context context])
+   Remove a directory */
+PHP_METHOD(File, unlink) {
+	zend_string *filename;
+	zval *zcontext = NULL;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "S|O", &filename, &zcontext, pthreads_stream_context_entry) != SUCCESS) {
+		RETURN_FALSE;
+	}
+
+	if (zcontext != NULL && !Z_ISNULL_P(zcontext)  && !instanceof_function(Z_OBJCE_P(zcontext), pthreads_stream_context_entry)) {
+		zend_throw_exception_ex(spl_ce_RuntimeException,
+			0, "only StreamContext objects may be submitted, %s is no StreamContext",
+			ZSTR_VAL(Z_OBJCE_P(zcontext)->name));
+		RETURN_FALSE;
+	}
+
+	pthreads_streams_api_file_unlink(filename, zcontext, return_value);
+} /* }}} */
+
+/* {{{ proto bool File::copy(string source_file, string destination_file [, resource context])
+   Copy a file */
+PHP_METHOD(File, copy) {
+	zend_string *source, *destination;
+	zval *zcontext = NULL;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "SS|O", &source, &destination, &zcontext, pthreads_stream_context_entry) != SUCCESS) {
+		RETURN_FALSE;
+	}
+
+	if (zcontext != NULL && !Z_ISNULL_P(zcontext)  && !instanceof_function(Z_OBJCE_P(zcontext), pthreads_stream_context_entry)) {
+		zend_throw_exception_ex(spl_ce_RuntimeException,
+			0, "only StreamContext objects may be submitted, %s is no StreamContext",
+			ZSTR_VAL(Z_OBJCE_P(zcontext)->name));
+		RETURN_FALSE;
+	}
+
+	pthreads_streams_api_file_copy(ZSTR_VAL(source), ZSTR_VAL(destination), zcontext, return_value);
+} /* }}} */
+
+
+/* {{{ proto FileStream File::sockopen(string $hostname [, int $port = -1 [, int &$errno [, string &$errstr [, float $timeout = ini_get("default_socket_timeout") ]]]])
+   */
+PHP_METHOD(File, sockopen) {
+	zend_string *host;
+	zval *zerrno = NULL, *zerrstr = NULL;
+	zend_long port = -1;
+	double timeout = (double)FG(default_socket_timeout);
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "S|lz/z/d", &host, &port, &zerrno, &zerrstr, &timeout) != SUCCESS) {
+		RETURN_NULL();
+	}
+
+	pthreads_streams_api_file_sockopen(host, port, zerrno, zerrstr, timeout, return_value);
+} /* }}} */
+
+#	endif
+#endif

--- a/classes/filter.h
+++ b/classes/filter.h
@@ -1,0 +1,177 @@
+/*
+  +----------------------------------------------------------------------+
+  | pthreads                                                             |
+  +----------------------------------------------------------------------+
+  | Copyright (c) Joe Watkins 2018                                       |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | http://www.php.net/license/3_01.txt                                  |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors: Bastian Schneider <b.schneider@badnoob.com>                 |
+  +----------------------------------------------------------------------+
+ */
+#ifndef HAVE_PTHREADS_CLASS_FILTER_H
+#define HAVE_PTHREADS_CLASS_FILTER_H
+PHP_METHOD(StreamBucket, __construct);
+
+/* {{{ */
+static PHP_METHOD(StreamBucketBrigade, __construct) {
+	zend_throw_error(NULL, "Instantiation of 'StreamBucketBrigade' is not allowed");
+} /* }}} */
+PHP_METHOD(StreamBucketBrigade, append);
+PHP_METHOD(StreamBucketBrigade, prepend);
+PHP_METHOD(StreamBucketBrigade, fetch);
+
+/* {{{ */
+static PHP_METHOD(StreamFilter, __construct) {
+	zend_throw_error(NULL, "Instantiation of 'StreamFilter' is not allowed");
+} /* }}} */
+PHP_METHOD(StreamFilter, remove);
+
+PHP_FUNCTION(user_filter_nop)
+{
+}
+
+ZEND_BEGIN_ARG_INFO_EX(StreamBucket___construct, 0, 0, 1)
+	ZEND_ARG_TYPE_INFO(0, buffer, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(pthreads_user_filter_class_filter, 0, 0, 4)
+	ZEND_ARG_OBJ_INFO(0, in, StreamBucketBrigade, 0)
+	ZEND_ARG_OBJ_INFO(0, out, StreamBucketBrigade, 0)
+	ZEND_ARG_TYPE_INFO(1, consumed, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, closing, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(filters_noargs, 0, 0, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(StreamBucketBrigade_append, 0, 0, 1)
+	ZEND_ARG_OBJ_INFO(0, bucket, StreamBucket, 0)
+	ZEND_ARG_TYPE_INFO(0, separate, _IS_BOOL, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(StreamBucketBrigade_prepend, 0, 0, 1)
+	ZEND_ARG_OBJ_INFO(0, bucket, StreamBucket, 0)
+	ZEND_ARG_TYPE_INFO(0, separate, _IS_BOOL, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(StreamFilter_remove, 0, 0, 0)
+ZEND_END_ARG_INFO()
+
+extern zend_function_entry pthreads_streams_user_filter_class_methods[];
+extern zend_function_entry pthreads_streams_bucket_methods[];
+extern zend_function_entry pthreads_streams_bucketbrigade_methods[];
+extern zend_function_entry pthreads_streams_filter_methods[];
+#else
+#	ifndef HAVE_PTHREADS_CLASS_FILTER
+#	define HAVE_PTHREADS_CLASS_FILTER
+zend_function_entry pthreads_streams_user_filter_class_methods[] = {
+	PHP_NAMED_FE(filter       , PHP_FN(user_filter_nop), pthreads_user_filter_class_filter)
+	PHP_NAMED_FE(onCreate     , PHP_FN(user_filter_nop), filters_noargs)
+	PHP_NAMED_FE(onClose      , PHP_FN(user_filter_nop), filters_noargs)
+	PHP_FE_END
+};
+
+zend_function_entry pthreads_streams_bucket_methods[] = {
+	PHP_ME(StreamBucket       , __construct , StreamBucket___construct      , ZEND_ACC_PUBLIC)
+	PHP_FE_END
+};
+
+zend_function_entry pthreads_streams_bucketbrigade_methods[] = {
+	PHP_ME(StreamBucketBrigade, __construct , NULL                          , ZEND_ACC_PRIVATE)
+	PHP_ME(StreamBucketBrigade, append      , StreamBucketBrigade_append    , ZEND_ACC_PUBLIC)
+	PHP_ME(StreamBucketBrigade, prepend     , StreamBucketBrigade_prepend   , ZEND_ACC_PUBLIC)
+	PHP_ME(StreamBucketBrigade, fetch       , filters_noargs                , ZEND_ACC_PUBLIC)
+	PHP_FE_END
+};
+
+zend_function_entry pthreads_streams_filter_methods[] = {
+	PHP_ME(StreamFilter       , __construct , NULL                          , ZEND_ACC_PRIVATE)
+	PHP_ME(StreamFilter       , remove      , StreamFilter_remove           , ZEND_ACC_PUBLIC)
+	PHP_FE_END
+};
+
+
+/* {{{ proto StreamBucket::__construct(string buffer)
+	Create a new bucket for use on the current stream  */
+PHP_METHOD(StreamBucket, __construct) {
+	zend_string *buffer;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "S", &buffer) != SUCCESS) {
+		RETURN_FALSE;
+	}
+
+	pthreads_streams_api_bucket_construct(getThis(), buffer, return_value);
+} /* }}} */
+
+/* {{{ proto void StreamBucketBrigade::append(Bucket bucket)
+   Append bucket to brigade */
+PHP_METHOD(StreamBucketBrigade, append) {
+	zval *bucket = NULL;
+	zend_bool separate = 0;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "O|b", &bucket, pthreads_stream_bucket_entry, &separate) != SUCCESS) {
+		RETURN_FALSE;
+	}
+
+	if (!instanceof_function(Z_OBJCE_P(bucket), pthreads_stream_bucket_entry)) {
+		zend_throw_exception_ex(spl_ce_RuntimeException,
+			0, "only Bucket objects may be submitted, %s is no Bucket",
+			ZSTR_VAL(Z_OBJCE_P(bucket)->name));
+		return;
+	}
+
+	pthreads_streams_api_bucket_attach(getThis(), bucket, 1, separate);
+
+} /* }}} */
+
+/* {{{ proto void StreamBucketBrigade::prepend(Bucket bucket)
+   Prepend bucket to brigade */
+PHP_METHOD(StreamBucketBrigade, prepend) {
+	zval *bucket = NULL;
+	zend_bool separate = 0;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "O|b", &bucket, pthreads_stream_bucket_entry, &separate) != SUCCESS) {
+		RETURN_FALSE;
+	}
+
+	if (!instanceof_function(Z_OBJCE_P(bucket), pthreads_stream_bucket_entry)) {
+		zend_throw_exception_ex(spl_ce_RuntimeException,
+			0, "only Bucket objects may be submitted, %s is no Bucket",
+			ZSTR_VAL(Z_OBJCE_P(bucket)->name));
+		return;
+	}
+
+	pthreads_streams_api_bucket_attach(getThis(), bucket, 0, separate);
+
+} /* }}} */
+
+/* {{{ proto Bucket StreamBucketBrigade::fetch(void)
+   Return a bucket object from the brigade for operating on */
+PHP_METHOD(StreamBucketBrigade, fetch) {
+
+	if (zend_parse_parameters_none() == FAILURE) {
+		return;
+	}
+
+	pthreads_streams_api_bucket_fetch(getThis(), return_value);
+} /* }}} */
+
+
+/* {{{ proto bool StreamFilter::remove() */
+PHP_METHOD(StreamFilter, remove) {
+	if (zend_parse_parameters_none() == FAILURE) {
+		return;
+	}
+
+	pthreads_streams_api_filter_remove(getThis(), return_value);
+} /* }}} */
+
+#	endif
+#endif

--- a/classes/stream.h
+++ b/classes/stream.h
@@ -1,0 +1,975 @@
+/*
+  +----------------------------------------------------------------------+
+  | pthreads                                                             |
+  +----------------------------------------------------------------------+
+  | Copyright (c) Joe Watkins 2018                                       |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | http://www.php.net/license/3_01.txt                                  |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors: Bastian Schneider <b.schneider@badnoob.com>                 |
+  +----------------------------------------------------------------------+
+ */
+#ifndef HAVE_PTHREADS_CLASS_STREAM_H
+#define HAVE_PTHREADS_CLASS_STREAM_H
+
+// Streams
+/* {{{ */
+static PHP_METHOD(Streams, __construct) {
+	zend_throw_error(NULL, "Instantiation of 'Streams' is not allowed");
+} /* }}} */
+PHP_METHOD(Streams, getFilters);
+PHP_METHOD(Streams, getTransports);
+PHP_METHOD(Streams, getWrappers);
+PHP_METHOD(Streams, registerWrapper);
+PHP_METHOD(Streams, unregisterWrapper);
+PHP_METHOD(Streams, registerFilter);
+
+// StreamContext
+PHP_METHOD(StreamContext, __construct);
+PHP_METHOD(StreamContext, getOptions);
+PHP_METHOD(StreamContext, setOptions);
+PHP_METHOD(StreamContext, setOption);
+PHP_METHOD(StreamContext, getParams);
+PHP_METHOD(StreamContext, setParams);
+PHP_METHOD(StreamContext, getDefault);
+PHP_METHOD(StreamContext, setDefault);
+
+// Stream
+/* {{{ */
+static PHP_METHOD(Stream, __construct) {
+	zend_throw_error(NULL, "Instantiation of 'Stream' is not allowed");
+} /* }}} */
+PHP_METHOD(Stream, copyToStream);
+PHP_METHOD(Stream, appendFilter);
+PHP_METHOD(Stream, prependFilter);
+PHP_METHOD(Stream, enableCrypto);
+PHP_METHOD(Stream, getContents);
+PHP_METHOD(Stream, getLine);
+PHP_METHOD(Stream, getMetaData);
+PHP_METHOD(Stream, isLocal);
+PHP_METHOD(Stream, isATTY);
+#ifdef PHP_WIN32
+PHP_METHOD(Stream, windowsVT100Support);
+#endif
+PHP_METHOD(Stream, select);
+PHP_METHOD(Stream, setBlocking);
+PHP_METHOD(Stream, setChunkSize);
+PHP_METHOD(Stream, setReadBuffer);
+#if HAVE_SYS_TIME_H || defined(PHP_WIN32)
+PHP_METHOD(Stream, setTimeout);
+#endif
+PHP_METHOD(Stream, setWriteBuffer);
+PHP_METHOD(Stream, supportsLock);
+PHP_METHOD(Stream, fromResource);
+
+// SocketStream
+/* {{{ */
+static PHP_METHOD(SocketStream, __construct) {
+	zend_throw_error(NULL, "Instantiation of 'SocketStream' is not allowed");
+} /* }}} */
+PHP_METHOD(SocketStream, createClient);
+PHP_METHOD(SocketStream, createServer);
+#if HAVE_SOCKETPAIR
+PHP_METHOD(SocketStream, createPair);
+#endif
+PHP_METHOD(SocketStream, accept);
+PHP_METHOD(SocketStream, getName);
+PHP_METHOD(SocketStream, recvfrom);
+PHP_METHOD(SocketStream, sendto);
+#ifdef HAVE_SHUTDOWN
+PHP_METHOD(SocketStream, shutdown);
+#endif
+
+// StreamWrapper
+/* {{{ */
+static PHP_METHOD(StreamWrapper, __construct) {
+	zend_throw_error(NULL, "Instantiation of 'StreamWrapper' is not allowed");
+} /* }}} */
+
+
+/**
+ * Streams
+ */
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO(Streams_getFilters, IS_ARRAY, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO(Streams_getTransports, IS_ARRAY, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO(Streams_getWrappers, IS_ARRAY, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(Streams_registerWrapper, 0, 1, _IS_BOOL, 0)
+	ZEND_ARG_TYPE_INFO(0, protocol, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, classname, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, flags, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(Streams_unregisterWrapper, 0, 1, _IS_BOOL, 0)
+	ZEND_ARG_TYPE_INFO(0, protocol, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(Streams_registerFilter, 0, 1, _IS_BOOL, 0)
+	ZEND_ARG_TYPE_INFO(0, filtername, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, classname, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
+/**
+ * StreamContext
+ */
+ZEND_BEGIN_ARG_INFO_EX(StreamContext___construct, 0, 0, 0)
+	ZEND_ARG_TYPE_INFO(0, options, IS_ARRAY, 0)
+	ZEND_ARG_TYPE_INFO(0, params, IS_ARRAY, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO(StreamContext_getOptions, IS_ARRAY, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(StreamContext_setOptions, 0, 1, _IS_BOOL, 0)
+	ZEND_ARG_TYPE_INFO(0, options, IS_ARRAY, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(StreamContext_setOption, 0, 3, _IS_BOOL, 0)
+	ZEND_ARG_TYPE_INFO(0, wrapper, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, option, IS_STRING, 0)
+	ZEND_ARG_INFO(0, value)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO(StreamContext_getParams, IS_ARRAY, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(StreamContext_setParams, 0, 1, _IS_BOOL, 0)
+	ZEND_ARG_TYPE_INFO(0, params, IS_ARRAY, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(StreamContext_getDefault, 0, 0, StreamContext, 0)
+	ZEND_ARG_TYPE_INFO(0, options, IS_ARRAY, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(StreamContext_setDefault, 0, 1, StreamContext, 0)
+	ZEND_ARG_TYPE_INFO(0, options, IS_ARRAY, 0)
+ZEND_END_ARG_INFO()
+
+/**
+ * Stream
+ */
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(Stream_copyToStream, 0, 1, IS_LONG, 0)
+	ZEND_ARG_OBJ_INFO(0, dest, Stream, 0)
+	ZEND_ARG_TYPE_INFO(0, maxlength, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, offset, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(Stream_appendFilter, 0, 1, StreamFilter, 1)
+	ZEND_ARG_TYPE_INFO(0, filtername, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, read_write, IS_LONG, 0)
+	ZEND_ARG_INFO(0, params)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(Stream_prependFilter, 0, 1, StreamFilter, 1)
+	ZEND_ARG_TYPE_INFO(0, filtername, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, read_write, IS_LONG, 0)
+	ZEND_ARG_INFO(0, params)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(Stream_enableCrypto, 0, 0, 1)
+	ZEND_ARG_TYPE_INFO(0, enable, _IS_BOOL, 0)
+	ZEND_ARG_TYPE_INFO(0, crypto_type, IS_LONG, 0)
+	ZEND_ARG_OBJ_INFO(0, session_stream, Stream, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(Stream_getContents, 0, 0, IS_STRING, 1)
+	ZEND_ARG_TYPE_INFO(0, maxlength, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, offset, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(Stream_getLine, 0, 1, IS_STRING, 1)
+	ZEND_ARG_TYPE_INFO(0, length, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, ending, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(Stream_getMetaData, 0, 0, IS_ARRAY, 1)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(Stream_isLocal, 0, 1, _IS_BOOL, 0)
+	ZEND_ARG_TYPE_INFO(0, stream_or_url, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(Stream_isATTY, 0, 0, _IS_BOOL, 0)
+ZEND_END_ARG_INFO()
+
+#ifdef PHP_WIN32
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(Stream_windowsVT100Support, 0, 0, _IS_BOOL, 0)
+	ZEND_ARG_TYPE_INFO(0, enable, _IS_BOOL, 0)
+ZEND_END_ARG_INFO()
+#endif
+
+ZEND_BEGIN_ARG_INFO_EX(Stream_select, 0, 0, 4)
+	ZEND_ARG_TYPE_INFO(1, read, IS_ARRAY, 1)
+	ZEND_ARG_TYPE_INFO(1, write, IS_ARRAY, 1)
+	ZEND_ARG_TYPE_INFO(1, except, IS_ARRAY, 1)
+	ZEND_ARG_TYPE_INFO(0, tv_sec, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, tv_usec, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(Stream_setBlocking, 0, 1, _IS_BOOL, 0)
+	ZEND_ARG_TYPE_INFO(0, mode, _IS_BOOL, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(Stream_setChunkSize, 0, 1, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, chunk_size, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(Stream_setReadBuffer, 0, 1, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, buffer, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
+#if HAVE_SYS_TIME_H || defined(PHP_WIN32)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(Stream_setTimeout, 0, 2, _IS_BOOL, 0)
+	ZEND_ARG_TYPE_INFO(0, seconds, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, microseconds, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+#endif
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(Stream_setWriteBuffer, 0, 1, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, buffer, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(Stream_supportsLock, 0, 0, _IS_BOOL, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(Stream_fromResource, 0, 1, Stream, 0)
+	ZEND_ARG_TYPE_INFO(0, stream, IS_RESOURCE, 0)
+ZEND_END_ARG_INFO()
+
+/**
+ * SocketStream
+ */
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(SocketStream_createClient, 0, 1, SocketStream, 1)
+	ZEND_ARG_TYPE_INFO(0, remote_socket, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(1, errno, IS_LONG, 1)
+	ZEND_ARG_TYPE_INFO(1, errstr, IS_STRING, 1)
+	ZEND_ARG_TYPE_INFO(0, timeout, IS_DOUBLE, 0)
+	ZEND_ARG_TYPE_INFO(0, flags, IS_LONG, 0)
+	ZEND_ARG_OBJ_INFO(0, context, StreamContext, 1)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(SocketStream_createServer, 0, 1, SocketStream, 1)
+	ZEND_ARG_TYPE_INFO(0, local_socket, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(1, errno, IS_LONG, 1)
+	ZEND_ARG_TYPE_INFO(1, errstr, IS_STRING, 1)
+	ZEND_ARG_TYPE_INFO(0, flags, IS_LONG, 0)
+	ZEND_ARG_OBJ_INFO(0, context, StreamContext, 1)
+ZEND_END_ARG_INFO()
+
+#if HAVE_SOCKETPAIR
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(SocketStream_createPair, 0, 3, IS_ARRAY, 1)
+	ZEND_ARG_TYPE_INFO(0, domain, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, type, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, protocol, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+#endif
+
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(SocketStream_accept, 0, 0, SocketStream, 1)
+	ZEND_ARG_TYPE_INFO(0, timeout, IS_DOUBLE, 0)
+	ZEND_ARG_TYPE_INFO(1, peername, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(SocketStream_getName, 0, 1, IS_STRING, 1)
+	ZEND_ARG_TYPE_INFO(0, $want_peer, _IS_BOOL, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(SocketStream_recvfrom, 0, 1, IS_STRING, 1)
+	ZEND_ARG_TYPE_INFO(0, length, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, flags, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(1, address, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(SocketStream_sendto, 0, 1, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, data, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, flags, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, address, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
+#ifdef HAVE_SHUTDOWN
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(SocketStream_shutdown, 0, 1, _IS_BOOL, 0)
+	ZEND_ARG_TYPE_INFO(0, $how, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+#endif
+
+/**
+ * StreamWrapper
+ */
+
+extern zend_function_entry pthreads_streams_streams_methods[];
+extern zend_function_entry pthreads_streams_context_methods[];
+extern zend_function_entry pthreads_streams_stream_methods[];
+extern zend_function_entry pthreads_streams_socket_stream_methods[];
+extern zend_function_entry pthreads_streams_wrapper_methods[];
+#else
+#	ifndef HAVE_PTHREADS_CLASS_STREAM
+#	define HAVE_PTHREADS_CLASS_STREAM
+
+zend_function_entry pthreads_streams_streams_methods[] = {
+	PHP_ME(Streams, __construct         , NULL                      , ZEND_ACC_PRIVATE)
+	PHP_ME(Streams, getFilters          , Streams_getFilters        , ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
+	PHP_ME(Streams, getTransports       , Streams_getTransports     , ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
+	PHP_ME(Streams, getWrappers         , Streams_getWrappers       , ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
+	PHP_ME(Streams, registerWrapper     , Streams_registerWrapper   , ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
+	PHP_ME(Streams, unregisterWrapper   , Streams_unregisterWrapper , ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
+	PHP_ME(Streams, registerFilter      , Streams_registerFilter    , ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
+	PHP_FE_END
+};
+
+zend_function_entry pthreads_streams_context_methods[] = {
+	PHP_ME(StreamContext, __construct   , StreamContext___construct , ZEND_ACC_PUBLIC)
+	PHP_ME(StreamContext, getOptions    , StreamContext_getOptions  , ZEND_ACC_PUBLIC)
+	PHP_ME(StreamContext, setOptions    , StreamContext_setOptions  , ZEND_ACC_PUBLIC)
+	PHP_ME(StreamContext, setOption     , StreamContext_setOption   , ZEND_ACC_PUBLIC)
+	PHP_ME(StreamContext, getParams     , StreamContext_getParams   , ZEND_ACC_PUBLIC)
+	PHP_ME(StreamContext, setParams     , StreamContext_setParams   , ZEND_ACC_PUBLIC)
+	PHP_ME(StreamContext, getDefault    , StreamContext_getDefault  , ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
+	PHP_ME(StreamContext, setDefault    , StreamContext_setDefault  , ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
+	PHP_FE_END
+};
+
+zend_function_entry pthreads_streams_stream_methods[] = {
+	PHP_ME(Stream, __construct          , NULL                      , ZEND_ACC_PRIVATE)
+	PHP_ME(Stream, copyToStream         , Stream_copyToStream       , ZEND_ACC_PUBLIC)
+	PHP_ME(Stream, appendFilter         , Stream_appendFilter       , ZEND_ACC_PUBLIC)
+	PHP_ME(Stream, prependFilter        , Stream_prependFilter      , ZEND_ACC_PUBLIC)
+	PHP_ME(Stream, enableCrypto         , Stream_enableCrypto       , ZEND_ACC_PUBLIC)
+	PHP_ME(Stream, getContents          , Stream_getContents        , ZEND_ACC_PUBLIC)
+	PHP_ME(Stream, getLine              , Stream_getLine            , ZEND_ACC_PUBLIC)
+	PHP_ME(Stream, getMetaData          , Stream_getMetaData        , ZEND_ACC_PUBLIC)
+	PHP_ME(Stream, isLocal              , Stream_isLocal            , ZEND_ACC_PUBLIC)
+	PHP_ME(Stream, isATTY               , Stream_isATTY             , ZEND_ACC_PUBLIC)
+#ifdef PHP_WIN32
+	PHP_ME(Stream, windowsVT100Support  , Stream_windowsVT100Support, ZEND_ACC_PUBLIC)
+#endif
+	PHP_ME(Stream, select               , Stream_select             , ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
+	PHP_ME(Stream, setBlocking          , Stream_setBlocking        , ZEND_ACC_PUBLIC)
+	PHP_ME(Stream, setChunkSize         , Stream_setChunkSize       , ZEND_ACC_PUBLIC)
+	PHP_ME(Stream, setReadBuffer        , Stream_setReadBuffer      , ZEND_ACC_PUBLIC)
+#if HAVE_SYS_TIME_H || defined(PHP_WIN32)
+	PHP_ME(Stream, setTimeout           , Stream_setTimeout         , ZEND_ACC_PUBLIC)
+#endif
+	PHP_ME(Stream, setWriteBuffer       , Stream_setWriteBuffer     , ZEND_ACC_PUBLIC)
+	PHP_ME(Stream, supportsLock         , Stream_supportsLock       , ZEND_ACC_PUBLIC)
+	PHP_ME(Stream, fromResource         , Stream_fromResource       , ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
+	PHP_FE_END
+};
+
+zend_function_entry pthreads_streams_socket_stream_methods[] = {
+	PHP_ME(SocketStream, __construct    , NULL                      , ZEND_ACC_PRIVATE)
+	PHP_ME(SocketStream, createClient   , SocketStream_createClient , ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
+	PHP_ME(SocketStream, createServer   , SocketStream_createServer , ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
+#if HAVE_SOCKETPAIR
+	PHP_ME(SocketStream, createPair     , SocketStream_createPair   , ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
+#endif
+	PHP_ME(SocketStream, accept         , SocketStream_accept       , ZEND_ACC_PUBLIC)
+	PHP_ME(SocketStream, getName        , SocketStream_getName      , ZEND_ACC_PUBLIC)
+	PHP_ME(SocketStream, recvfrom       , SocketStream_recvfrom     , ZEND_ACC_PUBLIC)
+	PHP_ME(SocketStream, sendto         , SocketStream_sendto       , ZEND_ACC_PUBLIC)
+#ifdef HAVE_SHUTDOWN
+	PHP_ME(SocketStream, shutdown       , SocketStream_shutdown     , ZEND_ACC_PUBLIC)
+#endif
+	PHP_FE_END
+};
+
+zend_function_entry pthreads_streams_wrapper_methods[] = {
+	PHP_ME(StreamWrapper, __construct   , NULL                      , ZEND_ACC_PRIVATE)
+	PHP_FE_END
+};
+
+/**
+ *
+ * Streams
+ *
+ */
+/* {{{ proto array Streams::getFilters(void)
+   Returns a list of registered filters */
+PHP_METHOD(Streams, getFilters) {
+
+	if (zend_parse_parameters_none() == FAILURE) {
+		return;
+	}
+
+	pthreads_streams_api_get_filters(return_value);
+} /* }}} */
+
+/* {{{ proto array Streams::getTransports(void)
+   Returns a list of registered filters */
+PHP_METHOD(Streams, getTransports) {
+
+	if (zend_parse_parameters_none() == FAILURE) {
+		return;
+	}
+
+	pthreads_streams_api_get_transports(return_value);
+} /* }}} */
+
+/* {{{ proto array Streams::getWrappers(void)
+   Returns a list of registered filters */
+PHP_METHOD(Streams, getWrappers) {
+
+	if (zend_parse_parameters_none() == FAILURE) {
+		return;
+	}
+
+	pthreads_streams_api_get_wrappers(return_value);
+} /* }}} */
+
+/* {{{ proto bool Streams::registerWrapper(string protocol, string classname [, int flags = 0]) */
+PHP_METHOD(Streams, registerWrapper) {
+
+	zend_string *protocol = NULL, *classname = NULL;
+	zend_long flags = 0;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "SS|l", &protocol, &classname, &flags) != SUCCESS) {
+		RETURN_FALSE;
+	}
+
+	if (!ZSTR_LEN(protocol)) {
+		php_error_docref(NULL, E_WARNING, "Protocol name cannot be empty");
+		return;
+	}
+
+	if (!ZSTR_LEN(classname)) {
+		php_error_docref(NULL, E_WARNING, "Class name cannot be empty");
+		return;
+	}
+
+	pthreads_streams_api_register_wrapper(protocol, classname, flags, return_value);
+} /* }}} */
+
+/* {{{ proto bool Streams::unregisterWrapper(string protocol) */
+PHP_METHOD(Streams, unregisterWrapper) {
+	zend_string *protocol = NULL;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "S", &protocol) != SUCCESS) {
+		RETURN_FALSE;
+	}
+
+	if (!ZSTR_LEN(protocol)) {
+		php_error_docref(NULL, E_WARNING, "Protocol name cannot be empty");
+		return;
+	}
+
+	pthreads_streams_api_unregister_wrapper(protocol, return_value);
+} /* }}} */
+
+/* {{{ proto bool Streams::registerFilter(string filtername, string classname)  */
+PHP_METHOD(Streams, registerFilter) {
+	zend_string *filtername = NULL, *classname = NULL;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "SS", &filtername, &classname) != SUCCESS) {
+		RETURN_FALSE;
+	}
+
+	if (!ZSTR_LEN(filtername)) {
+		php_error_docref(NULL, E_WARNING, "Filter name cannot be empty");
+		return;
+	}
+
+	if (!ZSTR_LEN(classname)) {
+		php_error_docref(NULL, E_WARNING, "Class name cannot be empty");
+		return;
+	}
+
+	pthreads_streams_api_register_filter(filtername, classname, return_value);
+} /* }}} */
+
+/**
+ *
+ * StreamContext
+ *
+ */
+
+/* {{{ proto StreamContext::__construct([array options [, array $params]]) */
+PHP_METHOD(StreamContext, __construct) {
+	zval *options = NULL, *params = NULL;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "|aa", &options, &params) != SUCCESS) {
+		return;
+	}
+
+	pthreads_streams_api_context_create(getThis(), options, params, return_value);
+} /* }}} */
+
+/* {{{ proto array StreamContext::getOptions() */
+PHP_METHOD(StreamContext, getOptions) {
+
+	if (zend_parse_parameters_none() == FAILURE) {
+		return;
+	}
+
+	pthreads_streams_api_context_get_options(getThis(), return_value);
+} /* }}} */
+
+/* {{{ proto bool StreamContext::setOptions() */
+PHP_METHOD(StreamContext, setOptions) {
+	zval *options = NULL;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "|a", &options) != SUCCESS) {
+		return;
+	}
+
+	pthreads_streams_api_context_set_options(getThis(), options, return_value);
+} /* }}} */
+
+/* {{{ proto bool StreamContext::setOption(string wrapper, string option, value) */
+PHP_METHOD(StreamContext, setOption) {
+	zend_string *wrapper, *option;
+	zval *value;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "SSz", &wrapper, &option, &value) != SUCCESS) {
+		return;
+	}
+
+	pthreads_streams_api_context_set_option(getThis(), wrapper, option, value, return_value);
+} /* }}} */
+
+/* {{{ proto array StreamContext::getParams() */
+PHP_METHOD(StreamContext, getParams) {
+
+	if (zend_parse_parameters_none() == FAILURE) {
+		return;
+	}
+
+	pthreads_streams_api_context_get_params(getThis(), return_value);
+} /* }}} */
+
+/* {{{ proto bool StreamContext::setParams() */
+PHP_METHOD(StreamContext, setParams) {
+	zval *params = NULL;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "|a", &params) != SUCCESS) {
+		return;
+	}
+
+	pthreads_streams_api_context_set_params(getThis(), params, return_value);
+} /* }}} */
+
+/* {{{ proto static StreamContext StreamContext::getDefault([array options]) */
+PHP_METHOD(StreamContext, getDefault) {
+	zval *options = NULL;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "|a", &options) != SUCCESS) {
+		return;
+	}
+
+	pthreads_streams_api_context_get_default(options, return_value);
+} /* }}} */
+
+/* {{{ proto static StreamContext StreamContext::setDefault(array options) */
+PHP_METHOD(StreamContext, setDefault) {
+	zval *options = NULL;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "a", &options) != SUCCESS) {
+		return;
+	}
+
+	pthreads_streams_api_context_set_default(options, return_value);
+} /* }}} */
+
+/**
+ *
+ * Stream
+ *
+ */
+
+/* {{{ proto int Stream::copyToStream(Stream dest [, int maxlength = -1 [, int offset = 0]]) */
+PHP_METHOD(Stream, copyToStream) {
+	zval *dest = NULL;
+	zend_long maxlength = PTHREADS_STREAM_COPY_ALL, offset = 0;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "O|ll", &dest, pthreads_stream_entry, &maxlength, &offset) != SUCCESS) {
+		return;
+	}
+
+	if (!instanceof_function(Z_OBJCE_P(dest), pthreads_stream_entry)) {
+		zend_throw_exception_ex(spl_ce_RuntimeException,
+			0, "only Stream objects may be submitted, %s is no Stream",
+			ZSTR_VAL(Z_OBJCE_P(dest)->name));
+		return;
+	}
+
+	pthreads_streams_api_stream_copy_to_stream(getThis(), dest, maxlength, offset, return_value);
+} /* }}} */
+
+/* {{{ proto ?StreamFilter Stream::appendFilter(string filtername [, int read_write [, mixed params]]) */
+PHP_METHOD(Stream, appendFilter) {
+	zval *params = NULL;
+	zend_long read_write = 0;
+	zend_string *filtername;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "S|lz", &filtername, &read_write, &params) != SUCCESS) {
+		return;
+	}
+
+	pthreads_streams_api_stream_apply_filter_to_stream(1, getThis(), filtername, read_write, params, return_value);
+} /* }}} */
+
+/* {{{ proto ?StreamFilter Stream::prependFilter(string filtername [, int read_write [, mixed params]]) */
+PHP_METHOD(Stream, prependFilter) {
+	zval *params = NULL;
+	zend_long read_write = 0;
+	zend_string *filtername;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "S|lz", &filtername, &read_write, &params) != SUCCESS) {
+		return;
+	}
+
+	pthreads_streams_api_stream_apply_filter_to_stream(0, getThis(), filtername, read_write, params, return_value);
+} /* }}} */
+
+/* {{{ proto mixed Stream::enableCrypto(bool enable [, int crypto_type [, Stream session_stream ]]) */
+PHP_METHOD(Stream, enableCrypto) {
+	zend_bool enable;
+	zend_long cryptokind = 0;
+	zval *zsession_stream = NULL;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "b|lO", &enable, &cryptokind, &zsession_stream, pthreads_stream_entry) != SUCCESS) {
+		return;
+	}
+
+	if (enable && (ZEND_NUM_ARGS() < 3 || cryptokind == 0)) {
+		zval *val;
+		pthreads_stream_t *threaded_stream = PTHREADS_FETCH_FROM(Z_OBJ_P(getThis()));
+
+		if (!PTHREADS_GET_CTX_OPT(threaded_stream, "ssl", "crypto_method", val)) {
+			php_error_docref(NULL, E_WARNING, "When enabling encryption you must specify the crypto type");
+			RETURN_FALSE;
+		}
+
+		cryptokind = Z_LVAL_P(val);
+	}
+
+	pthreads_streams_api_stream_enable_crypto(getThis(), enable, cryptokind, zsession_stream, return_value);
+} /* }}} */
+
+/* {{{ proto string|null Stream::getContents([int maxlength = -1 [, int offset = -1]]) */
+PHP_METHOD(Stream, getContents) {
+	zend_long maxlength = (ssize_t) PTHREADS_STREAM_COPY_ALL, offset = -1L;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "|ll", &maxlength, &offset) != SUCCESS) {
+		return;
+	}
+
+	pthreads_streams_api_stream_get_contents(getThis(), maxlength, offset, return_value);
+} /* }}} */
+
+/* {{{ proto string|null Stream::getLine(int length [, string ending]) */
+PHP_METHOD(Stream, getLine) {
+	zend_long length;
+	zend_string *ending = NULL;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "|ll", &length, &ending) != SUCCESS) {
+		return;
+	}
+
+	if (length < 0) {
+		php_error_docref(NULL, E_WARNING, "The maximum allowed length must be greater than or equal to zero");
+		RETURN_NULL();
+	}
+
+	pthreads_streams_api_stream_get_line(getThis(), length, ending, return_value);
+} /* }}} */
+
+/* {{{ proto array|null Stream::getMetaData(void) */
+PHP_METHOD(Stream, getMetaData) {
+
+	if (zend_parse_parameters_none() == FAILURE) {
+		return;
+	}
+
+	pthreads_streams_api_stream_get_meta_data(getThis(), return_value);
+} /* }}} */
+
+/* {{{ proto bool Stream::isLocal(string stream_or_url) */
+PHP_METHOD(Stream, isLocal) {
+	zval *stream_or_url = NULL;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "z", &stream_or_url) != SUCCESS) {
+		return;
+	}
+
+	pthreads_streams_api_stream_is_local(getThis(), stream_or_url, return_value);
+} /* }}} */
+
+/* {{{ proto bool Stream::isATTY(void) */
+PHP_METHOD(Stream, isATTY) {
+
+	if (zend_parse_parameters_none() == FAILURE) {
+		return;
+	}
+
+	pthreads_streams_api_stream_isatty(getThis(), return_value);
+} /* }}} */
+
+#ifdef PHP_WIN32
+/* {{{ proto bool Stream::windowsVT100Support([bool enable]) */
+PHP_METHOD(Stream, windowsVT100Support) {
+	zend_bool enable = 0;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "b", &enable) != SUCCESS) {
+		return;
+	}
+
+	pthreads_streams_api_stream_windows_vt100_support(ZEND_NUM_ARGS(), getThis(), enable, return_value);
+} /* }}} */
+#endif
+
+/* {{{ proto static mixed Stream::select(array &read, array &write, array &except, int tv_sec [, int tv_usec = 0]) */
+PHP_METHOD(Stream, select) {
+	zval *read, *write, *except, *sec = NULL;
+	zend_long usec = 0;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "a/!a/!a/!z!|l", &read, &write, &except, &sec, &usec) != SUCCESS) {
+		return;
+	}
+
+	pthreads_streams_api_stream_select(read, write, except, sec, usec, return_value);
+} /* }}} */
+
+/* {{{ proto bool Stream::setBlocking(bool mode) */
+PHP_METHOD(Stream, setBlocking) {
+	zend_bool blocking = 0;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "b", &blocking) != SUCCESS) {
+		return;
+	}
+
+	pthreads_streams_api_stream_set_blocking(getThis(), blocking, return_value);
+} /* }}} */
+
+/* {{{ proto int Stream::setChunkSize(int chunk_size) */
+PHP_METHOD(Stream, setChunkSize) {
+	zend_long csize;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "l", &csize) != SUCCESS) {
+		return;
+	}
+
+	if (csize <= 0) {
+		php_error_docref(NULL, E_WARNING, "The chunk size must be a positive integer, given " ZEND_LONG_FMT, csize);
+		RETURN_FALSE;
+	}
+
+	/* stream.chunk_size is actually a size_t, but pthreads_stream_set_option
+	 * can only use an int to accept the new value and return the old one.
+	 * In any case, values larger than INT_MAX for a chunk size make no sense.
+	 */
+	if (csize > INT_MAX) {
+		php_error_docref(NULL, E_WARNING, "The chunk size cannot be larger than %d", INT_MAX);
+		RETURN_FALSE;
+	}
+
+	pthreads_streams_api_stream_set_chunk_size(getThis(), csize, return_value);
+} /* }}} */
+
+/* {{{ proto int Stream::setReadBuffer(int buffer) */
+PHP_METHOD(Stream, setReadBuffer) {
+	zend_long buffer;
+	size_t buff;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "l", &buffer) != SUCCESS) {
+		return;
+	}
+	buff = buffer;
+
+	pthreads_streams_api_stream_set_read_buffer(getThis(), buff, return_value);
+} /* }}} */
+
+#if HAVE_SYS_TIME_H || defined(PHP_WIN32)
+/* {{{ proto bool Stream::setTimeout(int seconds [, int microseconds = 0]) */
+PHP_METHOD(Stream, setTimeout) {
+	zend_long seconds, microseconds = 0;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "l|l", &seconds, &microseconds) != SUCCESS) {
+		return;
+	}
+
+	pthreads_streams_api_stream_set_timeout(ZEND_NUM_ARGS(), getThis(), seconds, microseconds, return_value);
+} /* }}} */
+#endif
+
+/* {{{ proto int Stream::setWriteBuffer(int buffer) */
+PHP_METHOD(Stream, setWriteBuffer) {
+	zend_long buffer;
+	size_t buff;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "l", &buffer) != SUCCESS) {
+		return;
+	}
+	buff = buffer;
+
+	pthreads_streams_api_stream_set_write_buffer(getThis(), buff, return_value);
+} /* }}} */
+
+/* {{{ proto bool Stream::supportsLock(void) */
+PHP_METHOD(Stream, supportsLock) {
+
+	if (zend_parse_parameters_none() == FAILURE) {
+		return;
+	}
+
+	pthreads_streams_api_stream_supports_lock(getThis(), return_value);
+} /* }}} */
+
+/* {{{ proto bool Stream::fromResource(resource stream) */
+PHP_METHOD(Stream, fromResource) {
+	zval *zstream;
+	php_stream *stream;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "z", &zstream) != SUCCESS) {
+		return;
+	}
+
+	if ((stream = (php_stream*)zend_fetch_resource2_ex(zstream,
+				"stream", php_file_le_stream(), php_file_le_pstream())) == NULL) {
+		RETURN_NULL();
+	}
+
+	pthreads_streams_api_stream_from_resource(stream, return_value);
+} /* }}} */
+
+
+
+/**
+ *
+ * SocketStream
+ *
+ */
+
+/* {{{ proto static SocketStream|null SocketStream::createClient(string remote_socket [, int &errno [, string &errstr [,
+			float timeout = ini_get("default_socket_timeout") [, int flags = PTHREADS_STREAM_CLIENT_CONNECT [, StreamContext context ]]]]]) */
+PHP_METHOD(SocketStream, createClient) {
+	zend_string *remote_socket = NULL;
+	zval *zcontext = NULL, *errstr, *errorno = NULL;
+	double timeout = (double)FG(default_socket_timeout);
+	zend_long flags = PTHREADS_STREAM_CLIENT_CONNECT;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "S|z/z/dlO", &remote_socket, &errorno, &errstr, &timeout, &flags, &zcontext, pthreads_stream_context_entry) != SUCCESS) {
+		RETURN_NULL();
+	}
+
+	if (zcontext != NULL && !Z_ISNULL_P(zcontext) && !instanceof_function(Z_OBJCE_P(zcontext), pthreads_stream_context_entry)) {
+		zend_throw_exception_ex(spl_ce_RuntimeException,
+			0, "only StreamContext objects may be submitted, %s is no StreamContext",
+			ZSTR_VAL(Z_OBJCE_P(zcontext)->name));
+		RETURN_NULL();
+	}
+
+	pthreads_streams_api_socket_stream_create_client(remote_socket, errorno, errstr, timeout, flags, zcontext, return_value);
+} /* }}} */
+
+/* {{{ proto static SocketStream|null SocketStream::createServer(string local_socket [, int &errno [, string &errstr [,
+ 	 	 	 int flags = PTHREADS_STREAM_SERVER_BIND | PTHREADS_STREAM_SERVER_LISTEN [, StreamContext context ]]]]]) */
+PHP_METHOD(SocketStream, createServer) {
+	zend_string *local_socket = NULL;
+	zval *zcontext = NULL, *errstr, *errorno = NULL;
+	zend_long flags = PTHREADS_STREAM_XPORT_BIND | PTHREADS_STREAM_XPORT_LISTEN;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "S|z/z/lO", &local_socket, &errorno, &errstr, &flags, &zcontext, pthreads_stream_context_entry) != SUCCESS) {
+		RETURN_NULL();
+	}
+
+	if (zcontext != NULL && !Z_ISNULL_P(zcontext)  && !instanceof_function(Z_OBJCE_P(zcontext), pthreads_stream_context_entry)) {
+		zend_throw_exception_ex(spl_ce_RuntimeException,
+			0, "only StreamContext objects may be submitted, %s is no StreamContext",
+			ZSTR_VAL(Z_OBJCE_P(zcontext)->name));
+		RETURN_NULL();
+	}
+
+	pthreads_streams_api_socket_stream_create_server(local_socket, errorno, errstr, flags, zcontext, return_value);
+} /* }}} */
+
+#if HAVE_SOCKETPAIR
+/* {{{ proto static array|null SocketStream::createPair(int domain, int type, int protocol) */
+PHP_METHOD(SocketStream, createPair) {
+	zend_long domain, type, protocol = 0;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "lll", &domain, &type, &protocol) != SUCCESS) {
+		RETURN_NULL();
+	}
+
+	pthreads_streams_api_socket_stream_pair(domain, type, protocol, return_value);
+} /* }}} */
+#endif
+
+/* {{{ proto SocketStream|null SocketStream::accept([float timeout = ini_get("default_socket_timeout") [, string $peername ]]) */
+PHP_METHOD(SocketStream, accept) {
+	double timeout = (double)FG(default_socket_timeout);
+	zval *zpeername = NULL;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "|dz/", &timeout, &zpeername) != SUCCESS) {
+		RETURN_NULL();
+	}
+
+	pthreads_streams_api_socket_stream_accept(getThis(), timeout, zpeername, return_value);
+} /* }}} */
+
+/* {{{ proto string|null SocketStream::getName(bool want_peer) */
+PHP_METHOD(SocketStream, getName) {
+	zend_bool want_peer;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "b", &want_peer) != SUCCESS) {
+		RETURN_NULL();
+	}
+
+	pthreads_streams_api_socket_stream_get_name(getThis(), want_peer, return_value);
+} /* }}} */
+
+/* {{{ proto string|null SocketStream::recvfrom(int length [, int flags = 0 [, string &$address ]]) */
+PHP_METHOD(SocketStream, recvfrom) {
+	zend_long length, flags = 0;
+	zend_string *address = NULL;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "l|lz/", &length, &flags, &address) != SUCCESS) {
+		RETURN_NULL();
+	}
+
+	pthreads_streams_api_socket_stream_recvfrom(getThis(), length, flags, address, return_value);
+} /* }}} */
+
+/* {{{ proto int SocketStream::sendto(string data [, int flags = 0 [, string $address ]]) */
+PHP_METHOD(SocketStream, sendto) {
+	zend_long flags = 0;
+	zend_string *data, *address = NULL;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "S|lS", &data, &flags, &address) != SUCCESS) {
+		RETURN_LONG(-1);
+	}
+
+	pthreads_streams_api_socket_stream_sendto(getThis(), data, flags, address, return_value);
+} /* }}} */
+
+#ifdef HAVE_SHUTDOWN
+/* {{{ proto bool SocketStream::shutdown(int how) */
+PHP_METHOD(SocketStream, shutdown) {
+	zend_long how;
+
+	if (zend_parse_parameters(ZEND_NUM_ARGS(), "l", &how) != SUCCESS) {
+		RETURN_FALSE;
+	}
+
+	if (how != PTHREADS_STREAM_SHUT_RD &&
+	    how != PTHREADS_STREAM_SHUT_WR &&
+	    how != PTHREADS_STREAM_SHUT_RDWR) {
+		php_error_docref(NULL, E_WARNING, "Second parameter $how needs to be one of Streams::STREAM_SHUT_RD, Streams::STREAM_SHUT_WR or Streams::STREAM_SHUT_RDWR");
+		RETURN_FALSE;
+	}
+
+	pthreads_streams_api_socket_stream_shutdown(getThis(), how, return_value);
+} /* }}} */
+#endif
+
+#	endif
+#endif

--- a/config.m4
+++ b/config.m4
@@ -27,7 +27,40 @@ if test "$PHP_PTHREADS" != "no"; then
 		EXTRA_CFLAGS="$EXTRA_CFLAGS -DDMALLOC"
 	fi
 
-	PHP_NEW_EXTENSION(pthreads, php_pthreads.c src/monitor.c src/stack.c src/globals.c src/prepare.c src/store.c src/resources.c src/handlers.c src/object.c src/socket.c, $ext_shared,, -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1)
+	PHP_NEW_EXTENSION(pthreads, php_pthreads.c \
+		src/monitor.c \
+		src/stack.c \
+		src/globals.c \
+		src/prepare.c \
+		src/store.c \
+		src/resources.c \
+		src/handlers.c \
+		src/object.c \
+		src/socket.c \
+		src/network.c \
+		src/hash.c \
+		src/utils.c \
+		src/info.c \
+		src/url.c \
+		src/file/file.c \
+		src/streams.c \
+		src/streams/wrappers.c \
+		src/streams/streamglobals.c \
+		src/streams/cast.c \
+		src/streams/buckets.c \
+		src/streams/memory.c \
+		src/streams/filters.c \
+		src/streams/wrappers/plain_wrapper.c \
+		src/streams/wrappers/user_wrapper.c \
+		src/streams/transports.c \
+		src/streams/xp_socket.c \
+		src/streams/mmap.c \
+		src/streams/wrappers/glob_wrapper.c \
+		src/streams/wrappers/fopen_wrapper.c \
+		src/streams/wrappers/http_fopen_wrapper.c \
+		src/streams/wrappers/ftp_fopen_wrapper.c \
+		src/streams/standard_filters.c, $ext_shared,, -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1)
+		
 	PHP_ADD_BUILD_DIR($ext_builddir/src, 1)
 	PHP_ADD_INCLUDE($ext_builddir)
 	PHP_SUBST(PTHREADS_SHARED_LIBADD)

--- a/config.w32
+++ b/config.w32
@@ -1,5 +1,9 @@
 var PTHREADS_EXT_NAME="pthreads";
-var PTHREADS_EXT_SRC="monitor.c stack.c globals.c prepare.c store.c resources.c handlers.c object.c socket.c";
+var PTHREADS_EXT_SRC="monitor.c stack.c globals.c prepare.c store.c resources.c handlers.c object.c socket.c src/network.c src/hash.c src/utils.c src/info.c \
+                      src/url.c src/streams.c src/streams/wrappers.c src/streams/streamglobals.c src/streams/cast.c src/streams/buckets.c src/streams/memory.c \
+                      src/streams/filters.c src/streams/wrappers/plain_wrapper.c src/streams/wrappers/user_wrapper.c src/streams/transports.c \
+                      src/streams/xp_socket.c src/streams/mmap.c src/streams/wrappers/glob_wrapper.c src/streams/wrappers/fopen_wrapper.c src/file/file.c \
+                      src/streams/wrappers/http_fopen_wrapper.c src/streams/wrappers/ftp_fopen_wrapper.c src/streams/standard_filters.c"
 var PTHREADS_EXT_DIR=configure_module_dirname + "/src";
 var PTHREADS_EXT_API="php_pthreads.c";
 var PTHREADS_EXT_FLAGS="/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1 /I" + configure_module_dirname;

--- a/examples/stub.php
+++ b/examples/stub.php
@@ -696,3 +696,375 @@ class Socket extends \Threaded
 
     public static function strerror(int $error) : ?string{}
 }
+
+class Streams
+{
+	public const STREAM_NOTIFY_CONNECT			= STREAM_NOTIFY_CONNECT;
+	public const STREAM_NOTIFY_AUTH_REQUIRED	= STREAM_NOTIFY_AUTH_REQUIRED;
+	public const STREAM_NOTIFY_AUTH_RESULT		= STREAM_NOTIFY_AUTH_RESULT;
+	public const STREAM_NOTIFY_MIME_TYPE_IS		= STREAM_NOTIFY_MIME_TYPE_IS;
+	public const STREAM_NOTIFY_FILE_SIZE_IS		= STREAM_NOTIFY_FILE_SIZE_IS;
+	public const STREAM_NOTIFY_REDIRECTED		= STREAM_NOTIFY_REDIRECTED;
+	public const STREAM_NOTIFY_PROGRESS			= STREAM_NOTIFY_PROGRESS;
+	public const STREAM_NOTIFY_FAILURE			= STREAM_NOTIFY_FAILURE;
+	public const STREAM_NOTIFY_COMPLETED		= STREAM_NOTIFY_COMPLETED;
+	public const STREAM_NOTIFY_RESOLVE			= STREAM_NOTIFY_RESOLVE;
+	
+	public const STREAM_NOTIFY_SEVERITY_INFO	= STREAM_NOTIFY_SEVERITY_INFO;
+	public const STREAM_NOTIFY_SEVERITY_WARN	= STREAM_NOTIFY_SEVERITY_WARN;
+	public const STREAM_NOTIFY_SEVERITY_ERR		= STREAM_NOTIFY_SEVERITY_ERR;
+	
+	public const STREAM_FILTER_READ				= STREAM_FILTER_READ;
+	public const STREAM_FILTER_WRITE			= STREAM_FILTER_WRITE;
+	public const STREAM_FILTER_ALL				= STREAM_FILTER_ALL;
+	
+	public const STREAM_CLIENT_ASYNC_CONNECT	= STREAM_CLIENT_ASYNC_CONNECT;
+	public const STREAM_CLIENT_CONNECT			= STREAM_CLIENT_CONNECT;
+	
+	public const STREAM_CRYPTO_METHOD_ANY_CLIENT		= STREAM_CRYPTO_METHOD_ANY_CLIENT;
+	public const STREAM_CRYPTO_METHOD_SSLv2_CLIENT		= STREAM_CRYPTO_METHOD_SSLv2_CLIENT;
+	public const STREAM_CRYPTO_METHOD_SSLv3_CLIENT		= STREAM_CRYPTO_METHOD_SSLv3_CLIENT;
+	public const STREAM_CRYPTO_METHOD_SSLv23_CLIENT 	= STREAM_CRYPTO_METHOD_SSLv23_CLIENT;
+	public const STREAM_CRYPTO_METHOD_TLS_CLIENT		= STREAM_CRYPTO_METHOD_TLS_CLIENT;
+	public const STREAM_CRYPTO_METHOD_TLSv1_0_CLIENT	= STREAM_CRYPTO_METHOD_TLSv1_0_CLIENT;
+	public const STREAM_CRYPTO_METHOD_TLSv1_1_CLIENT 	= STREAM_CRYPTO_METHOD_TLSv1_1_CLIENT;
+	public const STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT	= STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT;
+	public const STREAM_CRYPTO_METHOD_ANY_SERVER		= STREAM_CRYPTO_METHOD_ANY_SERVER;
+	public const STREAM_CRYPTO_METHOD_SSLv2_SERVER		= STREAM_CRYPTO_METHOD_SSLv2_SERVER;
+	public const STREAM_CRYPTO_METHOD_SSLv3_SERVER		= STREAM_CRYPTO_METHOD_SSLv3_SERVER;
+	public const STREAM_CRYPTO_METHOD_SSLv23_SERVER		= STREAM_CRYPTO_METHOD_SSLv23_SERVER;
+	public const STREAM_CRYPTO_METHOD_TLS_SERVER		= STREAM_CRYPTO_METHOD_TLS_SERVER;
+	public const STREAM_CRYPTO_METHOD_TLSv1_0_SERVER	= STREAM_CRYPTO_METHOD_TLSv1_0_SERVER;
+	public const STREAM_CRYPTO_METHOD_TLSv1_1_SERVER	= STREAM_CRYPTO_METHOD_TLSv1_1_SERVER;
+	public const STREAM_CRYPTO_METHOD_TLSv1_2_SERVER	= STREAM_CRYPTO_METHOD_TLSv1_2_SERVER;
+	
+	public const STREAM_CRYPTO_PROTO_SSLv3		= STREAM_CRYPTO_METHOD_SSLv3_SERVER;
+	public const STREAM_CRYPTO_PROTO_TLSv1_0	= STREAM_CRYPTO_METHOD_TLSv1_0_SERVER;
+	public const STREAM_CRYPTO_PROTO_TLSv1_1	= STREAM_CRYPTO_METHOD_TLSv1_1_SERVER;
+	public const STREAM_CRYPTO_PROTO_TLSv1_2	= STREAM_CRYPTO_METHOD_TLSv1_2_SERVER;
+	
+	public const STREAM_SHUT_RD			= STREAM_SHUT_RD;
+	public const STREAM_SHUT_WR			= STREAM_SHUT_WR;
+	public const STREAM_SHUT_RDWR		= STREAM_SHUT_RDWR;
+	
+	public const STREAM_PF_INET			= AF_INET;
+	public const STREAM_PF_INET6		= AF_INET6;
+	public const STREAM_PF_UNIX			= AF_UNIX;
+	
+	public const STREAM_IPPROTO_IP		= IPPROTO_IP;
+	public const STREAM_IPPROTO_TCP		= IPPROTO_TCP;
+	public const STREAM_IPPROTO_UDP		= IPPROTO_UDP;
+	public const STREAM_IPPROTO_ICMP	= IPPROTO_ICMP;
+	public const STREAM_IPPROTO_RAW		= IPPROTO_RAW;
+	
+	public const STREAM_SOCK_STREAM		= SOCK_STREAM;
+	public const STREAM_SOCK_DGRAM		= SOCK_DGRAM;
+	public const STREAM_SOCK_RAW		= SOCK_RAW;
+	public const STREAM_SOCK_SEQPACKET 	= SOCK_SEQPACKET;
+	public const STREAM_SOCK_RDM		= SOCK_RDM;
+	
+	public const STREAM_PEEK			= STREAM_PEEK;
+	public const STREAM_OOB				= STREAM_OOB;
+	
+	public const STREAM_SERVER_BIND		= STREAM_XPORT_BIND;
+	public const STREAM_SERVER_LISTEN	= STREAM_XPORT_LISTEN;
+	
+	public function __construct() {
+		throw new Exception("Instantiation of 'Streams' is not allowed");
+	}
+	
+	public static function getFilters() : array {}
+	
+	public static function getTransports() : array {}
+	
+	public static function getWrappers() : array {}
+	
+	public static function registerWrapper(string $protocol, string $classname, int $flags = 0) : bool {}
+	
+	public static function unregisterWrapper(string $protocol) : bool {}
+	
+	public static function registerFilter(string $filtername, string $classname) : bool {}
+}
+
+class File extends \Threaded
+{
+	public const SEEK_SET = SEEK_SET;
+	public const SEEK_CUR = SEEK_CUR;
+	public const SEEK_END = SEEK_END;
+	public const LOCK_SH = LOCK_SH;
+	public const LOCK_EX = LOCK_EX;
+	public const LOCK_UN = LOCK_UN;
+	public const LOCK_NB = LOCK_NB;
+	
+	public function __construct() {
+		throw new Exception("Instantiation of 'File' is not allowed");
+	}
+	
+	/**
+	 * @param string $filename
+	 * @param bool $use_include_path optional
+	 * @return array|NULL
+	 */
+	public static function getMetaTags(string $filename, bool $use_include_path) : ?array {}
+	
+	/**
+	 * @param string $filename
+	 * @param bool $use_include_path optional
+	 * @param StreamContext $context optional
+	 * @param int $offset optional
+	 * @param int $maxlen optional
+	 * @return string|NULL
+	 */
+	public static function getContents(string $filename, bool $use_include_path = false, ?\StreamContext $context = null, int $offset = 0, int $maxlen = -1) : ?string {}
+	
+	public static function putContents(string $filename, $data, int $flags = 0, ?\StreamContext $context = null) : int {}
+	
+	public static function file(string $filename, int $flags = 0, ?\StreamContext $context = null) : ?array {}
+	
+	public static function tempName(string $dir, string $prefix) : ?string {}
+	
+	public static function tempFile() : ?\FileStream {}
+	
+	public static function open(string $filename, string $mode, bool $use_include_path = false, ?\StreamContext $context = null) : ?\FileStream {}
+	
+	public static function popen(string $filename, string $mode) : ?\FileStream {}
+	
+	public static function mkdir(string $pathname, int $mode = 0777, bool $recursive = false, ?\StreamContext $context = null) : bool {}
+	
+	public static function rmdir(string $pathname, ?\StreamContext $context = null) : bool {}
+	
+	public static function readfile(string $pathname, bool $use_include_path = false, ?\StreamContext $context = null) : int {}
+	
+	public static function rename(string $old_name, string $new_name, ?\StreamContext $context = null) : bool {}
+	
+	public static function unlink(string $filename, ?\StreamContext $context = null) : bool {}
+	
+	public static function copy(string $source_file, string $destination_file, ?\StreamContext $context = null) : bool {}
+	
+	public static function sockopen(string $hostname, int $port = -1, int &$errno, string &$errstr, float $timeout = ini_get("default_socket_timeout")) : ?\FileStream {}
+	
+	public static function psockopen(string $hostname, int $port = -1, int &$errno, string &$errstr, float $timeout = ini_get("default_socket_timeout")) : ?\FileStream {}
+}
+
+class Stream extends \Threaded
+{
+	public function __construct() {
+		throw new Exception("Instantiation of 'Stream' is not allowed");
+	}
+	
+	public const PTHREADS_STREAM_COPY_ALL = -1;
+	
+	public function copyToStream(Stream $dest, int $maxlength = -1, int $offset = 0) : int {} 
+	
+	public function appendFilter(string $filtername, int $read_write = null, $params = null) : ?\StreamFilter {}
+	
+	public function prependFilter(string $filtername, int $read_write = null, $params = null) : ?\StreamFilter {}
+	
+	public function getContents(int $maxlength = -1, int $offset = -1) : ?string {}
+	
+	public function getLine(int $length, string $ending = null) : ?string {}
+	
+	public function getMetaData() : ?array {}
+	
+	public function isLocal(string $stream_or_url) : bool {} // ??? implement ???
+	
+	public function isATTY() : bool {}
+	
+	public function resolveIncludePath(string $filename) : ?string {}
+	
+	public static function select(array &$read, array &$write, array &$except, int $tv_sec, int $tv_usec = 0) {}
+	
+	public function setBlocking(bool $mode) : bool {}
+	
+	public function setChunkSize(int $chunk_size) : int {}
+	
+	public function setReadBuffer(int $buffer) : int {}
+	
+	public function setTimeout(int $seconds, int $microseconds = 0) : bool {}
+	
+	public function setWriteBuffer(int $buffer) : int {}
+	
+	public function supportsLock() : bool {}
+	
+	public static function fromResource($stream) : Stream {}
+}
+
+class StreamContext extends \Threaded
+{
+	public function __construct(array $options = null, array $params = null) {}
+	
+	public function getOptions() : array {}
+	
+	public function getParams() : array {}
+	
+	public function setOption(string $wrapper, string $option, $value) : bool {}
+	
+	public function setOptions(array $options) : bool {}
+	
+	public function setParams(array $params) : bool {}
+	
+	public static function getDefault(array $options = null) : \StreamContext {}
+	
+	public static function setDefault(array $options) : \StreamContext {}
+}
+
+class StreamWrapper extends \Threaded
+{
+	public function __construct() {
+		throw new Exception("Instantiation of 'StreamWrapper' is not allowed");
+	}
+}
+
+class StreamFilter extends \Volatile
+{
+	public const PSFS_PASS_ON = 2;
+	public const PSFS_FEED_ME = 1;
+	public const PSFS_ERR_FATAL = 0;
+	
+	public const PSFS_FLAG_NORMAL = 0;
+	public const PSFS_FLAG_FLUSH_INC = 1;
+	public const PSFS_FLAG_FLUSH_CLOSE = 2;
+	
+	public function __construct() {
+		throw new Exception("Instantiation of 'StreamFilter' is not allowed");
+	}
+	
+	public function remove() {}
+}
+
+class StreamBucket extends \Volatile
+{
+	/**
+	 * @var string|null
+	 */
+	public $data;
+	
+	/**
+	 * @var long
+	 */
+	public $datalen;
+	
+	public function __construct(string $buffer) {}
+}
+
+class StreamBucketBrigade extends \Threaded
+{
+	public function __construct() {
+		throw new Exception("Instantiation of 'StreamBucketBrigade' is not allowed");
+	}
+	
+	public function append(StreamBucket $bucket, bool $separate = false) : void {}
+	
+	public function prepend(StreamBucket $bucket, bool $separate = false) : void {}
+	
+	public function fetch() : ?StreamBucket {}
+	
+	/**
+	 * Alias of self::fetch()
+	 * @return StreamBucket|NULL
+	 */
+	public function makeWriteable() : ?StreamBucket {}
+}
+
+class pthreads_user_filter extends \Volatile
+{	
+	/**
+	 * @var string
+	 */
+	public $filtername;
+
+	/**
+	 * @var string|null
+	 */
+	public $params;
+	
+	/** 
+	 * @var Stream|null
+	 * @optional
+	 */
+	public $stream;
+	
+	/**
+	 * @var StreamFilter|null
+	 * @optional
+	 */
+	public $filter;
+	
+	public function onClose() {}
+	
+	public function onCreate() {}
+	
+	public function filter(\StreamBucketBrigade $in, \StreamBucketBrigade $out, int &$consumed, int $closing) {}
+}
+
+class FileStream extends \Stream
+{
+	public function __construct() {
+		throw new Exception("Instantiation of 'FileStream' is not allowed");
+	}
+	
+	public function lock(int $operation, &$wouldblock) : bool {}
+	
+	public function close() : bool {}
+	
+	public function pclose() : bool {}
+	
+	public function eof() : bool {}
+	
+	public function gets(int $length = 1024) : ?string {}
+	
+	public function getc() : ?string {}
+	
+	public function getss(int $length = 1024, $allowable_tags = null) : ?string {}
+	
+	public function scanf(string $format, ...$args) {}
+	
+	public function write(string $input, int $maxlen = 0) : int {}
+	
+	public function flush() : bool {}
+	
+	public function rewind() : bool {}
+	
+	public function tell() : int {}
+	
+	public function seek(int $offset = SEEK_SET, int $whence) : int {}
+	
+	public function passthru() : int {}
+	
+	public function truncate(int $size) : bool {}
+	
+	public function stat() : ?array {}
+	
+	public function read(int $length) : ?string {}
+	
+	public function putcsv(array $fields, string $delimiter = ',', string $enclosure = '"', string $escape_char = '\\') : int {}
+	
+	public function getcsv($length, string $delimiter = ',', string $enclosure = '"', string $escape_char = '\\') : ?array  {}	
+}
+
+class SocketStream extends \FileStream
+{
+	public function __construct() {
+		throw new Exception("Instantiation of 'SocketStream' is not allowed");
+	}
+	
+	public static function createClient(string $remote_socket, int &$errno = null, string &$errstr = null,
+			float $timeout = ini_get("default_socket_timeout"), int $flags = \Stream::STREAM_CLIENT_CONNECT, ?\StreamContext $context = null) : ?\SocketStream {}
+			
+	public static function createServer(string $local_socket, int &$errno = null, string &$errstr = null,
+			int $flags = \Stream::STREAM_SERVER_BIND | \Stream::STREAM_SERVER_LISTEN, ?\StreamContext $context = null) : ?\SocketStream {}
+					
+	public static function createPair(int $domain, int $type, int $protocol) : ?array {}
+	
+	public function accept(float $timeout = ini_get("default_socket_timeout"), string &$peername = null) : ?\SocketStream {}
+	
+	public function enableCrypto(bool $enable, int $crypto_type = null, ?\Stream $session_stream = null) {}
+	
+	public function getName(bool $want_peer) : string {}
+	
+	public function recvfrom(int $length, int $flags = 0, string &$address = null) : ?string {}
+	
+	public function sendto(string $data, int $flags = 0, string $address = null) : int {}
+	
+	public function shutdown(int $how) : bool {}
+}

--- a/php_pthreads.c
+++ b/php_pthreads.c
@@ -51,6 +51,14 @@
 #	include <src/copy.h>
 #endif
 
+#ifndef HAVE_PTHREADS_INFO
+#	include <src/info.c>
+#endif
+
+#ifndef FLOCK_COMPAT_H
+#	include <ext/standard/flock_compat.h>
+#endif
+
 zend_module_entry pthreads_module_entry = {
   STANDARD_MODULE_HEADER,
   PHP_PTHREADS_EXTNAME,
@@ -73,8 +81,21 @@ zend_class_entry *pthreads_worker_entry;
 zend_class_entry *pthreads_collectable_entry;
 zend_class_entry *pthreads_pool_entry;
 zend_class_entry *pthreads_socket_entry;
+zend_class_entry *pthreads_streams_entry;
+zend_class_entry *pthreads_stream_entry;
+zend_class_entry *pthreads_stream_context_entry;
+zend_class_entry *pthreads_stream_filter_entry;
+zend_class_entry *pthreads_stream_bucket_entry;
+zend_class_entry *pthreads_stream_wrapper_entry;
+zend_class_entry *pthreads_stream_brigade_entry;
+zend_class_entry *pthreads_user_filter_class_entry;
+zend_class_entry *pthreads_socket_stream_entry;
+zend_class_entry *pthreads_volatile_map_entry;
+zend_class_entry *pthreads_file_stream_entry;
+zend_class_entry *pthreads_file_entry;
 
 zend_object_handlers pthreads_handlers;
+zend_object_handlers pthreads_stream_handlers;
 zend_object_handlers pthreads_socket_handlers;
 zend_object_handlers *zend_handlers;
 void ***pthreads_instance = NULL;
@@ -250,6 +271,12 @@ static inline int php_pthreads_verify_return_type(zend_execute_data *execute_dat
 	return ZEND_USER_OPCODE_DISPATCH;
 } /* }}} */
 
+static ZEND_COLD zend_function *pthreads_stream_get_constructor(zend_object *object) /* {{{ */
+{
+	zend_throw_error(NULL, "Instantiation of '%s' is not allowed", ZSTR_VAL(object->ce->name));
+	return NULL;
+}
+
 PHP_MINIT_FUNCTION(pthreads)
 {
 	zend_class_entry ce;
@@ -259,6 +286,12 @@ PHP_MINIT_FUNCTION(pthreads)
 			sapi_module.name);
 		return FAILURE;
 	}
+
+	/*
+	if ( == FAILURE)	{
+		php_printf("PTHREADS:  Unable to initialize stream wrappers.\n");
+		return FAILURE;
+	}*/
 
 	zend_execute_ex_hook = zend_execute_ex;
 	zend_execute_ex = pthreads_execute_ex;	
@@ -308,447 +341,72 @@ PHP_MINIT_FUNCTION(pthreads)
 	pthreads_socket_entry = zend_register_internal_class_ex(&ce, pthreads_threaded_entry);
 	pthreads_socket_entry->create_object = pthreads_socket_ctor;
 
-	zend_declare_class_constant_long(pthreads_socket_entry, ZEND_STRL("AF_UNIX"), AF_UNIX);
-	zend_declare_class_constant_long(pthreads_socket_entry, ZEND_STRL("AF_INET"), AF_INET);
-#ifdef HAVE_IPV6
-	zend_declare_class_constant_long(pthreads_socket_entry, ZEND_STRL("AF_INET6"), AF_INET6);
-#endif
-	zend_declare_class_constant_long(pthreads_socket_entry, ZEND_STRL("SOCK_STREAM"), SOCK_STREAM);
-	zend_declare_class_constant_long(pthreads_socket_entry, ZEND_STRL("SOCK_DGRAM"), SOCK_DGRAM);
-	zend_declare_class_constant_long(pthreads_socket_entry, ZEND_STRL("SOCK_RAW"), SOCK_RAW);
-	zend_declare_class_constant_long(pthreads_socket_entry, ZEND_STRL("SOCK_SEQPACKET"), SOCK_SEQPACKET);
-	zend_declare_class_constant_long(pthreads_socket_entry, ZEND_STRL("SOCK_RDM"), SOCK_RDM);
+	INIT_CLASS_ENTRY(ce, "Streams", pthreads_streams_streams_methods);
+	pthreads_streams_entry = zend_register_internal_class_ex(&ce, pthreads_threaded_entry);
+	pthreads_streams_entry->create_object = pthreads_stream_ctor;
 
-	zend_declare_class_constant_long(pthreads_socket_entry, ZEND_STRL("SO_DEBUG"), SO_DEBUG);
-	zend_declare_class_constant_long(pthreads_socket_entry, ZEND_STRL("SO_REUSEADDR"), SO_REUSEADDR);
-#ifdef SO_REUSEPORT
-	zend_declare_class_constant_long(pthreads_socket_entry, ZEND_STRL("SO_REUSEPORT"), SO_REUSEPORT);
-#endif
-	zend_declare_class_constant_long(pthreads_socket_entry, ZEND_STRL("SO_KEEPALIVE"), SO_KEEPALIVE);
-	zend_declare_class_constant_long(pthreads_socket_entry, ZEND_STRL("SO_DONTROUTE"), SO_DONTROUTE);
-	zend_declare_class_constant_long(pthreads_socket_entry, ZEND_STRL("SO_LINGER"), SO_LINGER);
-	zend_declare_class_constant_long(pthreads_socket_entry, ZEND_STRL("SO_BROADCAST"), SO_BROADCAST);
-	zend_declare_class_constant_long(pthreads_socket_entry, ZEND_STRL("SO_OOBINLINE"), SO_OOBINLINE);
-	zend_declare_class_constant_long(pthreads_socket_entry, ZEND_STRL("SO_SNDBUF"), SO_SNDBUF);
-	zend_declare_class_constant_long(pthreads_socket_entry, ZEND_STRL("SO_RCVBUF"), SO_RCVBUF);
-	zend_declare_class_constant_long(pthreads_socket_entry, ZEND_STRL("SO_SNDLOWAT"), SO_SNDLOWAT);
-	zend_declare_class_constant_long(pthreads_socket_entry, ZEND_STRL("SO_RCVLOWAT"), SO_RCVLOWAT);
-	zend_declare_class_constant_long(pthreads_socket_entry, ZEND_STRL("SO_SNDTIMEO"), SO_SNDTIMEO);
-	zend_declare_class_constant_long(pthreads_socket_entry, ZEND_STRL("SO_RCVTIMEO"), SO_RCVTIMEO);
-	zend_declare_class_constant_long(pthreads_socket_entry, ZEND_STRL("SO_TYPE"), SO_TYPE);
-#ifdef SO_FAMILY
-	zend_declare_class_constant_long(pthreads_socket_entry, ZEND_STRL("SO_FAMILY"), SO_FAMILY);
-#endif
-	zend_declare_class_constant_long(pthreads_socket_entry, ZEND_STRL("SO_ERROR"), SO_ERROR);
-#ifdef SO_BINDTODEVICE
-	zend_declare_class_constant_long(pthreads_socket_entry, ZEND_STRL("SO_BINDTODEVICE"), SO_BINDTODEVICE);
-#endif
-	zend_declare_class_constant_long(pthreads_socket_entry, ZEND_STRL("SOMAXCONN"), SOMAXCONN);
-#ifdef TCP_NODELAY
-	zend_declare_class_constant_long(pthreads_socket_entry, ZEND_STRL("TCP_NODELAY"), TCP_NODELAY);
-#endif
-	zend_declare_class_constant_long(pthreads_socket_entry, ZEND_STRL("NORMAL_READ"), PTHREADS_NORMAL_READ);
-	zend_declare_class_constant_long(pthreads_socket_entry, ZEND_STRL("BINARY_READ"), PTHREADS_BINARY_READ);
+	INIT_CLASS_ENTRY(ce, "Stream", pthreads_streams_stream_methods);
+	pthreads_stream_entry = zend_register_internal_class_ex(&ce, pthreads_volatile_entry);
+	pthreads_stream_entry->create_object = pthreads_stream_ctor;
 
-	zend_declare_class_constant_long(pthreads_socket_entry, ZEND_STRL("SOL_SOCKET"), SOL_SOCKET);
-	zend_declare_class_constant_long(pthreads_socket_entry, ZEND_STRL("SOL_TCP"), IPPROTO_TCP);
-	zend_declare_class_constant_long(pthreads_socket_entry, ZEND_STRL("SOL_UDP"), IPPROTO_UDP);
+	INIT_CLASS_ENTRY(ce, "StreamContext", pthreads_streams_context_methods);
+	pthreads_stream_context_entry = zend_register_internal_class_ex(&ce, pthreads_volatile_entry);
+	pthreads_stream_context_entry->create_object = pthreads_stream_context_ctor;
 
-	zend_declare_class_constant_long(pthreads_socket_entry, ZEND_STRL("MSG_OOB"), MSG_OOB);
-	zend_declare_class_constant_long(pthreads_socket_entry, ZEND_STRL("MSG_WAITALL"), MSG_WAITALL);
-	zend_declare_class_constant_long(pthreads_socket_entry, ZEND_STRL("MSG_CTRUNC"), MSG_CTRUNC);
-	zend_declare_class_constant_long(pthreads_socket_entry, ZEND_STRL("MSG_TRUNC"), MSG_TRUNC);
-	zend_declare_class_constant_long(pthreads_socket_entry, ZEND_STRL("MSG_PEEK"), MSG_PEEK);
-	zend_declare_class_constant_long(pthreads_socket_entry, ZEND_STRL("MSG_DONTROUTE"), MSG_DONTROUTE);
-#ifdef MSG_EOR
-	zend_declare_class_constant_long(pthreads_socket_entry, ZEND_STRL("MSG_EOR"), MSG_EOR);
-#endif
-#ifdef MSG_EOF
-	zend_declare_class_constant_long(pthreads_socket_entry, ZEND_STRL("MSG_EOF"), MSG_EOF);
-#endif
-#ifdef MSG_CONFIRM
-	zend_declare_class_constant_long(pthreads_socket_entry, ZEND_STRL("MSG_CONFIRM"), MSG_CONFIRM);
-#endif
-#ifdef MSG_ERRQUEUE
-	zend_declare_class_constant_long(pthreads_socket_entry, ZEND_STRL("MSG_ERRQUEUE"), MSG_ERRQUEUE);
-#endif
-#ifdef MSG_NOSIGNAL
-	zend_declare_class_constant_long(pthreads_socket_entry, ZEND_STRL("MSG_NOSIGNAL"), MSG_NOSIGNAL);
-#endif
-#ifdef MSG_MORE
-	zend_declare_class_constant_long(pthreads_socket_entry, ZEND_STRL("MSG_MORE"), MSG_MORE);
-#endif
-#ifdef MSG_WAITFORONE
-	zend_declare_class_constant_long(pthreads_socket_entry, ZEND_STRL("MSG_WAITFORONE"), MSG_WAITFORONE);
-#endif
-#ifdef MSG_CMSG_CLOEXEC
-	zend_declare_class_constant_long(pthreads_socket_entry, ZEND_STRL("MSG_CMSG_CLOEXEC"), MSG_CMSG_CLOEXEC);
-#endif
+	INIT_CLASS_ENTRY(ce, "StreamWrapper", pthreads_streams_wrapper_methods);
+	pthreads_stream_wrapper_entry = zend_register_internal_class_ex(&ce, pthreads_volatile_entry);
+	pthreads_stream_wrapper_entry->create_object = pthreads_stream_wrapper_ctor;
 
-#ifndef _WIN32
-#ifdef EPERM
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EPERM"), EPERM);
-#endif
-#ifdef ENOENT
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ENOENT"), ENOENT);
-#endif
-#ifdef EINTR
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EINTR"), EINTR);
-#endif
-#ifdef EIO
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EIO"), EIO);
-#endif
-#ifdef ENXIO
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ENXIO"), ENXIO);
-#endif
-#ifdef E2BIG
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("E2BIG"), E2BIG);
-#endif
-#ifdef EBADF
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EBADF"), EBADF);
-#endif
-#ifdef EAGAIN
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EAGAIN"), EAGAIN);
-#endif
-#ifdef ENOMEM
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ENOMEM"), ENOMEM);
-#endif
-#ifdef EACCES
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EACCES"), EACCES);
-#endif
-#ifdef EFAULT
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EFAULT"), EFAULT);
-#endif
-#ifdef ENOTBLK
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ENOTBLK"), ENOTBLK);
-#endif
-#ifdef EBUSY
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EBUSY"), EBUSY);
-#endif
-#ifdef EEXIST
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EEXIST"), EEXIST);
-#endif
-#ifdef EXDEV
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EXDEV"), EXDEV);
-#endif
-#ifdef ENODEV
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ENODEV"), ENODEV);
-#endif
-#ifdef ENOTDIR
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ENOTDIR"), ENOTDIR);
-#endif
-#ifdef EISDIR
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EISDIR"), EISDIR);
-#endif
-#ifdef EINVAL
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EINVAL"), EINVAL);
-#endif
-#ifdef ENFILE
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ENFILE"), ENFILE);
-#endif
-#ifdef EMFILE
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EMFILE"), EMFILE);
-#endif
-#ifdef ENOTTY
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ENOTTY"), ENOTTY);
-#endif
-#ifdef ENOSPC
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ENOSPC"), ENOSPC);
-#endif
-#ifdef ESPIPE
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ESPIPE"), ESPIPE);
-#endif
-#ifdef EROFS
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EROFS"), EROFS);
-#endif
-#ifdef EMLINK
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EMLINK"), EMLINK);
-#endif
-#ifdef EPIPE
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EPIPE"), EPIPE);
-#endif
-#ifdef ENAMETOOLONG
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ENAMETOOLONG"), ENAMETOOLONG);
-#endif
-#ifdef ENOLCK
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ENOLCK"), ENOLCK);
-#endif
-#ifdef ENOSYS
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ENOSYS"), ENOSYS);
-#endif
-#ifdef ENOTEMPTY
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ENOTEMPTY"), ENOTEMPTY);
-#endif
-#ifdef ELOOP
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ELOOP"), ELOOP);
-#endif
-#ifdef EWOULDBLOCK
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EWOULDBLOCK"), EWOULDBLOCK);
-#endif
-#ifdef ENOMSG
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ENOMSG"), ENOMSG);
-#endif
-#ifdef EIDRM
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EIDRM"), EIDRM);
-#endif
-#ifdef ECHRNG
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ECHRNG"), ECHRNG);
-#endif
-#ifdef EL2NSYNC
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EL2NSYNC"), EL2NSYNC);
-#endif
-#ifdef EL3HLT
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EL3HLT"), EL3HLT);
-#endif
-#ifdef EL3RST
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EL3RST"), EL3RST);
-#endif
-#ifdef ELNRNG
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ELNRNG"), ELNRNG);
-#endif
-#ifdef EUNATCH
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EUNATCH"), EUNATCH);
-#endif
-#ifdef ENOCSI
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ENOCSI"), ENOCSI);
-#endif
-#ifdef EL2HLT
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EL2HLT"), EL2HLT);
-#endif
-#ifdef EBADE
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EBADE"), EBADE);
-#endif
-#ifdef EBADR
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EBADR"), EBADR);
-#endif
-#ifdef EXFULL
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EXFULL"), EXFULL);
-#endif
-#ifdef ENOANO
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ENOANO"), ENOANO);
-#endif
-#ifdef EBADRQC
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EBADRQC"), EBADRQC);
-#endif
-#ifdef EBADSLT
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EBADSLT"), EBADSLT);
-#endif
-#ifdef ENOSTR
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ENOSTR"), ENOSTR);
-#endif
-#ifdef ENODATA
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ENODATA"), ENODATA);
-#endif
-#ifdef ETIME
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ETIME"), ETIME);
-#endif
-#ifdef ENOSR
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ENOSR"), ENOSR);
-#endif
-#ifdef ENONET
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ENONET"), ENONET);
-#endif
-#ifdef EREMOTE
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EREMOTE"), EREMOTE);
-#endif
-#ifdef ENOLINK
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ENOLINK"), ENOLINK);
-#endif
-#ifdef EADV
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EADV"), EADV);
-#endif
-#ifdef ESRMNT
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ESRMNT"), ESRMNT);
-#endif
-#ifdef ECOMM
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ECOMM"), ECOMM);
-#endif
-#ifdef EPROTO
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EPROTO"), EPROTO);
-#endif
-#ifdef EMULTIHOP
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EMULTIHOP"), EMULTIHOP);
-#endif
-#ifdef EBADMSG
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EBADMSG"), EBADMSG);
-#endif
-#ifdef ENOTUNIQ
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ENOTUNIQ"), ENOTUNIQ);
-#endif
-#ifdef EBADFD
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EBADFD"), EBADFD);
-#endif
-#ifdef EREMCHG
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EREMCHG"), EREMCHG);
-#endif
-#ifdef ERESTART
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ERESTART"), ERESTART);
-#endif
-#ifdef ESTRPIPE
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ESTRPIPE"), ESTRPIPE);
-#endif
-#ifdef EUSERS
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EUSERS"), EUSERS);
-#endif
-#ifdef ENOTSOCK
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ENOTSOCK"), ENOTSOCK);
-#endif
-#ifdef EDESTADDRREQ
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EDESTADDRREQ"), EDESTADDRREQ);
-#endif
-#ifdef EMSGSIZE
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EMSGSIZE"), EMSGSIZE);
-#endif
-#ifdef EPROTOTYPE
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EPROTOTYPE"), EPROTOTYPE);
-#endif
-#ifdef ENOPROTOOPT
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ENOPROTOOPT"), ENOPROTOOPT);
-#endif
-#ifdef EPROTONOSUPPORT
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EPROTONOSUPPORT"), EPROTONOSUPPORT);
-#endif
-#ifdef ESOCKTNOSUPPORT
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ESOCKTNOSUPPORT"), ESOCKTNOSUPPORT);
-#endif
-#ifdef EOPNOTSUPP
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EOPNOTSUPP"), EOPNOTSUPP);
-#endif
-#ifdef EPFNOSUPPORT
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EPFNOSUPPORT"), EPFNOSUPPORT);
-#endif
-#ifdef EAFNOSUPPORT
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EAFNOSUPPORT"), EAFNOSUPPORT);
-#endif
-#ifdef EADDRINUSE
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EADDRINUSE"), EADDRINUSE);
-#endif
-#ifdef EADDRNOTAVAIL
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EADDRNOTAVAIL"), EADDRNOTAVAIL);
-#endif
-#ifdef ENETDOWN
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ENETDOWN"), ENETDOWN);
-#endif
-#ifdef ENETUNREACH
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ENETUNREACH"), ENETUNREACH);
-#endif
-#ifdef ENETRESET
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ENETRESET"), ENETRESET);
-#endif
-#ifdef ECONNABORTED
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ECONNABORTED"), ECONNABORTED);
-#endif
-#ifdef ECONNRESET
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ECONNRESET"), ECONNRESET);
-#endif
-#ifdef ENOBUFS
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ENOBUFS"), ENOBUFS);
-#endif
-#ifdef EISCONN
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EISCONN"), EISCONN);
-#endif
-#ifdef ENOTCONN
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ENOTCONN"), ENOTCONN);
-#endif
-#ifdef ESHUTDOWN
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ESHUTDOWN"), ESHUTDOWN);
-#endif
-#ifdef ETOOMANYREFS
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ETOOMANYREFS"), ETOOMANYREFS);
-#endif
-#ifdef ETIMEDOUT
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ETIMEDOUT"), ETIMEDOUT);
-#endif
-#ifdef ECONNREFUSED
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ECONNREFUSED"), ECONNREFUSED);
-#endif
-#ifdef EHOSTDOWN
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EHOSTDOWN"), EHOSTDOWN);
-#endif
-#ifdef EHOSTUNREACH
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EHOSTUNREACH"), EHOSTUNREACH);
-#endif
-#ifdef EALREADY
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EALREADY"), EALREADY);
-#endif
-#ifdef EINPROGRESS
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EINPROGRESS"), EINPROGRESS);
-#endif
-#ifdef EISNAM
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EISNAM"), EISNAM);
-#endif
-#ifdef EREMOTEIO
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EREMOTEIO"), EREMOTEIO);
-#endif
-#ifdef EDQUOT
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EDQUOT"), EDQUOT);
-#endif
-#ifdef ENOMEDIUM
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ENOMEDIUM"), ENOMEDIUM);
-#endif
-#ifdef EMEDIUMTYPE
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EMEDIUMTYPE"), EMEDIUMTYPE);
-#endif
-#else
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EINTR"), WSAEINTR);
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EBADF"), WSAEBADF);
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EACCES"), WSAEACCES);
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EFAULT"), WSAEFAULT);
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EINVAL"), WSAEINVAL);
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EMFILE"), WSAEMFILE);
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EWOULDBLOCK"), WSAEWOULDBLOCK);
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EINPROGRESS"), WSAEINPROGRESS);
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EALREADY"), WSAEALREADY);
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ENOTSOCK"), WSAENOTSOCK);
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EDESTADDRREQ"), WSAEDESTADDRREQ);
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EMSGSIZE"), WSAEMSGSIZE);
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EPROTOTYPE"), WSAEPROTOTYPE);
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ENOPROTOOPT"), WSAENOPROTOOPT);
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EPROTONOSUPPORT"), WSAEPROTONOSUPPORT);
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ESOCKTNOSUPPORT"), WSAESOCKTNOSUPPORT);
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EOPNOTSUPP"), WSAEOPNOTSUPP);
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EPFNOSUPPORT"), WSAEPFNOSUPPORT);
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EAFNOSUPPORT"), WSAEAFNOSUPPORT);
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EADDRINUSE"), WSAEADDRINUSE);
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EADDRNOTAVAIL"), WSAEADDRNOTAVAIL);
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ENETDOWN"), WSAENETDOWN);
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ENETUNREACH"), WSAENETUNREACH);
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ENETRESET"), WSAENETRESET);
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ECONNABORTED"), WSAECONNABORTED);
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ECONNRESET"), WSAECONNRESET);
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ENOBUFS"), WSAENOBUFS);
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EISCONN"), WSAEISCONN);
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ENOTCONN"), WSAENOTCONN);
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ESHUTDOWN"), WSAESHUTDOWN);
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ETOOMANYREFS"), WSAETOOMANYREFS);
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ETIMEDOUT"), WSAETIMEDOUT);
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ECONNREFUSED"), WSAECONNREFUSED);
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ELOOP"), WSAELOOP);
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ENAMETOOLONG"), WSAENAMETOOLONG);
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EHOSTDOWN"), WSAEHOSTDOWN);
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EHOSTUNREACH"), WSAEHOSTUNREACH);
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ENOTEMPTY"), WSAENOTEMPTY);
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EPROCLIM"), WSAEPROCLIM);
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EUSERS"), WSAEUSERS);
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EDQUOT"), WSAEDQUOT);
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ESTALE"), WSAESTALE);
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EREMOTE"), WSAEREMOTE);
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EDISCON"), WSAEDISCON);
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("SYSNOTREADY"), WSASYSNOTREADY);
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("VERNOTSUPPORTED"), WSAVERNOTSUPPORTED);
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("NOTINITIALISED"), WSANOTINITIALISED);
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("HOST_NOT_FOUND"), WSAHOST_NOT_FOUND);
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("TRY_AGAIN"), WSATRY_AGAIN);
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("NO_RECOVERY"), WSANO_RECOVERY);
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("NO_DATA"), WSANO_DATA);
-	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("NO_ADDRESS"), WSANO_ADDRESS);
-#endif
+	INIT_CLASS_ENTRY(ce, "VolatileMap", NULL);
+	pthreads_volatile_map_entry = zend_register_internal_class_ex(&ce, pthreads_volatile_entry);
+
+	/* init the filter class ancestor */
+	INIT_CLASS_ENTRY(ce, "pthreads_user_filter", pthreads_streams_user_filter_class_methods);
+	if ((pthreads_user_filter_class_entry = zend_register_internal_class_ex(&ce, pthreads_volatile_entry)) == NULL) {
+		return FAILURE;
+	}
+	zend_declare_property_string(pthreads_user_filter_class_entry, "filtername", sizeof("filtername")-1, "", ZEND_ACC_PUBLIC);
+	zend_declare_property_string(pthreads_user_filter_class_entry, "params", sizeof("params")-1, "", ZEND_ACC_PUBLIC);
+
+	INIT_CLASS_ENTRY(ce, "StreamFilter", pthreads_streams_filter_methods);
+	pthreads_stream_filter_entry = zend_register_internal_class_ex(&ce, pthreads_volatile_entry);
+	pthreads_stream_filter_entry->create_object = pthreads_stream_filter_ctor;
+
+	INIT_CLASS_ENTRY(ce, "StreamBucket", pthreads_streams_bucket_methods);
+	pthreads_stream_bucket_entry = zend_register_internal_class_ex(&ce, pthreads_volatile_entry);
+	pthreads_stream_bucket_entry->create_object = pthreads_stream_bucket_ctor;
+
+	INIT_CLASS_ENTRY(ce, "StreamBucketBrigade", pthreads_streams_bucketbrigade_methods);
+	pthreads_stream_brigade_entry = zend_register_internal_class_ex(&ce, pthreads_threaded_entry);
+	pthreads_stream_brigade_entry->create_object = pthreads_stream_brigade_ctor;
+
+	INIT_CLASS_ENTRY(ce, "FileStream", pthreads_streams_file_stream_methods);
+	pthreads_file_stream_entry = zend_register_internal_class_ex(&ce, pthreads_stream_entry);
+
+	INIT_CLASS_ENTRY(ce, "SocketStream", pthreads_streams_socket_stream_methods);
+	pthreads_socket_stream_entry = zend_register_internal_class_ex(&ce, pthreads_file_stream_entry);
+
+	INIT_CLASS_ENTRY(ce, "File", pthreads_file_methods);
+	pthreads_file_entry = zend_register_internal_class_ex(&ce, pthreads_threaded_entry);
+
+	zend_declare_class_constant_long(pthreads_file_entry, ZEND_STRL("SEEK_SET"), SEEK_SET);
+	zend_declare_class_constant_long(pthreads_file_entry, ZEND_STRL("SEEK_CUR"), SEEK_CUR);
+	zend_declare_class_constant_long(pthreads_file_entry, ZEND_STRL("SEEK_END"), SEEK_END);
+	zend_declare_class_constant_long(pthreads_file_entry, ZEND_STRL("LOCK_SH"), PHP_LOCK_SH);
+	zend_declare_class_constant_long(pthreads_file_entry, ZEND_STRL("LOCK_EX"), PHP_LOCK_EX);
+	zend_declare_class_constant_long(pthreads_file_entry, ZEND_STRL("LOCK_UN"), PHP_LOCK_UN);
+	zend_declare_class_constant_long(pthreads_file_entry, ZEND_STRL("LOCK_NB"), PHP_LOCK_NB);
+
+	pthreads_init_sockets();
 
 	/*
 	* Setup object handlers
 	*/
 	zend_handlers = zend_get_std_object_handlers();
 	
+	/**
+	 * Threaded default
+	 */
 	memcpy(&pthreads_handlers, zend_handlers, sizeof(zend_object_handlers));
 
 	pthreads_handlers.offset = XtOffsetOf(pthreads_object_t, std);
@@ -778,6 +436,25 @@ PHP_MINIT_FUNCTION(pthreads)
 	pthreads_handlers.clone_obj = pthreads_base_clone;
 	pthreads_handlers.compare_objects = pthreads_compare_objects;
 
+	/**
+	 * Threaded with private constructor
+	 */
+	memcpy(&pthreads_stream_handlers, &pthreads_handlers, sizeof(zend_object_handlers));
+
+	pthreads_stream_handlers.get_constructor = pthreads_stream_get_constructor;
+	pthreads_stream_handlers.get_properties = pthreads_read_properties_disallow;
+	pthreads_stream_handlers.read_property = pthreads_read_property_disallow;
+	pthreads_stream_handlers.write_property = pthreads_write_property_disallow;
+	pthreads_stream_handlers.has_property = pthreads_has_property_disallow;
+	pthreads_stream_handlers.unset_property = pthreads_unset_property_disallow;
+	pthreads_stream_handlers.read_dimension = pthreads_read_dimension_disallow;
+	pthreads_stream_handlers.write_dimension = pthreads_write_dimension_disallow;
+	pthreads_stream_handlers.has_dimension = pthreads_has_dimension_disallow;
+	pthreads_stream_handlers.unset_dimension = pthreads_unset_dimension_disallow;
+
+	/**
+	 * Sockets
+	 */
 	memcpy(&pthreads_socket_handlers, &pthreads_handlers, sizeof(zend_object_handlers));
 
 	pthreads_socket_handlers.count_elements = pthreads_count_properties_disallow;
@@ -796,12 +473,15 @@ PHP_MINIT_FUNCTION(pthreads)
 	ZEND_INIT_MODULE_GLOBALS(pthreads, pthreads_globals_ctor, NULL);	
 
 	if (pthreads_globals_init()) {
+
 		TSRMLS_CACHE_UPDATE();
 		
 		/*
 		* Global Init
 		*/
 		pthreads_instance = TSRMLS_CACHE;
+
+		pthreads_stream_globals_init();
 	}
 
 #ifndef HAVE_SPL
@@ -829,6 +509,7 @@ static inline int sapi_cli_deactivate(void)
 PHP_MSHUTDOWN_FUNCTION(pthreads)
 {
 	if (pthreads_instance == TSRMLS_CACHE) {
+		pthreads_stream_globals_shutdown();
 		pthreads_globals_shutdown();
 
 		if (memcmp(sapi_module.name, ZEND_STRL("cli")) == SUCCESS) {
@@ -866,12 +547,21 @@ PHP_RINIT_FUNCTION(pthreads) {
 		}
 	}
 
+	if(pthreads_stream_globals_object_init() == SUCCESS) {
+		pthreads_init_streams();
+	}
+
 	return SUCCESS;
 }
 
 PHP_RSHUTDOWN_FUNCTION(pthreads) {
 	zend_hash_destroy(&PTHREADS_ZG(resolve));
 	zend_hash_destroy(&PTHREADS_ZG(filenames));
+
+	if(pthreads_stream_globals_is_main_context()) {
+		pthreads_shutdown_streams();
+		pthreads_stream_globals_object_shutdown();
+	}
 
 	return SUCCESS;
 }
@@ -880,7 +570,12 @@ PHP_MINFO_FUNCTION(pthreads)
 {
 	php_info_print_table_start();
 	php_info_print_table_row(2, "Version", PHP_PTHREADS_VERSION);
-	php_info_print_table_end();
+
+	pthreads_info_print_stream_hash("Streams",  PTHREADS_HT_P(pthreads_stream_get_url_stream_wrappers_hash()));
+	pthreads_info_print_stream_hash("Stream Socket Transports", PTHREADS_HT_P(pthreads_stream_xport_get_hash()));
+	pthreads_info_print_stream_hash("Stream Filters", PTHREADS_HT_P(pthreads_get_stream_filters_hash()));
+
+	pthreads_info_print_table_end();
 }
 
 #ifndef HAVE_PTHREADS_CLASS_THREADED
@@ -905,6 +600,18 @@ PHP_MINFO_FUNCTION(pthreads)
 
 #ifndef HAVE_PTHREADS_CLASS_SOCKET
 #	include <classes/socket.h>
+#endif
+
+#ifndef HAVE_PTHREADS_CLASS_FILTER
+#	include <classes/filter.h>
+#endif
+
+#ifndef HAVE_PTHREADS_CLASS_STREAM
+#	include <classes/stream.h>
+#endif
+
+#ifndef HAVE_PTHREADS_CLASS_FILESTREAM
+#	include <classes/filestream.h>
 #endif
 
 #endif

--- a/php_pthreads.h
+++ b/php_pthreads.h
@@ -18,7 +18,7 @@
 #ifndef HAVE_PHP_PTHREADS_H
 #define HAVE_PHP_PTHREADS_H
 #define PHP_PTHREADS_EXTNAME "pthreads"
-#define PHP_PTHREADS_VERSION "3.1.7dev"
+#define PHP_PTHREADS_VERSION "4.0.0dev"
 
 PHP_MINIT_FUNCTION(pthreads);
 PHP_MSHUTDOWN_FUNCTION(pthreads);
@@ -49,6 +49,18 @@ ZEND_MODULE_POST_ZEND_DEACTIVATE_D(pthreads);
 
 #ifndef HAVE_PTHREADS_CLASS_SOCKET_H
 #	include <classes/socket.h>
+#endif
+
+#ifndef HAVE_PTHREADS_CLASS_FILTER_H
+#	include <classes/filter.h>
+#endif
+
+#ifndef HAVE_PTHREADS_CLASS_STREAM_H
+#	include <classes/stream.h>
+#endif
+
+#ifndef HAVE_PTHREADS_CLASS_FILESTREAM_H
+#	include <classes/filestream.h>
 #endif
 
 extern zend_module_entry pthreads_module_entry;

--- a/src/file/file.c
+++ b/src/file/file.c
@@ -1,0 +1,601 @@
+/*
+  +----------------------------------------------------------------------+
+  | pthreads                                                             |
+  +----------------------------------------------------------------------+
+  | Copyright (c) Joe Watkins 2018                                       |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | http://www.php.net/license/3_01.txt                                  |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors: Bastian Schneider <b.schneider@badnoob.com>                 |
+  | Borrowed code from php-src                                           |
+  +----------------------------------------------------------------------+
+ */
+#ifndef HAVE_PTHREADS_FILE
+#define HAVE_PTHREADS_FILE
+
+#ifdef HAVE_CONFIG_H
+# include "config.h"
+#endif
+
+#ifndef HAVE_PTHREADS_H
+#	include <src/pthreads.h>
+#endif
+
+#ifndef HAVE_PTHREADS_STREAM_H
+#	include <src/streams.h>
+#endif
+
+#ifndef HAVE_PTHREADS_FILE_H
+#	include <src/file/file.h>
+#endif
+
+#include "ext/standard/flock_compat.h"
+#include "zend_smart_str.h"
+
+/* {{{ php_next_meta_token
+   Tokenizes an HTML file for get_meta_tags */
+php_meta_tags_token pthreads_next_meta_token(pthreads_meta_tags_data *md) {
+	int ch = 0, compliment;
+	char buff[PTHREADS_META_DEF_BUFSIZE + 1];
+
+	memset((void *)buff, 0, PTHREADS_META_DEF_BUFSIZE + 1);
+
+	while (md->ulc || (!pthreads_stream_eof(md->stream) && (ch = pthreads_stream_getc(md->stream)))) {
+		if (pthreads_stream_eof(md->stream)) {
+			break;
+		}
+
+		if (md->ulc) {
+			ch = md->lc;
+			md->ulc = 0;
+		}
+
+		switch (ch) {
+			case '<':
+				return TOK_OPENTAG;
+				break;
+
+			case '>':
+				return TOK_CLOSETAG;
+				break;
+
+			case '=':
+				return TOK_EQUAL;
+				break;
+			case '/':
+				return TOK_SLASH;
+				break;
+
+			case '\'':
+			case '"':
+				compliment = ch;
+				md->token_len = 0;
+				while (!pthreads_stream_eof(md->stream) && (ch = pthreads_stream_getc(md->stream)) && ch != compliment && ch != '<' && ch != '>') {
+					buff[(md->token_len)++] = ch;
+
+					if (md->token_len == PTHREADS_META_DEF_BUFSIZE) {
+						break;
+					}
+				}
+
+				if (ch == '<' || ch == '>') {
+					/* Was just an apostrohpe */
+					md->ulc = 1;
+					md->lc = ch;
+				}
+
+				/* We don't need to alloc unless we are in a meta tag */
+				if (md->in_meta) {
+					md->token_data = (char *) emalloc(md->token_len + 1);
+					memcpy(md->token_data, buff, md->token_len+1);
+				}
+
+				return TOK_STRING;
+				break;
+
+			case '\n':
+			case '\r':
+			case '\t':
+				break;
+
+			case ' ':
+				return TOK_SPACE;
+				break;
+
+			default:
+				if (isalnum(ch)) {
+					md->token_len = 0;
+					buff[(md->token_len)++] = ch;
+					while (!pthreads_stream_eof(md->stream) && (ch = pthreads_stream_getc(md->stream)) && (isalnum(ch) || strchr(PTHREADS_META_HTML401_CHARS, ch))) {
+						buff[(md->token_len)++] = ch;
+
+						if (md->token_len == PTHREADS_META_DEF_BUFSIZE) {
+							break;
+						}
+					}
+
+					/* This is ugly, but we have to replace ungetc */
+					if (!isalpha(ch) && ch != '-') {
+						md->ulc = 1;
+						md->lc = ch;
+					}
+
+					md->token_data = (char *) emalloc(md->token_len + 1);
+					memcpy(md->token_data, buff, md->token_len+1);
+
+					return TOK_ID;
+				} else {
+					return TOK_OTHER;
+				}
+				break;
+		}
+	}
+
+	return TOK_EOF;
+}
+/* }}} */
+
+/* {{{ php_copy_file_ctx */
+int pthreads_copy_file_ctx(const char *src, const char *dest, int src_flg, pthreads_stream_context_t *threaded_ctx) {
+	pthreads_stream_t *srcstream = NULL, *deststream = NULL;
+	int ret = FAILURE;
+	pthreads_stream_statbuf src_s, dest_s;
+
+	switch (pthreads_stream_stat_path_ex(src, 0, &src_s, threaded_ctx)) {
+		case -1:
+			/* non-statable stream */
+			goto safe_to_copy;
+			break;
+		case 0:
+			break;
+		default: /* failed to stat file, does not exist? */
+			return ret;
+	}
+	if (S_ISDIR(src_s.sb.st_mode)) {
+		php_error_docref(NULL, E_WARNING, "The first argument to copy() function cannot be a directory");
+		return FAILURE;
+	}
+
+	switch (pthreads_stream_stat_path_ex(dest, PTHREADS_STREAM_URL_STAT_QUIET | PTHREADS_STREAM_URL_STAT_NOCACHE, &dest_s, threaded_ctx)) {
+		case -1:
+			/* non-statable stream */
+			goto safe_to_copy;
+			break;
+		case 0:
+			break;
+		default: /* failed to stat file, does not exist? */
+			return ret;
+	}
+	if (S_ISDIR(dest_s.sb.st_mode)) {
+		php_error_docref(NULL, E_WARNING, "The second argument to copy() function cannot be a directory");
+		return FAILURE;
+	}
+	if (!src_s.sb.st_ino || !dest_s.sb.st_ino) {
+		goto no_stat;
+	}
+	if (src_s.sb.st_ino == dest_s.sb.st_ino && src_s.sb.st_dev == dest_s.sb.st_dev) {
+		return ret;
+	} else {
+		goto safe_to_copy;
+	}
+no_stat:
+	{
+		char *sp, *dp;
+		int res;
+
+		if ((sp = expand_filepath(src, NULL)) == NULL) {
+			return ret;
+		}
+		if ((dp = expand_filepath(dest, NULL)) == NULL) {
+			efree(sp);
+			goto safe_to_copy;
+		}
+
+		res =
+#ifndef PHP_WIN32
+			!strcmp(sp, dp);
+#else
+			!strcasecmp(sp, dp);
+#endif
+
+		efree(sp);
+		efree(dp);
+		if (res) {
+			return ret;
+		}
+	}
+safe_to_copy:
+
+	srcstream = pthreads_stream_open_wrapper_ex(src, "rb", src_flg | PTHREADS_REPORT_ERRORS, NULL, threaded_ctx, NULL);
+
+	if (!srcstream) {
+		return ret;
+	}
+	deststream = pthreads_stream_open_wrapper_ex(dest, "wb", PTHREADS_REPORT_ERRORS, NULL, threaded_ctx, NULL);
+
+	if (srcstream && deststream) {
+		ret = pthreads_stream_copy_to_stream_ex(srcstream, deststream, PTHREADS_STREAM_COPY_ALL, NULL);
+	}
+
+	if (srcstream) {
+		pthreads_stream_close(srcstream, PTHREADS_STREAM_FREE_CLOSE);
+	}
+
+	if (deststream) {
+		pthreads_stream_close(deststream, PTHREADS_STREAM_FREE_CLOSE);
+	}
+	return ret;
+}
+/* }}} */
+
+
+#define FPUTCSV_FLD_CHK(c) memchr(ZSTR_VAL(field_str), c, ZSTR_LEN(field_str))
+
+/* {{{ size_t pthreads_fputcsv(pthreads_stream_t *threaded_stream, zval *fields, char delimiter, char enclosure, char escape_char) */
+size_t pthreads_fputcsv(pthreads_stream_t *threaded_stream, zval *fields, char delimiter, char enclosure, char escape_char)
+{
+	int count, i = 0;
+	size_t ret;
+	zval *field_tmp;
+	smart_str csvline = {0};
+
+	count = zend_hash_num_elements(Z_ARRVAL_P(fields));
+	ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(fields), field_tmp) {
+		zend_string *tmp_field_str;
+		zend_string *field_str = zval_get_tmp_string(field_tmp, &tmp_field_str);
+
+		/* enclose a field that contains a delimiter, an enclosure character, or a newline */
+		if (FPUTCSV_FLD_CHK(delimiter) ||
+			FPUTCSV_FLD_CHK(enclosure) ||
+			FPUTCSV_FLD_CHK(escape_char) ||
+			FPUTCSV_FLD_CHK('\n') ||
+			FPUTCSV_FLD_CHK('\r') ||
+			FPUTCSV_FLD_CHK('\t') ||
+			FPUTCSV_FLD_CHK(' ')
+		) {
+			char *ch = ZSTR_VAL(field_str);
+			char *end = ch + ZSTR_LEN(field_str);
+			int escaped = 0;
+
+			smart_str_appendc(&csvline, enclosure);
+			while (ch < end) {
+				if (*ch == escape_char) {
+					escaped = 1;
+				} else if (!escaped && *ch == enclosure) {
+					smart_str_appendc(&csvline, enclosure);
+				} else {
+					escaped = 0;
+				}
+				smart_str_appendc(&csvline, *ch);
+				ch++;
+			}
+			smart_str_appendc(&csvline, enclosure);
+		} else {
+			smart_str_append(&csvline, field_str);
+		}
+
+		if (++i != count) {
+			smart_str_appendl(&csvline, &delimiter, 1);
+		}
+		zend_tmp_string_release(tmp_field_str);
+	} ZEND_HASH_FOREACH_END();
+
+	smart_str_appendc(&csvline, '\n');
+	smart_str_0(&csvline);
+
+	ret = pthreads_stream_write(threaded_stream, ZSTR_VAL(csvline.s), ZSTR_LEN(csvline.s));
+
+	smart_str_free(&csvline);
+
+	return ret;
+}
+/* }}} */
+
+static const char *pthreads_fgetcsv_lookup_trailing_spaces(const char *ptr, size_t len, const char delimiter) /* {{{ */
+{
+	int inc_len;
+	unsigned char last_chars[2] = { 0, 0 };
+
+	while (len > 0) {
+		inc_len = (*ptr == '\0' ? 1 : php_mblen(ptr, len));
+		switch (inc_len) {
+			case -2:
+			case -1:
+				inc_len = 1;
+				php_mb_reset();
+				break;
+			case 0:
+				goto quit_loop;
+			case 1:
+			default:
+				last_chars[0] = last_chars[1];
+				last_chars[1] = *ptr;
+				break;
+		}
+		ptr += inc_len;
+		len -= inc_len;
+	}
+quit_loop:
+	switch (last_chars[1]) {
+		case '\n':
+			if (last_chars[0] == '\r') {
+				return ptr - 2;
+			}
+			/* break is omitted intentionally */
+		case '\r':
+			return ptr - 1;
+	}
+	return ptr;
+}
+/* }}} */
+
+/* {{{ */
+void pthreads_fgetcsv(pthreads_stream_t *threaded_stream, char delimiter, char enclosure, char escape_char, size_t buf_len, char *buf, zval *return_value) {
+	char *temp, *tptr, *bptr, *line_end, *limit;
+	size_t temp_len, line_end_len;
+	int inc_len;
+	zend_bool first_field = 1;
+
+	/* initialize internal state */
+	php_mb_reset();
+
+	/* Now into new section that parses buf for delimiter/enclosure fields */
+
+	/* Strip trailing space from buf, saving end of line in case required for enclosure field */
+
+	bptr = buf;
+	tptr = (char *)pthreads_fgetcsv_lookup_trailing_spaces(buf, buf_len, delimiter);
+	line_end_len = buf_len - (size_t)(tptr - buf);
+	line_end = limit = tptr;
+
+	/* reserve workspace for building each individual field */
+	temp_len = buf_len;
+	temp = malloc(temp_len + line_end_len + 1);
+
+	/* Initialize return array */
+	array_init(return_value);
+
+	/* Main loop to read CSV fields */
+	/* NB this routine will return a single null entry for a blank line */
+
+	do {
+		char *comp_end, *hunk_begin;
+
+		tptr = temp;
+
+		inc_len = (bptr < limit ? (*bptr == '\0' ? 1 : php_mblen(bptr, limit - bptr)): 0);
+		if (inc_len == 1) {
+			char *tmp = bptr;
+			while ((*tmp != delimiter) && isspace((int)*(unsigned char *)tmp)) {
+				tmp++;
+  			}
+			if (*tmp == enclosure) {
+				bptr = tmp;
+			}
+  		}
+
+		if (first_field && bptr == line_end) {
+			add_next_index_null(return_value);
+			break;
+		}
+		first_field = 0;
+		/* 2. Read field, leaving bptr pointing at start of next field */
+		if (inc_len != 0 && *bptr == enclosure) {
+			int state = 0;
+
+			bptr++;	/* move on to first character in field */
+			hunk_begin = bptr;
+
+			/* 2A. handle enclosure delimited field */
+			for (;;) {
+				switch (inc_len) {
+					case 0:
+						switch (state) {
+							case 2:
+								memcpy(tptr, hunk_begin, bptr - hunk_begin - 1);
+								tptr += (bptr - hunk_begin - 1);
+								hunk_begin = bptr;
+								goto quit_loop_2;
+
+							case 1:
+								memcpy(tptr, hunk_begin, bptr - hunk_begin);
+								tptr += (bptr - hunk_begin);
+								hunk_begin = bptr;
+								/* break is omitted intentionally */
+
+							case 0: {
+								char *new_buf;
+								size_t new_len;
+								char *new_temp;
+
+								if (hunk_begin != line_end) {
+									memcpy(tptr, hunk_begin, bptr - hunk_begin);
+									tptr += (bptr - hunk_begin);
+									hunk_begin = bptr;
+								}
+
+								/* add the embedded line end to the field */
+								memcpy(tptr, line_end, line_end_len);
+								tptr += line_end_len;
+
+								if (threaded_stream == NULL) {
+									goto quit_loop_2;
+								} else if ((new_buf = pthreads_stream_get_line(threaded_stream, NULL, 0, &new_len)) == NULL) {
+									/* we've got an unterminated enclosure,
+									 * assign all the data from the start of
+									 * the enclosure to end of data to the
+									 * last element */
+									if ((size_t)temp_len > (size_t)(limit - buf)) {
+										goto quit_loop_2;
+									}
+									zend_array_destroy(Z_ARR_P(return_value));
+									RETVAL_NULL();
+									goto out;
+								}
+								temp_len += new_len;
+								new_temp = realloc(temp, temp_len);
+								tptr = new_temp + (size_t)(tptr - temp);
+								temp = new_temp;
+
+								free(buf);
+								buf_len = new_len;
+								bptr = buf = new_buf;
+								hunk_begin = buf;
+
+								line_end = limit = (char *)pthreads_fgetcsv_lookup_trailing_spaces(buf, buf_len, delimiter);
+								line_end_len = buf_len - (size_t)(limit - buf);
+
+								state = 0;
+							} break;
+						}
+						break;
+
+					case -2:
+					case -1:
+						php_mb_reset();
+						/* break is omitted intentionally */
+					case 1:
+						/* we need to determine if the enclosure is
+						 * 'real' or is it escaped */
+						switch (state) {
+							case 1: /* escaped */
+								bptr++;
+								state = 0;
+								break;
+							case 2: /* embedded enclosure ? let's check it */
+								if (*bptr != enclosure) {
+									/* real enclosure */
+									memcpy(tptr, hunk_begin, bptr - hunk_begin - 1);
+									tptr += (bptr - hunk_begin - 1);
+									hunk_begin = bptr;
+									goto quit_loop_2;
+								}
+								memcpy(tptr, hunk_begin, bptr - hunk_begin);
+								tptr += (bptr - hunk_begin);
+								bptr++;
+								hunk_begin = bptr;
+								state = 0;
+								break;
+							default:
+								if (*bptr == enclosure) {
+									state = 2;
+								} else if (*bptr == escape_char) {
+									state = 1;
+								}
+								bptr++;
+								break;
+						}
+						break;
+
+					default:
+						switch (state) {
+							case 2:
+								/* real enclosure */
+								memcpy(tptr, hunk_begin, bptr - hunk_begin - 1);
+								tptr += (bptr - hunk_begin - 1);
+								hunk_begin = bptr;
+								goto quit_loop_2;
+							case 1:
+								bptr += inc_len;
+								memcpy(tptr, hunk_begin, bptr - hunk_begin);
+								tptr += (bptr - hunk_begin);
+								hunk_begin = bptr;
+								state = 0;
+								break;
+							default:
+								bptr += inc_len;
+								break;
+						}
+						break;
+				}
+				inc_len = (bptr < limit ? (*bptr == '\0' ? 1 : php_mblen(bptr, limit - bptr)): 0);
+			}
+
+		quit_loop_2:
+			/* look up for a delimiter */
+			for (;;) {
+				switch (inc_len) {
+					case 0:
+						goto quit_loop_3;
+
+					case -2:
+					case -1:
+						inc_len = 1;
+						php_mb_reset();
+						/* break is omitted intentionally */
+					case 1:
+						if (*bptr == delimiter) {
+							goto quit_loop_3;
+						}
+						break;
+					default:
+						break;
+				}
+				bptr += inc_len;
+				inc_len = (bptr < limit ? (*bptr == '\0' ? 1 : php_mblen(bptr, limit - bptr)): 0);
+			}
+
+		quit_loop_3:
+			memcpy(tptr, hunk_begin, bptr - hunk_begin);
+			tptr += (bptr - hunk_begin);
+			bptr += inc_len;
+			comp_end = tptr;
+		} else {
+			/* 2B. Handle non-enclosure field */
+
+			hunk_begin = bptr;
+
+			for (;;) {
+				switch (inc_len) {
+					case 0:
+						goto quit_loop_4;
+					case -2:
+					case -1:
+						inc_len = 1;
+						php_mb_reset();
+						/* break is omitted intentionally */
+					case 1:
+						if (*bptr == delimiter) {
+							goto quit_loop_4;
+						}
+						break;
+					default:
+						break;
+				}
+				bptr += inc_len;
+				inc_len = (bptr < limit ? (*bptr == '\0' ? 1 : php_mblen(bptr, limit - bptr)): 0);
+			}
+		quit_loop_4:
+			memcpy(tptr, hunk_begin, bptr - hunk_begin);
+			tptr += (bptr - hunk_begin);
+
+			comp_end = (char *)pthreads_fgetcsv_lookup_trailing_spaces(temp, tptr - temp, delimiter);
+			if (*bptr == delimiter) {
+				bptr++;
+			}
+		}
+
+		/* 3. Now pass our field back to php */
+		*comp_end = '\0';
+		add_next_index_stringl(return_value, temp, comp_end - temp);
+	} while (inc_len > 0);
+
+out:
+	free(temp);
+	if (threaded_stream) {
+		free(buf);
+	}
+}
+/* }}} */
+
+#ifndef HAVE_PTHREADS_FILESTREAM_API
+#	include "src/file/filestream_api.c"
+#endif
+
+#endif

--- a/src/file/file.h
+++ b/src/file/file.h
@@ -1,0 +1,50 @@
+/*
+  +----------------------------------------------------------------------+
+  | pthreads                                                             |
+  +----------------------------------------------------------------------+
+  | Copyright (c) Joe Watkins 2018                                       |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | http://www.php.net/license/3_01.txt                                  |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors: Bastian Schneider <b.schneider@badnoob.com>                 |
+  | Borrowed code from php-src                                           |
+  +----------------------------------------------------------------------+
+ */
+#ifndef HAVE_PTHREADS_FILE_H
+#define HAVE_PTHREADS_FILE_H
+
+#define PTHREADS_META_DEF_BUFSIZE 8192
+
+#define PTHREADS_FILE_USE_INCLUDE_PATH 1
+#define PTHREADS_FILE_IGNORE_NEW_LINES 2
+#define PTHREADS_FILE_SKIP_EMPTY_LINES 4
+#define PTHREADS_FILE_APPEND 8
+#define PTHREADS_FILE_NO_DEFAULT_CONTEXT 16
+
+/* See http://www.w3.org/TR/html4/intro/sgmltut.html#h-3.2.2 */
+#define PTHREADS_META_HTML401_CHARS "-_.:"
+
+typedef struct _pthreads_meta_tags_data {
+	pthreads_stream_t *stream;
+	int ulc;
+	int lc;
+	char *input_buffer;
+	char *token_data;
+	int token_len;
+	int in_meta;
+} pthreads_meta_tags_data;
+
+php_meta_tags_token pthreads_next_meta_token(pthreads_meta_tags_data *);
+
+
+int pthreads_copy_file_ctx(const char *src, const char *dest, int src_flg, pthreads_stream_context_t *threaded_ctx);
+size_t pthreads_fputcsv(pthreads_stream_t *threaded_stream, zval *fields, char delimiter, char enclosure, char escape_char);
+void pthreads_fgetcsv(pthreads_stream_t *threaded_stream, char delimiter, char enclosure, char escape_char, size_t buf_len, char *buf, zval *return_value);
+
+#endif

--- a/src/file/filestream_api.c
+++ b/src/file/filestream_api.c
@@ -1,0 +1,1027 @@
+/*
+  +----------------------------------------------------------------------+
+  | pthreads                                                             |
+  +----------------------------------------------------------------------+
+  | Copyright (c) Joe Watkins 2018                                       |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | http://www.php.net/license/3_01.txt                                  |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors: Bastian Schneider <b.schneider@badnoob.com>                 |
+  | Borrowed code from php-src                                           |
+  +----------------------------------------------------------------------+
+ */
+#ifndef HAVE_PTHREADS_FILESTREAM_API
+#define HAVE_PTHREADS_FILESTREAM_API
+
+#ifdef HAVE_CONFIG_H
+# include "config.h"
+#endif
+
+#include "ext/standard/flock_compat.h"
+#include "ext/standard/scanf.h"
+#include "ext/standard/php_string.h"
+
+#ifdef HAVE_SYS_FILE_H
+# include <sys/file.h>
+#endif
+
+static int flock_values[] = { LOCK_SH, LOCK_EX, LOCK_UN };
+#define PHP_META_UNSAFE ".\\+*?[^]$() "
+
+/**
+ * FileStream API
+ */
+
+void pthreads_streams_api_filestream_lock(zval *object, int act, zend_long operation, zval *wouldblock, zval *return_value) {
+	pthreads_stream_t *threaded_stream = PTHREADS_FETCH_FROM(Z_OBJ_P(object));
+
+	if (wouldblock) {
+		zval_ptr_dtor(wouldblock);
+		ZVAL_LONG(wouldblock, 0);
+	}
+
+	/* flock_values contains all possible actions if (operation & 4) we won't block on the lock */
+	act = flock_values[act - 1] | (operation & PHP_LOCK_NB ? LOCK_NB : 0);
+	if (pthreads_stream_lock(threaded_stream, act)) {
+		if (operation && errno == EWOULDBLOCK && wouldblock) {
+			ZVAL_LONG(wouldblock, 1);
+		}
+		RETURN_FALSE;
+	}
+	RETURN_TRUE;
+}
+
+void pthreads_streams_api_filestream_close(zval *object, zval *return_value) {
+	pthreads_stream_t *threaded_stream = PTHREADS_FETCH_FROM(Z_OBJ_P(object));
+	pthreads_stream *stream = PTHREADS_FETCH_STREAMS_STREAM(threaded_stream);
+
+	if (PTHREADS_IS_INVALID_STREAM(stream)) {
+		php_error_docref(NULL, E_WARNING, "%s was already closed", ZSTR_VAL(Z_OBJCE_P(object)->name));
+		RETURN_FALSE;
+	}
+
+	if ((stream->flags & PTHREADS_STREAM_FLAG_NO_FCLOSE) != 0) {
+		php_error_docref(NULL, E_WARNING, "%s is not a valid stream", ZSTR_VAL(Z_OBJCE_P(object)->name));
+		RETURN_FALSE;
+	}
+	int ret = pthreads_stream_close(threaded_stream, PTHREADS_STREAM_FREE_CLOSE);
+
+	RETURN_LONG(ret);
+}
+
+void pthreads_streams_api_filestream_pclose(zval *object, zval *return_value) {
+	pthreads_stream_t *threaded_stream = PTHREADS_FETCH_FROM(Z_OBJ_P(object));
+
+	int ret = pthreads_stream_close(threaded_stream, PTHREADS_STREAM_FREE_CLOSE);
+
+	RETURN_LONG(ret);
+}
+
+void pthreads_streams_api_filestream_eof(zval *object, zval *return_value) {
+	pthreads_stream_t *threaded_stream = PTHREADS_FETCH_FROM(Z_OBJ_P(object));
+
+	if (pthreads_stream_eof(threaded_stream)) {
+		RETURN_TRUE;
+	} else {
+		RETURN_FALSE;
+	}
+}
+
+void pthreads_streams_api_filestream_gets(zval *object, int argc, zend_long len, zval *return_value) {
+	pthreads_stream_t *threaded_stream = PTHREADS_FETCH_FROM(Z_OBJ_P(object));
+	char *buf = NULL;
+	size_t line_len = 0;
+	zend_string *str;
+
+	if (argc == 0) {
+		/* ask streams to give us a buffer of an appropriate size */
+		buf = pthreads_stream_get_line(threaded_stream, NULL, 0, &line_len);
+
+		if (buf == NULL) {
+			RETURN_NULL();
+		}
+		// TODO: avoid reallocation ???
+		RETVAL_STRINGL(buf, line_len);
+
+		free(buf);
+	} else if (argc > 0) {
+		if (len <= 0) {
+			php_error_docref(NULL, E_WARNING, "Length parameter must be greater than 0");
+			RETURN_NULL();
+		}
+
+		str = zend_string_alloc(len, 0);
+		if (pthreads_stream_get_line(threaded_stream, ZSTR_VAL(str), len, &line_len) == NULL) {
+			zend_string_efree(str);
+			RETURN_NULL();
+		}
+		/* resize buffer if it's much larger than the result.
+		 * Only needed if the user requested a buffer size. */
+		if (line_len < (size_t)len / 2) {
+			str = zend_string_truncate(str, line_len, 0);
+		} else {
+			ZSTR_LEN(str) = line_len;
+		}
+		RETURN_NEW_STR(str);
+	}
+}
+
+void pthreads_streams_api_filestream_getc(zval *object, zval *return_value) {
+	pthreads_stream_t *threaded_stream = PTHREADS_FETCH_FROM(Z_OBJ_P(object));
+	char buf[2];
+	int result;
+
+	result = pthreads_stream_getc(threaded_stream);
+
+	if (result == EOF) {
+		RETURN_NULL();
+	}
+	buf[0] = result;
+	buf[1] = '\0';
+
+	RETURN_STRINGL(buf, 1);
+}
+
+void pthreads_streams_api_filestream_getss(zval *object, int argc, zend_long bytes, zend_string *allowed_tags, zval *return_value) {
+	pthreads_stream_t *threaded_stream = PTHREADS_FETCH_FROM(Z_OBJ_P(object));
+	pthreads_stream *stream = PTHREADS_FETCH_STREAMS_STREAM(threaded_stream);
+
+	size_t len = 0;
+	size_t actual_len, retval_len;
+	char *buf = NULL, *retval;
+
+	if (argc >= 1) {
+		if (bytes <= 0) {
+			php_error_docref(NULL, E_WARNING, "Length parameter must be greater than 0");
+			RETURN_FALSE;
+		}
+
+		len = (size_t) bytes;
+		buf = calloc(sizeof(char), (len + 1));
+	}
+
+	if(stream_lock(threaded_stream)) {
+		if ((retval = pthreads_stream_get_line(threaded_stream, buf, len, &actual_len)) == NULL)	{
+			if (buf != NULL) {
+				free(buf);
+			}
+			stream_unlock(threaded_stream);
+			RETURN_NULL();
+		}
+
+		retval_len = php_strip_tags(retval, actual_len, &stream->fgetss_state, ZSTR_VAL(allowed_tags), ZSTR_LEN(allowed_tags));
+
+		// TODO: avoid reallocation ???
+		RETVAL_STRINGL(retval, retval_len);
+
+		stream_unlock(threaded_stream);
+	}
+
+	if(retval != NULL) {
+		free(retval);
+	}
+}
+
+void pthreads_streams_api_filestream_scanf(zval *object, zend_string *format, zval *args, int argc, zval *return_value) {
+	pthreads_stream_t *threaded_stream = PTHREADS_FETCH_FROM(Z_OBJ_P(object));
+
+	int result;
+	size_t format_len;
+	zval *file_handle;
+	char *buf;
+	size_t len;
+
+	buf = pthreads_stream_get_line(threaded_stream, NULL, 0, &len);
+	if (buf == NULL) {
+		RETURN_FALSE;
+	}
+
+	result = php_sscanf_internal(buf, ZSTR_VAL(format), argc, args, 0, return_value);
+
+	free(buf);
+
+	if (SCAN_ERROR_WRONG_PARAM_COUNT == result) {
+		WRONG_PARAM_COUNT;
+	}
+}
+
+void pthreads_streams_api_filestream_write(zval *object, int argc, zend_string *input, zend_long maxlen, zval *return_value) {
+	pthreads_stream_t *threaded_stream = PTHREADS_FETCH_FROM(Z_OBJ_P(object));
+
+	size_t inputlen = ZSTR_LEN(input);
+	size_t ret, num_bytes;
+
+	if (argc == 1) {
+		num_bytes = inputlen;
+	} else if (maxlen <= 0) {
+		num_bytes = 0;
+	} else {
+		num_bytes = MIN((size_t) maxlen, inputlen);
+	}
+
+	if (!num_bytes) {
+		RETURN_LONG(0);
+	}
+	ret = pthreads_stream_write(threaded_stream, ZSTR_VAL(input), num_bytes);
+
+	RETURN_LONG(ret);
+}
+
+void pthreads_streams_api_filestream_flush(zval *object, zval *return_value) {
+	pthreads_stream_t *threaded_stream = PTHREADS_FETCH_FROM(Z_OBJ_P(object));
+
+	int ret = pthreads_stream_flush(threaded_stream);
+	if (ret) {
+		RETURN_FALSE;
+	}
+	RETURN_TRUE;
+}
+
+void pthreads_streams_api_filestream_rewind(zval *object, zval *return_value) {
+	pthreads_stream_t *threaded_stream = PTHREADS_FETCH_FROM(Z_OBJ_P(object));
+
+	int ret = pthreads_stream_rewind(threaded_stream);
+	if (ret) {
+		RETURN_FALSE;
+	}
+	RETURN_TRUE;
+}
+
+void pthreads_streams_api_filestream_tell(zval *object, zval *return_value) {
+	pthreads_stream_t *threaded_stream = PTHREADS_FETCH_FROM(Z_OBJ_P(object));
+
+	RETURN_LONG(pthreads_stream_tell(threaded_stream));
+}
+
+void pthreads_streams_api_filestream_seek(zval *object, zend_long offset, zend_long whence, zval *return_value) {
+	pthreads_stream_t *threaded_stream = PTHREADS_FETCH_FROM(Z_OBJ_P(object));
+
+	RETURN_LONG(pthreads_stream_seek(threaded_stream, offset, (int) whence));
+}
+
+void pthreads_streams_api_filestream_passthru(zval *object, zval *return_value) {
+	pthreads_stream_t *threaded_stream = PTHREADS_FETCH_FROM(Z_OBJ_P(object));
+
+	RETURN_LONG(pthreads_stream_passthru(threaded_stream));
+}
+
+void pthreads_streams_api_filestream_truncate(zval *object, zend_long size, zval *return_value) {
+	pthreads_stream_t *threaded_stream = PTHREADS_FETCH_FROM(Z_OBJ_P(object));
+
+	if (!pthreads_stream_truncate_supported(threaded_stream)) {
+		php_error_docref(NULL, E_WARNING, "Can't truncate this stream!");
+		RETURN_FALSE;
+	}
+
+	RETURN_BOOL(0 == pthreads_stream_truncate_set_size(threaded_stream, size));
+}
+
+void pthreads_streams_api_filestream_stat(zval *object, zval *return_value) {
+	pthreads_stream_t *threaded_stream = PTHREADS_FETCH_FROM(Z_OBJ_P(object));
+
+	zval stat_dev, stat_ino, stat_mode, stat_nlink, stat_uid, stat_gid, stat_rdev,
+		 stat_size, stat_atime, stat_mtime, stat_ctime, stat_blksize, stat_blocks;
+
+	pthreads_stream_statbuf stat_ssb;
+	char *stat_sb_names[13] = {
+		"dev", "ino", "mode", "nlink", "uid", "gid", "rdev",
+		"size", "atime", "mtime", "ctime", "blksize", "blocks"
+	};
+
+	if (pthreads_stream_stat(threaded_stream, &stat_ssb)) {
+		RETURN_FALSE;
+	}
+
+	array_init(return_value);
+
+	ZVAL_LONG(&stat_dev, stat_ssb.sb.st_dev);
+	ZVAL_LONG(&stat_ino, stat_ssb.sb.st_ino);
+	ZVAL_LONG(&stat_mode, stat_ssb.sb.st_mode);
+	ZVAL_LONG(&stat_nlink, stat_ssb.sb.st_nlink);
+	ZVAL_LONG(&stat_uid, stat_ssb.sb.st_uid);
+	ZVAL_LONG(&stat_gid, stat_ssb.sb.st_gid);
+#ifdef HAVE_STRUCT_STAT_ST_RDEV
+# ifdef PHP_WIN32
+	/* It is unsigned, so if a negative came from userspace, it'll
+	   convert to UINT_MAX, but we wan't to keep the userspace value.
+	   Almost the same as in php_fstat. This is ugly, but otherwise
+	   we would have to maintain a fully compatible struct stat. */
+	if ((int)stat_ssb.sb.st_rdev < 0) {
+		ZVAL_LONG(&stat_rdev, (int)stat_ssb.sb.st_rdev);
+	} else {
+		ZVAL_LONG(&stat_rdev, stat_ssb.sb.st_rdev);
+	}
+# else
+	ZVAL_LONG(&stat_rdev, stat_ssb.sb.st_rdev);
+# endif
+#else
+	ZVAL_LONG(&stat_rdev, -1);
+#endif
+	ZVAL_LONG(&stat_size, stat_ssb.sb.st_size);
+	ZVAL_LONG(&stat_atime, stat_ssb.sb.st_atime);
+	ZVAL_LONG(&stat_mtime, stat_ssb.sb.st_mtime);
+	ZVAL_LONG(&stat_ctime, stat_ssb.sb.st_ctime);
+#ifdef HAVE_STRUCT_STAT_ST_BLKSIZE
+	ZVAL_LONG(&stat_blksize, stat_ssb.sb.st_blksize);
+#else
+	ZVAL_LONG(&stat_blksize,-1);
+#endif
+#ifdef HAVE_ST_BLOCKS
+	ZVAL_LONG(&stat_blocks, stat_ssb.sb.st_blocks);
+#else
+	ZVAL_LONG(&stat_blocks,-1);
+#endif
+	/* Store numeric indexes in proper order */
+	zend_hash_next_index_insert(Z_ARRVAL_P(return_value), &stat_dev);
+	zend_hash_next_index_insert(Z_ARRVAL_P(return_value), &stat_ino);
+	zend_hash_next_index_insert(Z_ARRVAL_P(return_value), &stat_mode);
+	zend_hash_next_index_insert(Z_ARRVAL_P(return_value), &stat_nlink);
+	zend_hash_next_index_insert(Z_ARRVAL_P(return_value), &stat_uid);
+	zend_hash_next_index_insert(Z_ARRVAL_P(return_value), &stat_gid);
+	zend_hash_next_index_insert(Z_ARRVAL_P(return_value), &stat_rdev);
+	zend_hash_next_index_insert(Z_ARRVAL_P(return_value), &stat_size);
+	zend_hash_next_index_insert(Z_ARRVAL_P(return_value), &stat_atime);
+	zend_hash_next_index_insert(Z_ARRVAL_P(return_value), &stat_mtime);
+	zend_hash_next_index_insert(Z_ARRVAL_P(return_value), &stat_ctime);
+	zend_hash_next_index_insert(Z_ARRVAL_P(return_value), &stat_blksize);
+	zend_hash_next_index_insert(Z_ARRVAL_P(return_value), &stat_blocks);
+
+	/* Store string indexes referencing the same zval*/
+	zend_hash_str_add_new(Z_ARRVAL_P(return_value), stat_sb_names[0], strlen(stat_sb_names[0]), &stat_dev);
+	zend_hash_str_add_new(Z_ARRVAL_P(return_value), stat_sb_names[1], strlen(stat_sb_names[1]), &stat_ino);
+	zend_hash_str_add_new(Z_ARRVAL_P(return_value), stat_sb_names[2], strlen(stat_sb_names[2]), &stat_mode);
+	zend_hash_str_add_new(Z_ARRVAL_P(return_value), stat_sb_names[3], strlen(stat_sb_names[3]), &stat_nlink);
+	zend_hash_str_add_new(Z_ARRVAL_P(return_value), stat_sb_names[4], strlen(stat_sb_names[4]), &stat_uid);
+	zend_hash_str_add_new(Z_ARRVAL_P(return_value), stat_sb_names[5], strlen(stat_sb_names[5]), &stat_gid);
+	zend_hash_str_add_new(Z_ARRVAL_P(return_value), stat_sb_names[6], strlen(stat_sb_names[6]), &stat_rdev);
+	zend_hash_str_add_new(Z_ARRVAL_P(return_value), stat_sb_names[7], strlen(stat_sb_names[7]), &stat_size);
+	zend_hash_str_add_new(Z_ARRVAL_P(return_value), stat_sb_names[8], strlen(stat_sb_names[8]), &stat_atime);
+	zend_hash_str_add_new(Z_ARRVAL_P(return_value), stat_sb_names[9], strlen(stat_sb_names[9]), &stat_mtime);
+	zend_hash_str_add_new(Z_ARRVAL_P(return_value), stat_sb_names[10], strlen(stat_sb_names[10]), &stat_ctime);
+	zend_hash_str_add_new(Z_ARRVAL_P(return_value), stat_sb_names[11], strlen(stat_sb_names[11]), &stat_blksize);
+	zend_hash_str_add_new(Z_ARRVAL_P(return_value), stat_sb_names[12], strlen(stat_sb_names[12]), &stat_blocks);
+}
+
+void pthreads_streams_api_filestream_read(zval *object, zend_long len, zval *return_value) {
+	pthreads_stream_t *threaded_stream = PTHREADS_FETCH_FROM(Z_OBJ_P(object));
+
+	ZVAL_NEW_STR(return_value, zend_string_alloc(len, 0));
+	Z_STRLEN_P(return_value) = pthreads_stream_read(threaded_stream, Z_STRVAL_P(return_value), len);
+
+	/* needed because recv/read/gzread doesn't put a null at the end*/
+	Z_STRVAL_P(return_value)[Z_STRLEN_P(return_value)] = 0;
+
+	if (Z_STRLEN_P(return_value) < len / 2) {
+		Z_STR_P(return_value) = zend_string_truncate(Z_STR_P(return_value), Z_STRLEN_P(return_value), 0);
+	}
+}
+
+void pthreads_streams_api_filestream_putcsv(zval *object, zval *fields, char delimiter, char enclosure, char escape_char, zval *return_value) {
+	pthreads_stream_t *threaded_stream = PTHREADS_FETCH_FROM(Z_OBJ_P(object));
+
+	RETURN_LONG(pthreads_fputcsv(threaded_stream, fields, delimiter, enclosure, escape_char));
+}
+
+void pthreads_streams_api_filestream_getcsv(zval *object, zend_long len, char delimiter, char enclosure, char escape_char, zval *return_value) {
+	pthreads_stream_t *threaded_stream = PTHREADS_FETCH_FROM(Z_OBJ_P(object));
+	size_t buf_len;
+	char *buf;
+
+	if (len < 0) {
+		if ((buf = pthreads_stream_get_line(threaded_stream, NULL, 0, &buf_len)) == NULL) {
+			RETURN_NULL();
+		}
+	} else {
+		buf = malloc(len + 1);
+		if (pthreads_stream_get_line(threaded_stream, buf, len + 1, &buf_len) == NULL) {
+			free(buf);
+			RETURN_NULL();
+		}
+	}
+
+	pthreads_fgetcsv(threaded_stream, delimiter, enclosure, escape_char, buf_len, buf, return_value);
+}
+
+/**
+ * File API
+ */
+
+void pthreads_streams_api_file_get_meta_data(zend_string *filename, zend_bool use_include_path, zval *return_value) {
+	int in_tag = 0, done = 0;
+	int looking_for_val = 0, have_name = 0, have_content = 0;
+	int saw_name = 0, saw_content = 0;
+	char *name = NULL, *value = NULL, *temp = NULL;
+	php_meta_tags_token tok, tok_last;
+	pthreads_meta_tags_data md;
+
+	/* Initiailize our structure */
+	memset(&md, 0, sizeof(md));
+
+	md.stream = pthreads_stream_open_wrapper(ZSTR_VAL(filename), "rb",
+			(use_include_path ? PTHREADS_USE_PATH : 0) | PTHREADS_REPORT_ERRORS, NULL);
+	if (!md.stream)	{
+		RETURN_FALSE;
+	}
+
+	array_init(return_value);
+
+	tok_last = TOK_EOF;
+
+	if(stream_lock(md.stream)) {
+		while (!done && (tok = pthreads_next_meta_token(&md)) != TOK_EOF) {
+			if (tok == TOK_ID) {
+				if (tok_last == TOK_OPENTAG) {
+					md.in_meta = !strcasecmp("meta", md.token_data);
+				} else if (tok_last == TOK_SLASH && in_tag) {
+					if (strcasecmp("head", md.token_data) == 0) {
+						/* We are done here! */
+						done = 1;
+					}
+				} else if (tok_last == TOK_EQUAL && looking_for_val) {
+					if (saw_name) {
+						if (name) efree(name);
+						/* Get the NAME attr (Single word attr, non-quoted) */
+						temp = name = estrndup(md.token_data, md.token_len);
+
+						while (temp && *temp) {
+							if (strchr(PHP_META_UNSAFE, *temp)) {
+								*temp = '_';
+							}
+							temp++;
+						}
+
+						have_name = 1;
+					} else if (saw_content) {
+						if (value) efree(value);
+						value = estrndup(md.token_data, md.token_len);
+						have_content = 1;
+					}
+
+					looking_for_val = 0;
+				} else {
+					if (md.in_meta) {
+						if (strcasecmp("name", md.token_data) == 0) {
+							saw_name = 1;
+							saw_content = 0;
+							looking_for_val = 1;
+						} else if (strcasecmp("content", md.token_data) == 0) {
+							saw_name = 0;
+							saw_content = 1;
+							looking_for_val = 1;
+						}
+					}
+				}
+			} else if (tok == TOK_STRING && tok_last == TOK_EQUAL && looking_for_val) {
+				if (saw_name) {
+					if (name) efree(name);
+					/* Get the NAME attr (Quoted single/double) */
+					temp = name = estrndup(md.token_data, md.token_len);
+
+					while (temp && *temp) {
+						if (strchr(PHP_META_UNSAFE, *temp)) {
+							*temp = '_';
+						}
+						temp++;
+					}
+
+					have_name = 1;
+				} else if (saw_content) {
+					if (value) efree(value);
+					value = estrndup(md.token_data, md.token_len);
+					have_content = 1;
+				}
+
+				looking_for_val = 0;
+			} else if (tok == TOK_OPENTAG) {
+				if (looking_for_val) {
+					looking_for_val = 0;
+					have_name = saw_name = 0;
+					have_content = saw_content = 0;
+				}
+				in_tag = 1;
+			} else if (tok == TOK_CLOSETAG) {
+				if (have_name) {
+					/* For BC */
+					php_strtolower(name, strlen(name));
+					if (have_content) {
+						add_assoc_string(return_value, name, value);
+					} else {
+						add_assoc_string(return_value, name, "");
+					}
+
+					efree(name);
+					if (value) efree(value);
+				} else if (have_content) {
+					efree(value);
+				}
+
+				name = value = NULL;
+
+				/* Reset all of our flags */
+				in_tag = looking_for_val = 0;
+				have_name = saw_name = 0;
+				have_content = saw_content = 0;
+				md.in_meta = 0;
+			}
+
+			tok_last = tok;
+
+			if (md.token_data)
+				efree(md.token_data);
+
+			md.token_data = NULL;
+		}
+		stream_unlock(md.stream);
+	}
+
+	if (value) efree(value);
+	if (name) efree(name);
+
+	pthreads_stream_close(md.stream, PTHREADS_STREAM_FREE_CLOSE);
+}
+
+void pthreads_streams_api_file_get_contents(zend_string *filename, zend_bool use_include_path, zval *zcontext, zend_long offset, zend_long maxlen, zval *return_value) {
+	pthreads_stream_context_t *threaded_context = pthreads_stream_context_from_zval(zcontext, 0);
+	pthreads_stream_t *threaded_stream;
+	zend_string *contents;
+
+	threaded_stream = pthreads_stream_open_wrapper_ex(ZSTR_VAL(filename), "rb",
+				(use_include_path ? PTHREADS_USE_PATH : 0) | PTHREADS_REPORT_ERRORS,
+				NULL, threaded_context, pthreads_file_stream_entry);
+	if (!threaded_stream) {
+		RETURN_NULL();
+	}
+
+	if (offset != 0 && pthreads_stream_seek(threaded_stream, offset, ((offset > 0) ? SEEK_SET : SEEK_END)) < 0) {
+		php_error_docref(NULL, E_WARNING, "Failed to seek to position " ZEND_LONG_FMT " in the stream", offset);
+		pthreads_stream_close(threaded_stream, PTHREADS_STREAM_FREE_CLOSE);
+		RETURN_FALSE;
+	}
+
+	if (maxlen > INT_MAX) {
+		php_error_docref(NULL, E_WARNING, "maxlen truncated from " ZEND_LONG_FMT " to %d bytes", maxlen, INT_MAX);
+		maxlen = INT_MAX;
+	}
+	if ((contents = pthreads_stream_copy_to_mem(threaded_stream, maxlen, 0)) != NULL) {
+		RETVAL_STR(contents);
+	} else {
+		RETVAL_EMPTY_STRING();
+	}
+
+	pthreads_stream_close(threaded_stream, PTHREADS_STREAM_FREE_CLOSE);
+}
+
+void pthreads_streams_api_file_put_contents(char *filename, size_t filename_len, zval *data, zend_long flags, zval *zcontext, zval *return_value) {
+	pthreads_stream_context_t *threaded_context = pthreads_stream_context_from_zval(zcontext, flags & PTHREADS_FILE_NO_DEFAULT_CONTEXT);
+	pthreads_stream_t *threaded_stream;
+	char mode[3] = "wb";
+	size_t numbytes = 0;
+
+	if (flags & PTHREADS_FILE_APPEND) {
+		mode[0] = 'a';
+	} else if (flags & LOCK_EX) {
+		/* check to make sure we are dealing with a regular file */
+		if (php_memnstr(filename, "://", sizeof("://") - 1, filename + filename_len)) {
+			if (strncasecmp(filename, "file://", sizeof("file://") - 1)) {
+				php_error_docref(NULL, E_WARNING, "Exclusive locks may only be set for regular files");
+				RETURN_NULL();
+			}
+		}
+		mode[0] = 'c';
+	}
+	mode[2] = '\0';
+
+	threaded_stream = pthreads_stream_open_wrapper_ex(filename, mode,
+			((flags & PTHREADS_FILE_USE_INCLUDE_PATH) ? PTHREADS_USE_PATH : 0) | PTHREADS_REPORT_ERRORS, NULL, threaded_context, pthreads_file_stream_entry);
+	if (threaded_stream == NULL) {
+		RETURN_NULL();
+	}
+
+	if (flags & LOCK_EX && (!pthreads_stream_supports_lock(threaded_stream) || pthreads_stream_lock(threaded_stream, LOCK_EX))) {
+		pthreads_stream_close(threaded_stream, PTHREADS_STREAM_FREE_CLOSE);
+		php_error_docref(NULL, E_WARNING, "Exclusive locks are not supported for this stream");
+		RETURN_NULL();
+	}
+
+	if (mode[0] == 'c') {
+		pthreads_stream_truncate_set_size(threaded_stream, 0);
+	}
+
+	switch (Z_TYPE_P(data)) {
+		case IS_NULL:
+		case IS_LONG:
+		case IS_DOUBLE:
+		case IS_FALSE:
+		case IS_TRUE:
+			convert_to_string_ex(data);
+
+		case IS_STRING:
+			if (Z_STRLEN_P(data)) {
+				numbytes = pthreads_stream_write(threaded_stream, Z_STRVAL_P(data), Z_STRLEN_P(data));
+				if (numbytes != Z_STRLEN_P(data)) {
+					php_error_docref(NULL, E_WARNING, "Only "ZEND_LONG_FMT" of %zd bytes written, possibly out of free disk space", numbytes, Z_STRLEN_P(data));
+					numbytes = -1;
+				}
+			}
+			break;
+
+		case IS_ARRAY:
+			if (zend_hash_num_elements(Z_ARRVAL_P(data))) {
+				size_t bytes_written;
+				zval *tmp;
+
+				ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(data), tmp) {
+					zend_string *t;
+					zend_string *str = zval_get_tmp_string(tmp, &t);
+					if (ZSTR_LEN(str)) {
+						numbytes += ZSTR_LEN(str);
+						bytes_written = pthreads_stream_write(threaded_stream, ZSTR_VAL(str), ZSTR_LEN(str));
+						if (bytes_written != ZSTR_LEN(str)) {
+							php_error_docref(NULL, E_WARNING, "Failed to write %zd bytes to %s", ZSTR_LEN(str), filename);
+							zend_tmp_string_release(t);
+							numbytes = -1;
+							break;
+						}
+					}
+					zend_tmp_string_release(t);
+				} ZEND_HASH_FOREACH_END();
+			}
+			break;
+
+		case IS_OBJECT:
+			if(instanceof_function(Z_OBJCE_P(data), pthreads_stream_entry)) {
+				size_t len;
+				pthreads_stream_t *threaded_srcstream = PTHREADS_FETCH_FROM(Z_OBJ_P(data));
+
+				if (pthreads_stream_copy_to_stream_ex(threaded_srcstream, threaded_stream, PTHREADS_STREAM_COPY_ALL, &len) != SUCCESS) {
+					numbytes = -1;
+				} else {
+					if (len > ZEND_LONG_MAX) {
+						php_error_docref(NULL, E_WARNING, "content truncated from %zu to " ZEND_LONG_FMT " bytes", len, ZEND_LONG_MAX);
+						len = ZEND_LONG_MAX;
+					}
+					numbytes = len;
+				}
+				break;
+			}
+
+			if (Z_OBJ_HT_P(data) != NULL) {
+				zval out;
+
+				if (zend_std_cast_object_tostring(data, &out, IS_STRING) == SUCCESS) {
+					numbytes = pthreads_stream_write(threaded_stream, Z_STRVAL(out), Z_STRLEN(out));
+					if (numbytes != Z_STRLEN(out)) {
+						php_error_docref(NULL, E_WARNING, "Only "ZEND_LONG_FMT" of %zd bytes written, possibly out of free disk space", numbytes, Z_STRLEN(out));
+						numbytes = -1;
+					}
+					zval_ptr_dtor_str(&out);
+					break;
+				}
+			}
+		default:
+			numbytes = -1;
+			break;
+	}
+	pthreads_stream_close(threaded_stream, PTHREADS_STREAM_FREE_CLOSE);
+
+	if (numbytes == (size_t)-1) {
+		RETURN_NULL();
+	}
+
+	RETURN_LONG(numbytes);
+}
+
+void pthreads_streams_api_file_file(char *filename, zend_long flags, zval *context, zval *return_value) {
+	pthreads_stream_context_t *threaded_context = pthreads_stream_context_from_zval(context, flags & PTHREADS_FILE_NO_DEFAULT_CONTEXT);
+	pthreads_stream_t *threaded_stream;
+	pthreads_stream *stream;
+	char *p, *s, *e;
+	register int i = 0;
+	char eol_marker = '\n';
+	zend_bool use_include_path;
+	zend_bool include_new_line;
+	zend_bool skip_blank_lines;
+	zend_string *target_buf;
+
+	if (flags < 0 || flags > (PTHREADS_FILE_USE_INCLUDE_PATH | PTHREADS_FILE_IGNORE_NEW_LINES | PTHREADS_FILE_SKIP_EMPTY_LINES | PTHREADS_FILE_NO_DEFAULT_CONTEXT)) {
+		php_error_docref(NULL, E_WARNING, "'" ZEND_LONG_FMT "' flag is not supported", flags);
+		RETURN_NULL();
+	}
+
+	use_include_path = flags & PTHREADS_FILE_USE_INCLUDE_PATH;
+	include_new_line = !(flags & PTHREADS_FILE_IGNORE_NEW_LINES);
+	skip_blank_lines = flags & PTHREADS_FILE_SKIP_EMPTY_LINES;
+
+	threaded_stream = pthreads_stream_open_wrapper_ex(filename, "rb",
+			(use_include_path ? PTHREADS_USE_PATH : 0) | PTHREADS_REPORT_ERRORS, NULL, threaded_context, pthreads_file_stream_entry);
+	if (!threaded_stream) {
+		RETURN_NULL();
+	}
+	stream = PTHREADS_FETCH_STREAMS_STREAM(threaded_stream);
+
+	/* Initialize return array */
+	array_init(return_value);
+
+	if ((target_buf = pthreads_stream_copy_to_mem(threaded_stream, PTHREADS_STREAM_COPY_ALL, 0)) != NULL) {
+		s = ZSTR_VAL(target_buf);
+		e = ZSTR_VAL(target_buf) + ZSTR_LEN(target_buf);
+
+		if (!(p = (char*)pthreads_stream_locate_eol(threaded_stream, target_buf))) {
+			p = e;
+			goto parse_eol;
+		}
+
+		if (stream->flags & PTHREADS_STREAM_FLAG_EOL_MAC) {
+			eol_marker = '\r';
+		}
+
+		/* for performance reasons the code is duplicated, so that the if (include_new_line)
+		 * will not need to be done for every single line in the file. */
+		if (include_new_line) {
+			do {
+				p++;
+parse_eol:
+				add_index_stringl(return_value, i++, s, p-s);
+				s = p;
+			} while ((p = memchr(p, eol_marker, (e-p))));
+		} else {
+			do {
+				int windows_eol = 0;
+				if (p != ZSTR_VAL(target_buf) && eol_marker == '\n' && *(p - 1) == '\r') {
+					windows_eol++;
+				}
+				if (skip_blank_lines && !(p-s-windows_eol)) {
+					s = ++p;
+					continue;
+				}
+				add_index_stringl(return_value, i++, s, p-s-windows_eol);
+				s = ++p;
+			} while ((p = memchr(p, eol_marker, (e-p))));
+		}
+
+		/* handle any left overs of files without new lines */
+		if (s != e) {
+			p = e;
+			goto parse_eol;
+		}
+	}
+
+	if (target_buf) {
+		zend_string_free(target_buf);
+	}
+	pthreads_stream_close(threaded_stream, PTHREADS_STREAM_FREE_CLOSE);
+}
+
+void pthreads_streams_api_file_temp_name(char *dir, char *prefix, size_t prefix_len, zval *return_value) {
+	zend_string *opened_path;
+	int fd;
+	zend_string *p;
+
+	if (php_check_open_basedir(dir)) {
+		RETURN_NULL();
+	}
+
+	p = php_basename(prefix, prefix_len, NULL, 0);
+	if (ZSTR_LEN(p) > 64) {
+		ZSTR_VAL(p)[63] = '\0';
+	}
+
+	RETVAL_NULL();
+
+	if ((fd = pthreads_open_temporary_fd_ex(dir, ZSTR_VAL(p), &opened_path, 1)) >= 0) {
+		close(fd);
+		RETVAL_STR(opened_path);
+	}
+	zend_string_release(p);
+}
+
+void pthreads_streams_api_file_temp_file(zval *return_value) {
+	pthreads_stream_t *threaded_stream = pthreads_stream_fopen_tmpfile();
+
+	if (threaded_stream) {
+		pthreads_stream_to_zval(threaded_stream, return_value);
+	} else {
+		RETURN_NULL();
+	}
+}
+
+void pthreads_streams_api_file_open(zend_string *filename, zend_string *mode, zend_bool use_include_path, zval *zcontext, zval *return_value) {
+	pthreads_stream_context_t *threaded_context = pthreads_stream_context_from_zval(zcontext, 0);
+	pthreads_stream_t *threaded_stream;
+
+	threaded_stream = pthreads_stream_open_wrapper_ex(ZSTR_VAL(filename), ZSTR_VAL(mode),
+			(use_include_path ? PTHREADS_USE_PATH : 0) | PTHREADS_REPORT_ERRORS, NULL, threaded_context, pthreads_file_stream_entry);
+
+	if (threaded_stream == NULL) {
+		RETURN_NULL();
+	}
+
+	pthreads_stream_to_zval(threaded_stream, return_value);
+}
+
+void pthreads_streams_api_file_popen(char *command, char *mode, int mode_len, zval *return_value) {
+	pthreads_stream_t *threaded_stream;
+	FILE *fp;
+	char *posix_mode;
+
+	posix_mode = estrndup(mode, mode_len);
+#ifndef PHP_WIN32
+	{
+		char *z = memchr(posix_mode, 'b', mode_len);
+		if (z) {
+			memmove(z, z + 1, mode_len - (z - posix_mode));
+		}
+	}
+#endif
+
+	fp = VCWD_POPEN(command, posix_mode);
+	if (!fp) {
+		php_error_docref2(NULL, command, posix_mode, E_WARNING, "%s", strerror(errno));
+		efree(posix_mode);
+		RETURN_NULL();
+	}
+
+	threaded_stream = _pthreads_stream_fopen_from_pipe(fp, mode, pthreads_file_stream_entry);
+
+	if (threaded_stream == NULL)	{
+		php_error_docref2(NULL, command, mode, E_WARNING, "%s", strerror(errno));
+		RETVAL_NULL();
+	} else {
+		pthreads_stream_to_zval(threaded_stream, return_value);
+	}
+
+	efree(posix_mode);
+}
+
+void pthreads_streams_api_file_mkdir(zend_string *dir, zend_long mode, zend_bool recursive, zval *zcontext, zval *return_value) {
+	pthreads_stream_context_t *threaded_context = pthreads_stream_context_from_zval(zcontext, 0);
+
+	RETURN_BOOL(pthreads_stream_mkdir(ZSTR_VAL(dir), (int)mode, (recursive ? PTHREADS_STREAM_MKDIR_RECURSIVE : 0) | PTHREADS_REPORT_ERRORS, threaded_context));
+}
+
+void pthreads_streams_api_file_rmdir(zend_string *dir, zval *zcontext, zval *return_value) {
+	pthreads_stream_context_t *threaded_context = pthreads_stream_context_from_zval(zcontext, 0);
+
+	RETURN_BOOL(pthreads_stream_rmdir(ZSTR_VAL(dir), PTHREADS_REPORT_ERRORS, threaded_context));
+}
+
+void pthreads_streams_api_file_readfile(zend_string *filename, zend_bool use_include_path, zval *zcontext, zval *return_value) {
+	pthreads_stream_context_t *threaded_context = pthreads_stream_context_from_zval(zcontext, 0);
+	pthreads_stream_t *threaded_stream;
+	size_t size = 0;
+
+	threaded_stream = pthreads_stream_open_wrapper_ex(ZSTR_VAL(filename), "rb", (use_include_path ? PTHREADS_USE_PATH : 0) | PTHREADS_REPORT_ERRORS, NULL, threaded_context, NULL);
+	if (threaded_stream) {
+		size = pthreads_stream_passthru(threaded_stream);
+		pthreads_stream_close(threaded_stream, PTHREADS_STREAM_FREE_CLOSE);
+		RETURN_LONG(size);
+	}
+
+	RETURN_LONG(-1);
+}
+
+void pthreads_streams_api_file_rename(zend_string *old_name, zend_string *new_name, zval *zcontext, zval *return_value) {
+	pthreads_stream_context_t *threaded_context = pthreads_stream_context_from_zval(zcontext, 0);
+	pthreads_stream_wrapper_t *threaded_wrapper;
+	pthreads_stream_wrapper *wrapper;
+
+	// todo: threadsafety
+
+	threaded_wrapper = pthreads_stream_locate_url_wrapper(ZSTR_VAL(old_name), NULL, 0);
+
+	if (!threaded_wrapper || !PTHREADS_FETCH_STREAMS_WRAPPER(threaded_wrapper)->wops) {
+		php_error_docref(NULL, E_WARNING, "Unable to locate stream wrapper");
+		RETURN_FALSE;
+	}
+	wrapper = PTHREADS_FETCH_STREAMS_WRAPPER(threaded_wrapper);
+
+	if (!wrapper->wops->rename) {
+		php_error_docref(NULL, E_WARNING, "%s wrapper does not support renaming", wrapper->wops->label ? wrapper->wops->label : "Source");
+		RETURN_FALSE;
+	}
+
+	if (threaded_wrapper != pthreads_stream_locate_url_wrapper(ZSTR_VAL(new_name), NULL, 0)) {
+		php_error_docref(NULL, E_WARNING, "Cannot rename a file across wrapper types");
+		RETURN_FALSE;
+	}
+	RETURN_BOOL(wrapper->wops->rename(threaded_wrapper, ZSTR_VAL(old_name), ZSTR_VAL(new_name), 0, threaded_context));
+}
+
+void pthreads_streams_api_file_unlink(zend_string *filename, zval *zcontext, zval *return_value) {
+	pthreads_stream_context_t *threaded_context = pthreads_stream_context_from_zval(zcontext, 0);
+	pthreads_stream_wrapper_t *threaded_wrapper;
+	pthreads_stream_wrapper *wrapper;
+
+	threaded_wrapper = pthreads_stream_locate_url_wrapper(ZSTR_VAL(filename), NULL, 0);
+
+	if (!threaded_wrapper || !PTHREADS_FETCH_STREAMS_WRAPPER(threaded_wrapper)->wops) {
+		php_error_docref(NULL, E_WARNING, "Unable to locate stream wrapper");
+		RETURN_FALSE;
+	}
+	wrapper = PTHREADS_FETCH_STREAMS_WRAPPER(threaded_wrapper);
+
+	if (!wrapper->wops->unlink) {
+		php_error_docref(NULL, E_WARNING, "%s does not allow unlinking", wrapper->wops->label ? wrapper->wops->label : "Wrapper");
+		RETURN_FALSE;
+	}
+	RETURN_BOOL(wrapper->wops->unlink(threaded_wrapper, ZSTR_VAL(filename), PTHREADS_REPORT_ERRORS, threaded_context));
+}
+
+void pthreads_streams_api_file_copy(char *source, char *target, zval *zcontext, zval *return_value) {
+	pthreads_stream_context_t *threaded_context = pthreads_stream_context_from_zval(zcontext, 0);
+
+	if (php_check_open_basedir(source)) {
+		RETURN_FALSE;
+	}
+
+	if (pthreads_copy_file_ctx(source, target, 0, threaded_context) == SUCCESS) {
+		RETURN_TRUE;
+	} else {
+		RETURN_FALSE;
+	}
+}
+
+void pthreads_streams_api_file_sockopen(zend_string *host, zend_long port, zval *zerrno, zval *zerrstr, double timeout, int persistent, zval *return_value) {
+	struct timeval tv;
+	pthreads_stream_t *threaded_stream = NULL;
+#ifndef PHP_WIN32
+	time_t conv;
+#else
+	long conv;
+#endif
+	int err;
+	char *hostname = NULL;
+	size_t hostname_len;
+	zend_string *errstr = NULL;
+
+	RETVAL_NULL();
+
+
+	if (port > 0) {
+		hostname_len = spprintf(&hostname, 0, "%s:" ZEND_LONG_FMT, ZSTR_VAL(host), port);
+	} else {
+		hostname_len = ZSTR_LEN(host);
+		hostname = ZSTR_VAL(host);
+	}
+
+	/* prepare the timeout value for use */
+#ifndef PHP_WIN32
+	conv = (time_t) (timeout * 1000000.0);
+	tv.tv_sec = conv / 1000000;
+#else
+	conv = (long) (timeout * 1000000.0);
+	tv.tv_sec = conv / 1000000;
+#endif
+	tv.tv_usec = conv % 1000000;
+
+	if (zerrno)	{
+		zval_ptr_dtor(zerrno);
+		ZVAL_LONG(zerrno, 0);
+	}
+	if (zerrstr) {
+		zval_ptr_dtor(zerrstr);
+		ZVAL_EMPTY_STRING(zerrstr);
+	}
+
+	threaded_stream = pthreads_stream_xport_create(hostname, hostname_len, PTHREADS_REPORT_ERRORS,
+			PTHREADS_STREAM_XPORT_CLIENT | PTHREADS_STREAM_XPORT_CONNECT, &tv, NULL, &errstr, &err);
+
+	if (port > 0) {
+		efree(hostname);
+	}
+	if (threaded_stream == NULL) {
+		php_error_docref(NULL, E_WARNING, "unable to connect to %s:" ZEND_LONG_FMT " (%s)", ZSTR_VAL(host), port, errstr == NULL ? "Unknown error" : ZSTR_VAL(errstr));
+	}
+
+
+	if (threaded_stream == NULL) {
+		if (zerrno) {
+			zval_ptr_dtor(zerrno);
+			ZVAL_LONG(zerrno, err);
+		}
+
+		if (zerrstr && errstr) {
+			/* no need to dup; we need to efree buf anyway */
+			zval_ptr_dtor(zerrstr);
+			ZVAL_STR(zerrstr, errstr);
+		} else if (!zerrstr && errstr) {
+			zend_string_release(errstr);
+		}
+
+		RETURN_NULL();
+	}
+
+	if (errstr) {
+		zend_string_release(errstr);
+	}
+
+	pthreads_stream_to_zval(threaded_stream, return_value);
+}
+
+#endif

--- a/src/handlers.c
+++ b/src/handlers.c
@@ -64,7 +64,7 @@ HashTable* pthreads_read_debug(PTHREADS_READ_DEBUG_PASSTHRU_D) {
 	zend_hash_init(table, 8, NULL, ZVAL_PTR_DTOR, 0);
 	*is_temp = 1;
 
-	if (!PTHREADS_IS_SOCKET(threaded)) {
+	if (!PTHREADS_IS_SOCKET(threaded) && !PTHREADS_IS_STREAM(threaded) && !PTHREADS_IS_STREAM_CONTEXT(threaded)) {
 		pthreads_store_tohash(object, table);
 	}
 
@@ -369,12 +369,6 @@ int pthreads_compare_objects(PTHREADS_COMPARE_PASSTHRU_D) {
 	pthreads_object_t *left = PTHREADS_FETCH_FROM(Z_OBJ_P(op1));
 	pthreads_object_t *right = PTHREADS_FETCH_FROM(Z_OBJ_P(op2));
 
-	/* comparing property tables is not useful or efficient for threaded objects */
-	/* in addition, it might be useful to know if two variables are infact the same physical threaded object */
-	if (left->monitor == right->monitor) {
-		return 0;
-	}
-
-	return 1;
+	return pthreads_object_compare(left, right);
 } /* }}} */
 #endif

--- a/src/hash.c
+++ b/src/hash.c
@@ -1,0 +1,153 @@
+/*
+  +----------------------------------------------------------------------+
+  | pthreads                                                             |
+  +----------------------------------------------------------------------+
+  | Copyright (c) Joe Watkins 2018                                       |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | http://www.php.net/license/3_01.txt                                  |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors: Bastian Schneider <b.schneider@badnoob.com>                 |
+  | Borrowed code from php-src                                           |
+  +----------------------------------------------------------------------+
+ */
+#ifndef HAVE_PTHREADS_HASH
+#define HAVE_PTHREADS_HASH
+
+#ifndef HAVE_PTHREADS_H
+#	include <src/pthreads.h>
+#endif
+
+#ifndef HAVE_PTHREADS_OBJECT_H
+#	include <src/object.h>
+#endif
+
+static const uint32_t uninitialized_bucket[-HT_MIN_MASK] =
+	{HT_INVALID_IDX, HT_INVALID_IDX};
+
+/* {{{ */
+HashTable* pthreads_new_array(uint32_t nSize) {
+	HashTable *ht = calloc(1, sizeof(HashTable));
+	zend_hash_init(ht, nSize, NULL, ZVAL_PTR_DTOR, 1);
+	return ht;
+} /* }}} */
+
+/* {{{ */
+HashTable* pthreads_array_dup(HashTable *source) {
+	HashTable *target = pthreads_new_array(sizeof(HashTable));
+
+	zend_hash_init(target, zend_hash_num_elements(source), NULL, NULL, 1);
+	zend_hash_copy(target, source, NULL);
+
+	return target;
+} /* }}} */
+
+/* {{{ */
+void pthreads_hashtable_init(pthreads_hashtable *pht, uint32_t nSize, dtor_func_t pDestructor) {
+	pht->monitor = pthreads_monitor_alloc();
+	zend_hash_init(&pht->ht, nSize, NULL, pDestructor, 1);
+} /* }}} */
+
+/* {{{ */
+void pthreads_free_hashtable(pthreads_hashtable *pht) {
+	if(pht->monitor) {
+		pthreads_monitor_free(pht->monitor);
+		pht->monitor = NULL;
+	}
+	zend_hash_destroy(&pht->ht);
+} /* }}} */
+
+/* {{{ */
+void pthreads_clear_hashtable(pthreads_hashtable *pht) {
+	zend_hash_clean(&pht->ht);
+} /* }}} */
+
+pthreads_object_t *_pthreads_array_to_volatile_map(zval *array, int level) {
+	HashTable *myht;
+	zval *val;
+	zend_string *name = NULL;
+	zend_ulong idx;
+
+	pthreads_object_t *map = pthreads_object_init(pthreads_volatile_map_entry);
+
+	ZEND_HASH_FOREACH_KEY_VAL(Z_ARRVAL_P(array), idx, name, val) {
+		zval obj, nextlvl;
+		int converted = 0;
+
+		ZVAL_DEREF(val);
+
+		if (!name) {
+			name = zend_long_to_str(idx);
+			converted = 1;
+		}
+
+		ZVAL_OBJ(&obj, PTHREADS_STD_P(map));
+
+		if(Z_TYPE_P(val) == IS_ARRAY) {
+			myht = Z_ARRVAL_P(val);
+			if (level > 1 && ZEND_HASH_APPLY_PROTECTION(myht) && ++myht->u.v.nApplyCount > 1) {
+				--myht->u.v.nApplyCount;
+				return;
+			}
+			ZVAL_OBJ(&nextlvl, PTHREADS_STD_P(_pthreads_array_to_volatile_map(val, level + 1)));
+
+			if (level > 1 && ZEND_HASH_APPLY_PROTECTION(myht)) {
+				--myht->u.v.nApplyCount;
+			}
+
+			zend_update_property_ex(pthreads_volatile_map_entry, &obj, name, &nextlvl);
+		} else {
+			zend_update_property_ex(pthreads_volatile_map_entry, &obj, name, val);
+		}
+
+		if(converted) {
+			zend_string_release(name);
+		}
+
+	} ZEND_HASH_FOREACH_END();
+
+	return map;
+}
+
+zval *_pthreads_volatile_map_to_array(pthreads_object_t *map, zval *array) {
+	zend_string *name = NULL;
+	zend_ulong idx;
+	pthreads_storage *storage;
+
+	array_init(array);
+
+	ZEND_HASH_FOREACH_KEY_PTR(map->store.props, idx, name, storage) {
+		zval pzval;
+		zend_string *rename;
+
+		if (pthreads_store_convert(storage, &pzval) != SUCCESS) {
+			continue;
+		}
+
+		if(storage->type == IS_MAP) {
+			pthreads_object_t* nextlvl = PTHREADS_FETCH_FROM(Z_OBJ(pzval));
+
+			_pthreads_volatile_map_to_array(nextlvl, &pzval);
+		}
+
+		if (!name) {
+			if (!zend_hash_index_update(Z_ARRVAL_P(array), idx, &pzval)) {
+				zval_ptr_dtor(&pzval);
+			}
+		} else {
+			rename = zend_string_init(name->val, name->len, 0);
+			if (!zend_hash_update(Z_ARRVAL_P(array), rename, &pzval))
+				zval_ptr_dtor(&pzval);
+			zend_string_release(rename);
+		}
+	} ZEND_HASH_FOREACH_END();
+
+	return array;
+}
+
+#endif

--- a/src/hash.h
+++ b/src/hash.h
@@ -1,0 +1,57 @@
+/*
+  +----------------------------------------------------------------------+
+  | pthreads                                                             |
+  +----------------------------------------------------------------------+
+  | Copyright (c) Joe Watkins 2018                                       |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | http://www.php.net/license/3_01.txt                                  |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors: Bastian Schneider <b.schneider@badnoob.com>                 |
+  | Borrowed code from php-src                                           |
+  +----------------------------------------------------------------------+
+ */
+#ifndef HAVE_PTHREADS_HASH_H
+#define HAVE_PTHREADS_HASH_H
+
+typedef struct _pthreads_hashtable pthreads_hashtable;
+typedef struct _pthreads_object_t pthreads_object_t;
+
+struct _pthreads_hashtable {
+	pthreads_monitor_t *monitor;
+	HashTable ht;
+};
+
+#define PTHREADS_SEPARATE_ARRAY(zv) do {				\
+		zval *_zv = (zv);								\
+		zend_array *_arr = Z_ARR_P(_zv);				\
+		if (UNEXPECTED(GC_REFCOUNT(_arr) > 1)) {		\
+			if (Z_REFCOUNTED_P(_zv)) {					\
+				GC_DELREF(_arr);						\
+			}											\
+			ZVAL_ARR(_zv, pthreads_array_dup(_arr));	\
+		}												\
+	} while (0)
+
+#define pthreads_array_init(arg)				ZVAL_ARR((arg), pthreads_new_array(0))
+#define pthreads_array_init_size(arg, size)		ZVAL_ARR((arg), pthreads_new_array(size))
+
+void pthreads_hashtable_init(pthreads_hashtable *pht, uint32_t size, dtor_func_t pDestructor);
+void pthreads_free_hashtable(pthreads_hashtable *pht);
+void pthreads_clear_hashtable(pthreads_hashtable *pht);
+
+HashTable* pthreads_new_array(uint32_t size);
+HashTable* pthreads_array_dup(HashTable *source);
+
+pthreads_object_t *_pthreads_array_to_volatile_map(zval *array, int level);
+#define pthreads_array_to_volatile_map(array) _pthreads_array_to_volatile_map((array), 1)
+
+zval *_pthreads_volatile_map_to_array(pthreads_object_t *map, zval *array);
+#define pthreads_volatile_map_to_array(map, array) _pthreads_volatile_map_to_array((map), (array))
+
+#endif

--- a/src/info.c
+++ b/src/info.c
@@ -1,0 +1,116 @@
+/*
+  +----------------------------------------------------------------------+
+  | pthreads                                                             |
+  +----------------------------------------------------------------------+
+  | Copyright (c) Joe Watkins 2018                                       |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | http://www.php.net/license/3_01.txt                                  |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors: Bastian Schneider <b.schneider@badnoob.com>                 |
+  | Borrowed code from php-src                                           |
+  +----------------------------------------------------------------------+
+ */
+#ifndef HAVE_PTHREADS_INFO
+#define HAVE_PTHREADS_INFO
+
+#ifndef HAVE_PTHREADS_H
+#	include <src/pthreads.h>
+#endif
+
+#ifndef HTML_H
+#	include <ext/standard/html.h>
+#endif
+
+static int pthreads_info_printf(const char *fmt, ...) /* {{{ */
+{
+	char *buf;
+	size_t len, written;
+	va_list argv;
+
+	va_start(argv, fmt);
+	len = vspprintf(&buf, 0, fmt, argv);
+	va_end(argv);
+
+	written = php_output_write(buf, len);
+	efree(buf);
+	return written;
+}
+/* }}} */
+
+static int pthreads_info_print(const char *str) /* {{{ */
+{
+	return php_output_write(str, strlen(str));
+}
+
+static int pthreads_info_print_html_esc(const char *str, size_t len) /* {{{ */
+{
+	size_t written;
+	zend_string *new_str;
+
+	new_str = php_escape_html_entities((unsigned char *) str, len, 0, ENT_QUOTES, "utf-8");
+	written = php_output_write(ZSTR_VAL(new_str), ZSTR_LEN(new_str));
+	zend_string_free(new_str);
+	return written;
+}
+/* }}} */
+
+static void pthreads_info_print_stream_hash(const char *name, HashTable *ht) /* {{{ */
+{
+	zend_string *key;
+
+	if (ht) {
+		if (zend_hash_num_elements(ht)) {
+			int first = 1;
+
+			if (!sapi_module.phpinfo_as_text) {
+				pthreads_info_printf("<tr><td class=\"e\">Registered %s</td><td class=\"v\">", name);
+			} else {
+				pthreads_info_printf("\nRegistered %s => ", name);
+			}
+
+			ZEND_HASH_FOREACH_STR_KEY(ht, key) {
+				if (key) {
+					if (first) {
+						first = 0;
+					} else {
+						pthreads_info_print(", ");
+					}
+					if (!sapi_module.phpinfo_as_text) {
+						pthreads_info_print_html_esc(ZSTR_VAL(key), ZSTR_LEN(key));
+					} else {
+						pthreads_info_print(ZSTR_VAL(key));
+					}
+				}
+			} ZEND_HASH_FOREACH_END();
+
+			if (!sapi_module.phpinfo_as_text) {
+				pthreads_info_print("</td></tr>\n");
+			}
+		} else {
+			char reg_name[128];
+			snprintf(reg_name, sizeof(reg_name), "\nRegistered %s", name);
+			php_info_print_table_row(2, reg_name, "none registered");
+		}
+	} else {
+		php_info_print_table_row(2, name, "disabled");
+	}
+}
+/* }}} */
+
+static void pthreads_info_print_table_end(void) /* {{{ */
+{
+	if (!sapi_module.phpinfo_as_text) {
+		pthreads_info_print("</table>\n");
+	} else {
+		pthreads_info_print("\n");
+	}
+}
+/* }}} */
+
+#endif

--- a/src/monitor.c
+++ b/src/monitor.c
@@ -21,7 +21,11 @@
 #ifndef HAVE_PTHREADS_H
 #	include <src/pthreads.h>
 #endif
-
+/*
+#ifndef HAVE_PTHREADS_MONITOR_H
+#	include <src/monitor.h>
+#endif
+*/
 struct _pthreads_monitor_t {
 	pthreads_monitor_state_t state;	
 	pthread_mutex_t			 mutex;	
@@ -55,11 +59,19 @@ pthreads_monitor_t* pthreads_monitor_alloc() {
 	return m;
 }
 
-zend_bool pthreads_monitor_lock(pthreads_monitor_t *m) {
+int pthreads_monitor_get_lock(pthreads_monitor_t *m) {
+	return pthread_mutex_lock(&m->mutex);
+}
+
+int pthreads_monitor_lock(pthreads_monitor_t *m) {
 	return (pthread_mutex_lock(&m->mutex) == 0);
 }
 
-zend_bool pthreads_monitor_unlock(pthreads_monitor_t *m) {
+int pthreads_monitor_trylock(pthreads_monitor_t *m) {
+	return (pthread_mutex_trylock(&m->mutex) == 0);
+}
+
+int pthreads_monitor_unlock(pthreads_monitor_t *m) {
 	return (pthread_mutex_unlock(&m->mutex) == 0);
 }
 

--- a/src/monitor.h
+++ b/src/monitor.h
@@ -29,9 +29,14 @@ typedef struct _pthreads_monitor_t pthreads_monitor_t;
 #define PTHREADS_MONITOR_ERROR		(1<<3)
 #define PTHREADS_MONITOR_READY		(1<<4)
 
+#define MONITOR_LOCK(object) pthreads_monitor_lock((object)->monitor)
+#define MONITOR_UNLOCK(object) pthreads_monitor_unlock((object)->monitor)
+
 pthreads_monitor_t* pthreads_monitor_alloc();
-zend_bool pthreads_monitor_lock(pthreads_monitor_t *m);
-zend_bool pthreads_monitor_unlock(pthreads_monitor_t *m);
+int pthreads_monitor_get_lock(pthreads_monitor_t *m);
+int pthreads_monitor_lock(pthreads_monitor_t *m);
+int pthreads_monitor_trylock(pthreads_monitor_t *m) ;
+int pthreads_monitor_unlock(pthreads_monitor_t *m);
 pthreads_monitor_state_t pthreads_monitor_check(pthreads_monitor_t *m, pthreads_monitor_state_t state);
 int pthreads_monitor_wait(pthreads_monitor_t *m, long timeout);
 int pthreads_monitor_notify(pthreads_monitor_t *m);

--- a/src/network.c
+++ b/src/network.c
@@ -1,0 +1,71 @@
+/*
+  +----------------------------------------------------------------------+
+  | pthreads                                                             |
+  +----------------------------------------------------------------------+
+  | Copyright (c) Joe Watkins 2018                                       |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | http://www.php.net/license/3_01.txt                                  |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors: Bastian Schneider <b.schneider@badnoob.com>                 |
+  | Borrowed code from php-src                                           |
+  +----------------------------------------------------------------------+
+ */
+#ifndef HAVE_PTHREADS_NETWORK
+#define HAVE_PTHREADS_NETWORK
+
+#ifndef HAVE_PTHREADS_NETWORK_H
+#	include <src/network.h>
+#endif
+
+#ifndef HAVE_PTHREADS_STREAMS_TRANSPORTS_H
+#	include <src/streams/transports.h>
+#endif
+
+pthreads_stream_t *_pthreads_stream_sock_open_from_socket(php_socket_t socket, zend_class_entry *ce) {
+	pthreads_stream_t *threaded_stream;
+	pthreads_stream *stream;
+	pthreads_netstream_data_t *sock;
+
+	sock = malloc(sizeof(pthreads_netstream_data_t));
+	memset(sock, 0, sizeof(pthreads_netstream_data_t));
+
+	sock->is_blocked = 1;
+	sock->timeout.tv_sec = FG(default_socket_timeout);
+	sock->timeout.tv_usec = 0;
+	sock->socket = socket;
+
+	threaded_stream = PTHREADS_STREAM_CLASS_NEW(&pthreads_stream_generic_socket_ops, sock, "r+", ce);
+
+	if (threaded_stream == NULL) {
+		free(sock);
+	} else {
+		stream = PTHREADS_FETCH_STREAMS_STREAM(threaded_stream);
+		stream->flags |= PTHREADS_STREAM_FLAG_AVOID_BLOCKING;
+	}
+
+	return threaded_stream;
+}
+
+pthreads_stream_t *_pthreads_stream_sock_open_host(const char *host, unsigned short port,
+		int socktype, struct timeval *timeout) {
+	char *res;
+	zend_long reslen;
+	pthreads_stream_t *threaded_stream;
+
+	reslen = spprintf(&res, 0, "tcp://%s:%d", host, port);
+
+	threaded_stream = pthreads_stream_xport_create(res, reslen, PTHREADS_REPORT_ERRORS,
+			PTHREADS_STREAM_XPORT_CLIENT | PTHREADS_STREAM_XPORT_CONNECT, timeout, NULL, NULL, NULL);
+
+	efree(res);
+
+	return threaded_stream;
+}
+
+#endif

--- a/src/network.h
+++ b/src/network.h
@@ -1,0 +1,64 @@
+/*
+  +----------------------------------------------------------------------+
+  | pthreads                                                             |
+  +----------------------------------------------------------------------+
+  | Copyright (c) Joe Watkins 2018                                       |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | http://www.php.net/license/3_01.txt                                  |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors: Bastian Schneider <b.schneider@badnoob.com>                 |
+  | Borrowed code from php-src                                           |
+  +----------------------------------------------------------------------+
+ */
+#ifndef HAVE_PTHREADS_NETWORK_H
+#define HAVE_PTHREADS_NETWORK_H
+
+#ifndef _PHP_NETWORK_H
+#	include <php_network.h>
+#endif
+
+#ifndef HAVE_PTHREADS_H
+#	include <src/pthreads.h>
+#endif
+
+#ifndef HAVE_PTHREADS_STREAMS_H
+#	include <src/streams.h>
+#endif
+
+#define PTHREADS_STREAM_SOCKOP_NONE                (1 << 0)
+#define PTHREADS_STREAM_SOCKOP_SO_REUSEPORT        (1 << 1)
+#define PTHREADS_STREAM_SOCKOP_SO_BROADCAST        (1 << 2)
+#define PTHREADS_STREAM_SOCKOP_IPV6_V6ONLY         (1 << 3)
+#define PTHREADS_STREAM_SOCKOP_IPV6_V6ONLY_ENABLED (1 << 4)
+#define PTHREADS_STREAM_SOCKOP_TCP_NODELAY         (1 << 5)
+
+struct _pthreads_netstream_data_t	{
+	php_socket_t socket;
+	char is_blocked;
+	struct timeval timeout;
+	char timeout_event;
+	size_t ownsize;
+};
+typedef struct _pthreads_netstream_data_t pthreads_netstream_data_t;
+
+extern const pthreads_stream_ops pthreads_stream_socket_ops;
+extern const pthreads_stream_ops pthreads_stream_generic_socket_ops;
+
+#define PTHREADS_STREAM_IS_SOCKET	(&pthreads_stream_socket_ops)
+
+
+pthreads_stream_t *_pthreads_stream_sock_open_from_socket(php_socket_t socket, zend_class_entry *ce);
+/* open a connection to a host using php_hostconnect and return a stream */
+pthreads_stream_t *_pthreads_stream_sock_open_host(const char *host, unsigned short port,
+		int socktype, struct timeval *timeout);
+
+#define pthreads_stream_sock_open_from_socket(socket)	_pthreads_stream_sock_open_from_socket((socket), NULL)
+#define pthreads_stream_sock_open_host(host, port, socktype, timeout)	_pthreads_stream_sock_open_host((host), (port), (socktype), (timeout))
+
+#endif

--- a/src/object.h
+++ b/src/object.h
@@ -27,10 +27,28 @@
 #endif
 
 /* {{{ */
+pthreads_object_t* pthreads_object_init(zend_class_entry *ce); /* }}} */
+
+/* {{{ */
+int pthreads_object_compare(pthreads_object_t* left, pthreads_object_t *right); /* }}} */
+
+/* {{{ */
+void pthreads_ptr_dtor(pthreads_object_t* threaded);
+void pthreads_add_ref(pthreads_object_t* threaded);
+void pthreads_del_ref(pthreads_object_t* threaded);
+int pthreads_refcount(pthreads_object_t* threaded); /* }}} */
+
+/* {{{ */
 zend_object* pthreads_threaded_ctor(zend_class_entry *entry);
 zend_object* pthreads_worker_ctor(zend_class_entry *entry);
 zend_object* pthreads_thread_ctor(zend_class_entry *entry);
 zend_object* pthreads_socket_ctor(zend_class_entry *entry);
+zend_object* pthreads_stream_ctor(zend_class_entry *entry);
+zend_object* pthreads_stream_context_ctor(zend_class_entry *entry);
+zend_object* pthreads_stream_filter_ctor(zend_class_entry *entry);
+zend_object* pthreads_stream_wrapper_ctor(zend_class_entry *entry);
+zend_object* pthreads_stream_bucket_ctor(zend_class_entry *entry);
+zend_object* pthreads_stream_brigade_ctor(zend_class_entry *entry);
 void         pthreads_base_free(zend_object *object);
 zend_object* pthreads_base_clone(zval *object);
 HashTable*   pthreads_base_gc(zval *object, zval **table, int *n); /* }}} */

--- a/src/pthreads.h
+++ b/src/pthreads.h
@@ -86,6 +86,18 @@ extern zend_class_entry *pthreads_volatile_entry;
 extern zend_class_entry *pthreads_thread_entry;
 extern zend_class_entry *pthreads_worker_entry;
 extern zend_class_entry *pthreads_socket_entry;
+extern zend_class_entry *pthreads_streams_entry;
+extern zend_class_entry *pthreads_stream_entry;
+extern zend_class_entry *pthreads_stream_context_entry;
+extern zend_class_entry *pthreads_stream_filter_entry;
+extern zend_class_entry *pthreads_stream_bucket_entry;
+extern zend_class_entry *pthreads_stream_wrapper_entry;
+extern zend_class_entry *pthreads_stream_brigade_entry;
+extern zend_class_entry *pthreads_user_filter_class_entry;
+extern zend_class_entry *pthreads_socket_stream_entry;
+extern zend_class_entry *pthreads_volatile_map_entry;
+extern zend_class_entry *pthreads_file_stream_entry;
+extern zend_class_entry *pthreads_file_entry;
 
 #ifndef IS_PTHREADS_CLASS
 #define IS_PTHREADS_CLASS(c) \
@@ -108,6 +120,7 @@ extern zend_class_entry *pthreads_socket_entry;
 #endif
 
 extern zend_object_handlers pthreads_handlers;
+extern zend_object_handlers pthreads_stream_handlers;
 extern zend_object_handlers pthreads_socket_handlers;
 extern zend_object_handlers *zend_handlers;
 
@@ -136,7 +149,13 @@ ZEND_END_MODULE_GLOBALS(pthreads)
 #define PTHREADS_EG(ls, v) PTHREADS_FETCH_CTX(ls, executor_globals_id, zend_executor_globals*, v)
 #define PTHREADS_SG(ls, v) PTHREADS_FETCH_CTX(ls, sapi_globals_id, sapi_globals_struct*, v)
 #define PTHREADS_PG(ls, v) PTHREADS_FETCH_CTX(ls, core_globals_id, php_core_globals*, v)
+#define PTHREADS_FG(ls, v) PTHREADS_FETCH_CTX(ls, file_globals_id, php_file_globals*, v)
+#define PTHREADS_BG(ls, v) PTHREADS_FETCH_CTX(ls, basic_globals_id, php_basic_globals*, v)
 #define PTHREADS_EG_ALL(ls) PTHREADS_FETCH_ALL(ls, executor_globals_id, zend_executor_globals*)
+
+#define PTHREADS_STD(v) ((v)->std)
+#define PTHREADS_STD_P(v) &((v)->std)
+#define PTHREADS_HT_P(v) &((v)->ht)
 
 static zend_string *zend_string_new(zend_string *s)
 {
@@ -179,6 +198,20 @@ typedef struct _pthreads_call_t {
 	zend_fcall_info_cache fcc;
 } pthreads_call_t; /* }}} */
 
+/* {{{ */
+typedef struct _pthreads_storage {
+	zend_uchar 	type;
+	size_t 	length;
+	zend_bool 	exists;
+	union {
+		zend_long   lval;
+		double     dval;
+	} simple;
+	void    	*data;
+} pthreads_storage; /* }}} */
+
+typedef HashTable pthreads_store_t;
+
 #define PTHREADS_CALL_EMPTY {empty_fcall_info, empty_fcall_info_cache}
 
 #ifndef HAVE_PTHREADS_MONITOR_H
@@ -189,12 +222,20 @@ typedef struct _pthreads_call_t {
 #	include <src/stack.h>
 #endif
 
+#ifndef HAVE_PTHREADS_THREAD_H
+#	include <src/thread.h>
+#endif
+
 #ifndef HAVE_PTHREADS_STORE_H
 #	include <src/store.h>
 #endif
 
-#ifndef HAVE_PTHREADS_THREAD_H
-#	include <src/thread.h>
+#ifndef HAVE_PTHREADS_HASH_H
+#	include <src/hash.h>
+#endif
+
+#ifndef HAVE_PTHREADS_STREAMS_H
+#	include <src/streams.h>
 #endif
 
 #endif

--- a/src/socket.c
+++ b/src/socket.c
@@ -36,15 +36,6 @@
 # define SOCK_EINVAL EINVAL
 #endif
 
-#ifndef PHP_WIN32
-#define PTHREADS_INVALID_SOCKET -1
-#define PTHREADS_IS_INVALID_SOCKET(sock) ((sock)->fd < 0)
-#define PTHREADS_CLOSE_SOCKET_INTERNAL(sock) close((sock)->fd)
-#else
-#define PTHREADS_INVALID_SOCKET INVALID_SOCKET
-#define PTHREADS_IS_INVALID_SOCKET(sock) ((sock)->fd == INVALID_SOCKET)
-#define PTHREADS_CLOSE_SOCKET_INTERNAL(sock) closesocket((sock)->fd)
-#endif
 
 #define PTHREADS_IS_VALID_SOCKET(sock) !PTHREADS_IS_INVALID_SOCKET(sock)
 #define PTHREADS_CLEAR_SOCKET_ERROR(sock) (sock)->error = SUCCESS
@@ -1062,5 +1053,443 @@ void pthreads_socket_clear_error(zval *object) {
 
 	PTHREADS_SOCKET_CHECK(threaded->store.sock);
 	PTHREADS_CLEAR_SOCKET_ERROR(threaded->store.sock);
+}
+
+void pthreads_init_sockets() {
+	zend_declare_class_constant_long(pthreads_socket_entry, ZEND_STRL("AF_UNIX"), AF_UNIX);
+	zend_declare_class_constant_long(pthreads_socket_entry, ZEND_STRL("AF_INET"), AF_INET);
+#ifdef HAVE_IPV6
+	zend_declare_class_constant_long(pthreads_socket_entry, ZEND_STRL("AF_INET6"), AF_INET6);
+#endif
+	zend_declare_class_constant_long(pthreads_socket_entry, ZEND_STRL("SOCK_STREAM"), SOCK_STREAM);
+	zend_declare_class_constant_long(pthreads_socket_entry, ZEND_STRL("SOCK_DGRAM"), SOCK_DGRAM);
+	zend_declare_class_constant_long(pthreads_socket_entry, ZEND_STRL("SOCK_RAW"), SOCK_RAW);
+	zend_declare_class_constant_long(pthreads_socket_entry, ZEND_STRL("SOCK_SEQPACKET"), SOCK_SEQPACKET);
+	zend_declare_class_constant_long(pthreads_socket_entry, ZEND_STRL("SOCK_RDM"), SOCK_RDM);
+
+	zend_declare_class_constant_long(pthreads_socket_entry, ZEND_STRL("SO_DEBUG"), SO_DEBUG);
+	zend_declare_class_constant_long(pthreads_socket_entry, ZEND_STRL("SO_REUSEADDR"), SO_REUSEADDR);
+#ifdef SO_REUSEPORT
+	zend_declare_class_constant_long(pthreads_socket_entry, ZEND_STRL("SO_REUSEPORT"), SO_REUSEPORT);
+#endif
+	zend_declare_class_constant_long(pthreads_socket_entry, ZEND_STRL("SO_KEEPALIVE"), SO_KEEPALIVE);
+	zend_declare_class_constant_long(pthreads_socket_entry, ZEND_STRL("SO_DONTROUTE"), SO_DONTROUTE);
+	zend_declare_class_constant_long(pthreads_socket_entry, ZEND_STRL("SO_LINGER"), SO_LINGER);
+	zend_declare_class_constant_long(pthreads_socket_entry, ZEND_STRL("SO_BROADCAST"), SO_BROADCAST);
+	zend_declare_class_constant_long(pthreads_socket_entry, ZEND_STRL("SO_OOBINLINE"), SO_OOBINLINE);
+	zend_declare_class_constant_long(pthreads_socket_entry, ZEND_STRL("SO_SNDBUF"), SO_SNDBUF);
+	zend_declare_class_constant_long(pthreads_socket_entry, ZEND_STRL("SO_RCVBUF"), SO_RCVBUF);
+	zend_declare_class_constant_long(pthreads_socket_entry, ZEND_STRL("SO_SNDLOWAT"), SO_SNDLOWAT);
+	zend_declare_class_constant_long(pthreads_socket_entry, ZEND_STRL("SO_RCVLOWAT"), SO_RCVLOWAT);
+	zend_declare_class_constant_long(pthreads_socket_entry, ZEND_STRL("SO_SNDTIMEO"), SO_SNDTIMEO);
+	zend_declare_class_constant_long(pthreads_socket_entry, ZEND_STRL("SO_RCVTIMEO"), SO_RCVTIMEO);
+	zend_declare_class_constant_long(pthreads_socket_entry, ZEND_STRL("SO_TYPE"), SO_TYPE);
+#ifdef SO_FAMILY
+	zend_declare_class_constant_long(pthreads_socket_entry, ZEND_STRL("SO_FAMILY"), SO_FAMILY);
+#endif
+	zend_declare_class_constant_long(pthreads_socket_entry, ZEND_STRL("SO_ERROR"), SO_ERROR);
+#ifdef SO_BINDTODEVICE
+	zend_declare_class_constant_long(pthreads_socket_entry, ZEND_STRL("SO_BINDTODEVICE"), SO_BINDTODEVICE);
+#endif
+	zend_declare_class_constant_long(pthreads_socket_entry, ZEND_STRL("SOMAXCONN"), SOMAXCONN);
+#ifdef TCP_NODELAY
+	zend_declare_class_constant_long(pthreads_socket_entry, ZEND_STRL("TCP_NODELAY"), TCP_NODELAY);
+#endif
+	zend_declare_class_constant_long(pthreads_socket_entry, ZEND_STRL("NORMAL_READ"), PTHREADS_NORMAL_READ);
+	zend_declare_class_constant_long(pthreads_socket_entry, ZEND_STRL("BINARY_READ"), PTHREADS_BINARY_READ);
+
+	zend_declare_class_constant_long(pthreads_socket_entry, ZEND_STRL("SOL_SOCKET"), SOL_SOCKET);
+	zend_declare_class_constant_long(pthreads_socket_entry, ZEND_STRL("SOL_TCP"), IPPROTO_TCP);
+	zend_declare_class_constant_long(pthreads_socket_entry, ZEND_STRL("SOL_UDP"), IPPROTO_UDP);
+
+	zend_declare_class_constant_long(pthreads_socket_entry, ZEND_STRL("MSG_OOB"), MSG_OOB);
+	zend_declare_class_constant_long(pthreads_socket_entry, ZEND_STRL("MSG_WAITALL"), MSG_WAITALL);
+	zend_declare_class_constant_long(pthreads_socket_entry, ZEND_STRL("MSG_CTRUNC"), MSG_CTRUNC);
+	zend_declare_class_constant_long(pthreads_socket_entry, ZEND_STRL("MSG_TRUNC"), MSG_TRUNC);
+	zend_declare_class_constant_long(pthreads_socket_entry, ZEND_STRL("MSG_PEEK"), MSG_PEEK);
+	zend_declare_class_constant_long(pthreads_socket_entry, ZEND_STRL("MSG_DONTROUTE"), MSG_DONTROUTE);
+#ifdef MSG_EOR
+	zend_declare_class_constant_long(pthreads_socket_entry, ZEND_STRL("MSG_EOR"), MSG_EOR);
+#endif
+#ifdef MSG_EOF
+	zend_declare_class_constant_long(pthreads_socket_entry, ZEND_STRL("MSG_EOF"), MSG_EOF);
+#endif
+#ifdef MSG_CONFIRM
+	zend_declare_class_constant_long(pthreads_socket_entry, ZEND_STRL("MSG_CONFIRM"), MSG_CONFIRM);
+#endif
+#ifdef MSG_ERRQUEUE
+	zend_declare_class_constant_long(pthreads_socket_entry, ZEND_STRL("MSG_ERRQUEUE"), MSG_ERRQUEUE);
+#endif
+#ifdef MSG_NOSIGNAL
+	zend_declare_class_constant_long(pthreads_socket_entry, ZEND_STRL("MSG_NOSIGNAL"), MSG_NOSIGNAL);
+#endif
+#ifdef MSG_MORE
+	zend_declare_class_constant_long(pthreads_socket_entry, ZEND_STRL("MSG_MORE"), MSG_MORE);
+#endif
+#ifdef MSG_WAITFORONE
+	zend_declare_class_constant_long(pthreads_socket_entry, ZEND_STRL("MSG_WAITFORONE"), MSG_WAITFORONE);
+#endif
+#ifdef MSG_CMSG_CLOEXEC
+	zend_declare_class_constant_long(pthreads_socket_entry, ZEND_STRL("MSG_CMSG_CLOEXEC"), MSG_CMSG_CLOEXEC);
+#endif
+
+#ifndef _WIN32
+#ifdef EPERM
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EPERM"), EPERM);
+#endif
+#ifdef ENOENT
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ENOENT"), ENOENT);
+#endif
+#ifdef EINTR
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EINTR"), EINTR);
+#endif
+#ifdef EIO
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EIO"), EIO);
+#endif
+#ifdef ENXIO
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ENXIO"), ENXIO);
+#endif
+#ifdef E2BIG
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("E2BIG"), E2BIG);
+#endif
+#ifdef EBADF
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EBADF"), EBADF);
+#endif
+#ifdef EAGAIN
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EAGAIN"), EAGAIN);
+#endif
+#ifdef ENOMEM
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ENOMEM"), ENOMEM);
+#endif
+#ifdef EACCES
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EACCES"), EACCES);
+#endif
+#ifdef EFAULT
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EFAULT"), EFAULT);
+#endif
+#ifdef ENOTBLK
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ENOTBLK"), ENOTBLK);
+#endif
+#ifdef EBUSY
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EBUSY"), EBUSY);
+#endif
+#ifdef EEXIST
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EEXIST"), EEXIST);
+#endif
+#ifdef EXDEV
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EXDEV"), EXDEV);
+#endif
+#ifdef ENODEV
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ENODEV"), ENODEV);
+#endif
+#ifdef ENOTDIR
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ENOTDIR"), ENOTDIR);
+#endif
+#ifdef EISDIR
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EISDIR"), EISDIR);
+#endif
+#ifdef EINVAL
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EINVAL"), EINVAL);
+#endif
+#ifdef ENFILE
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ENFILE"), ENFILE);
+#endif
+#ifdef EMFILE
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EMFILE"), EMFILE);
+#endif
+#ifdef ENOTTY
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ENOTTY"), ENOTTY);
+#endif
+#ifdef ENOSPC
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ENOSPC"), ENOSPC);
+#endif
+#ifdef ESPIPE
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ESPIPE"), ESPIPE);
+#endif
+#ifdef EROFS
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EROFS"), EROFS);
+#endif
+#ifdef EMLINK
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EMLINK"), EMLINK);
+#endif
+#ifdef EPIPE
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EPIPE"), EPIPE);
+#endif
+#ifdef ENAMETOOLONG
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ENAMETOOLONG"), ENAMETOOLONG);
+#endif
+#ifdef ENOLCK
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ENOLCK"), ENOLCK);
+#endif
+#ifdef ENOSYS
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ENOSYS"), ENOSYS);
+#endif
+#ifdef ENOTEMPTY
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ENOTEMPTY"), ENOTEMPTY);
+#endif
+#ifdef ELOOP
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ELOOP"), ELOOP);
+#endif
+#ifdef EWOULDBLOCK
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EWOULDBLOCK"), EWOULDBLOCK);
+#endif
+#ifdef ENOMSG
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ENOMSG"), ENOMSG);
+#endif
+#ifdef EIDRM
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EIDRM"), EIDRM);
+#endif
+#ifdef ECHRNG
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ECHRNG"), ECHRNG);
+#endif
+#ifdef EL2NSYNC
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EL2NSYNC"), EL2NSYNC);
+#endif
+#ifdef EL3HLT
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EL3HLT"), EL3HLT);
+#endif
+#ifdef EL3RST
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EL3RST"), EL3RST);
+#endif
+#ifdef ELNRNG
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ELNRNG"), ELNRNG);
+#endif
+#ifdef EUNATCH
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EUNATCH"), EUNATCH);
+#endif
+#ifdef ENOCSI
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ENOCSI"), ENOCSI);
+#endif
+#ifdef EL2HLT
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EL2HLT"), EL2HLT);
+#endif
+#ifdef EBADE
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EBADE"), EBADE);
+#endif
+#ifdef EBADR
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EBADR"), EBADR);
+#endif
+#ifdef EXFULL
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EXFULL"), EXFULL);
+#endif
+#ifdef ENOANO
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ENOANO"), ENOANO);
+#endif
+#ifdef EBADRQC
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EBADRQC"), EBADRQC);
+#endif
+#ifdef EBADSLT
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EBADSLT"), EBADSLT);
+#endif
+#ifdef ENOSTR
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ENOSTR"), ENOSTR);
+#endif
+#ifdef ENODATA
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ENODATA"), ENODATA);
+#endif
+#ifdef ETIME
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ETIME"), ETIME);
+#endif
+#ifdef ENOSR
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ENOSR"), ENOSR);
+#endif
+#ifdef ENONET
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ENONET"), ENONET);
+#endif
+#ifdef EREMOTE
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EREMOTE"), EREMOTE);
+#endif
+#ifdef ENOLINK
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ENOLINK"), ENOLINK);
+#endif
+#ifdef EADV
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EADV"), EADV);
+#endif
+#ifdef ESRMNT
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ESRMNT"), ESRMNT);
+#endif
+#ifdef ECOMM
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ECOMM"), ECOMM);
+#endif
+#ifdef EPROTO
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EPROTO"), EPROTO);
+#endif
+#ifdef EMULTIHOP
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EMULTIHOP"), EMULTIHOP);
+#endif
+#ifdef EBADMSG
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EBADMSG"), EBADMSG);
+#endif
+#ifdef ENOTUNIQ
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ENOTUNIQ"), ENOTUNIQ);
+#endif
+#ifdef EBADFD
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EBADFD"), EBADFD);
+#endif
+#ifdef EREMCHG
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EREMCHG"), EREMCHG);
+#endif
+#ifdef ERESTART
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ERESTART"), ERESTART);
+#endif
+#ifdef ESTRPIPE
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ESTRPIPE"), ESTRPIPE);
+#endif
+#ifdef EUSERS
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EUSERS"), EUSERS);
+#endif
+#ifdef ENOTSOCK
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ENOTSOCK"), ENOTSOCK);
+#endif
+#ifdef EDESTADDRREQ
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EDESTADDRREQ"), EDESTADDRREQ);
+#endif
+#ifdef EMSGSIZE
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EMSGSIZE"), EMSGSIZE);
+#endif
+#ifdef EPROTOTYPE
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EPROTOTYPE"), EPROTOTYPE);
+#endif
+#ifdef ENOPROTOOPT
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ENOPROTOOPT"), ENOPROTOOPT);
+#endif
+#ifdef EPROTONOSUPPORT
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EPROTONOSUPPORT"), EPROTONOSUPPORT);
+#endif
+#ifdef ESOCKTNOSUPPORT
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ESOCKTNOSUPPORT"), ESOCKTNOSUPPORT);
+#endif
+#ifdef EOPNOTSUPP
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EOPNOTSUPP"), EOPNOTSUPP);
+#endif
+#ifdef EPFNOSUPPORT
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EPFNOSUPPORT"), EPFNOSUPPORT);
+#endif
+#ifdef EAFNOSUPPORT
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EAFNOSUPPORT"), EAFNOSUPPORT);
+#endif
+#ifdef EADDRINUSE
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EADDRINUSE"), EADDRINUSE);
+#endif
+#ifdef EADDRNOTAVAIL
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EADDRNOTAVAIL"), EADDRNOTAVAIL);
+#endif
+#ifdef ENETDOWN
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ENETDOWN"), ENETDOWN);
+#endif
+#ifdef ENETUNREACH
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ENETUNREACH"), ENETUNREACH);
+#endif
+#ifdef ENETRESET
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ENETRESET"), ENETRESET);
+#endif
+#ifdef ECONNABORTED
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ECONNABORTED"), ECONNABORTED);
+#endif
+#ifdef ECONNRESET
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ECONNRESET"), ECONNRESET);
+#endif
+#ifdef ENOBUFS
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ENOBUFS"), ENOBUFS);
+#endif
+#ifdef EISCONN
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EISCONN"), EISCONN);
+#endif
+#ifdef ENOTCONN
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ENOTCONN"), ENOTCONN);
+#endif
+#ifdef ESHUTDOWN
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ESHUTDOWN"), ESHUTDOWN);
+#endif
+#ifdef ETOOMANYREFS
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ETOOMANYREFS"), ETOOMANYREFS);
+#endif
+#ifdef ETIMEDOUT
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ETIMEDOUT"), ETIMEDOUT);
+#endif
+#ifdef ECONNREFUSED
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ECONNREFUSED"), ECONNREFUSED);
+#endif
+#ifdef EHOSTDOWN
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EHOSTDOWN"), EHOSTDOWN);
+#endif
+#ifdef EHOSTUNREACH
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EHOSTUNREACH"), EHOSTUNREACH);
+#endif
+#ifdef EALREADY
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EALREADY"), EALREADY);
+#endif
+#ifdef EINPROGRESS
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EINPROGRESS"), EINPROGRESS);
+#endif
+#ifdef EISNAM
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EISNAM"), EISNAM);
+#endif
+#ifdef EREMOTEIO
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EREMOTEIO"), EREMOTEIO);
+#endif
+#ifdef EDQUOT
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EDQUOT"), EDQUOT);
+#endif
+#ifdef ENOMEDIUM
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ENOMEDIUM"), ENOMEDIUM);
+#endif
+#ifdef EMEDIUMTYPE
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EMEDIUMTYPE"), EMEDIUMTYPE);
+#endif
+#else
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EINTR"), WSAEINTR);
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EBADF"), WSAEBADF);
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EACCES"), WSAEACCES);
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EFAULT"), WSAEFAULT);
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EINVAL"), WSAEINVAL);
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EMFILE"), WSAEMFILE);
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EWOULDBLOCK"), WSAEWOULDBLOCK);
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EINPROGRESS"), WSAEINPROGRESS);
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EALREADY"), WSAEALREADY);
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ENOTSOCK"), WSAENOTSOCK);
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EDESTADDRREQ"), WSAEDESTADDRREQ);
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EMSGSIZE"), WSAEMSGSIZE);
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EPROTOTYPE"), WSAEPROTOTYPE);
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ENOPROTOOPT"), WSAENOPROTOOPT);
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EPROTONOSUPPORT"), WSAEPROTONOSUPPORT);
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ESOCKTNOSUPPORT"), WSAESOCKTNOSUPPORT);
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EOPNOTSUPP"), WSAEOPNOTSUPP);
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EPFNOSUPPORT"), WSAEPFNOSUPPORT);
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EAFNOSUPPORT"), WSAEAFNOSUPPORT);
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EADDRINUSE"), WSAEADDRINUSE);
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EADDRNOTAVAIL"), WSAEADDRNOTAVAIL);
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ENETDOWN"), WSAENETDOWN);
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ENETUNREACH"), WSAENETUNREACH);
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ENETRESET"), WSAENETRESET);
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ECONNABORTED"), WSAECONNABORTED);
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ECONNRESET"), WSAECONNRESET);
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ENOBUFS"), WSAENOBUFS);
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EISCONN"), WSAEISCONN);
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ENOTCONN"), WSAENOTCONN);
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ESHUTDOWN"), WSAESHUTDOWN);
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ETOOMANYREFS"), WSAETOOMANYREFS);
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ETIMEDOUT"), WSAETIMEDOUT);
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ECONNREFUSED"), WSAECONNREFUSED);
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ELOOP"), WSAELOOP);
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ENAMETOOLONG"), WSAENAMETOOLONG);
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EHOSTDOWN"), WSAEHOSTDOWN);
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EHOSTUNREACH"), WSAEHOSTUNREACH);
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ENOTEMPTY"), WSAENOTEMPTY);
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EPROCLIM"), WSAEPROCLIM);
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EUSERS"), WSAEUSERS);
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EDQUOT"), WSAEDQUOT);
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("ESTALE"), WSAESTALE);
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EREMOTE"), WSAEREMOTE);
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("EDISCON"), WSAEDISCON);
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("SYSNOTREADY"), WSASYSNOTREADY);
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("VERNOTSUPPORTED"), WSAVERNOTSUPPORTED);
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("NOTINITIALISED"), WSANOTINITIALISED);
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("HOST_NOT_FOUND"), WSAHOST_NOT_FOUND);
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("TRY_AGAIN"), WSATRY_AGAIN);
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("NO_RECOVERY"), WSANO_RECOVERY);
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("NO_DATA"), WSANO_DATA);
+	zend_declare_class_constant_long(pthreads_socket_entry,  ZEND_STRL("NO_ADDRESS"), WSANO_ADDRESS);
+#endif
 }
 #endif

--- a/src/socket.h
+++ b/src/socket.h
@@ -22,6 +22,17 @@
 #	include <config.h>
 #endif
 
+
+#ifndef PHP_WIN32
+#define PTHREADS_INVALID_SOCKET -1
+#define PTHREADS_IS_INVALID_SOCKET(sock) ((sock)->fd < 0)
+#define PTHREADS_CLOSE_SOCKET_INTERNAL(sock) close((sock)->fd)
+#else
+#define PTHREADS_INVALID_SOCKET INVALID_SOCKET
+#define PTHREADS_IS_INVALID_SOCKET(sock) ((sock)->fd == INVALID_SOCKET)
+#define PTHREADS_CLOSE_SOCKET_INTERNAL(sock) closesocket((sock)->fd)
+#endif
+
 typedef struct _pthreads_socket_t {
 	php_socket_t fd;
 	zend_long domain;

--- a/src/store.c
+++ b/src/store.c
@@ -105,7 +105,7 @@ static inline zend_bool pthreads_store_coerce(HashTable *table, zval *key, zval 
 }
 
 /* {{{ */
-static inline zend_bool pthreads_store_is_immutable(zval *object, zval *key) {	
+static inline zend_bool pthreads_store_is_immutable(zval *object, zval *key) {
 	pthreads_object_t *threaded = PTHREADS_FETCH_FROM(Z_OBJ_P(object));
 	pthreads_storage *storage;
 
@@ -133,12 +133,18 @@ static inline zend_bool pthreads_store_is_immutable(zval *object, zval *key) {
 
 /* {{{ */
 int pthreads_store_delete(zval *object, zval *key) {
+	return _pthreads_store_delete(object, key, 1);
+}
+
+int _pthreads_store_delete(zval *object, zval *key, int std_obj_sync) {
+	pthreads_object_t *threaded = PTHREADS_FETCH_FROM(Z_OBJ_P(object));
 	int result = FAILURE;
 	zval member, *property = NULL;
-	pthreads_object_t *threaded = PTHREADS_FETCH_FROM(Z_OBJ_P(object));
 	zend_bool coerced = pthreads_store_coerce(threaded->store.props, key, &member);	
 
-	rebuild_object_properties(&threaded->std);
+	if(std_obj_sync) {
+		rebuild_object_properties(&threaded->std);
+	}
 
 	if (pthreads_monitor_lock(threaded->monitor)) {
 		if (!pthreads_store_is_immutable(object, &member)) {
@@ -149,7 +155,7 @@ int pthreads_store_delete(zval *object, zval *key) {
 		pthreads_monitor_unlock(threaded->monitor);
 	} else result = FAILURE;
 	
-	if (result == SUCCESS) {
+	if (std_obj_sync && result == SUCCESS) {
 		if (Z_TYPE(member) == IS_LONG) {
 			zend_hash_index_del(threaded->std.properties, Z_LVAL(member));
 		} else zend_hash_del(threaded->std.properties, Z_STR(member));
@@ -164,9 +170,9 @@ int pthreads_store_delete(zval *object, zval *key) {
 
 /* {{{ */
 zend_bool pthreads_store_isset(zval *object, zval *key, int has_set_exists) {
+	pthreads_object_t *threaded = PTHREADS_FETCH_FROM(Z_OBJ_P(object));
 	zend_bool isset = 0;
 	zval member;
-	pthreads_object_t *threaded = PTHREADS_FETCH_FROM(Z_OBJ_P(object));
 	zend_bool coerced = pthreads_store_coerce(threaded->store.props, key, &member);
 
 	if (pthreads_monitor_lock(threaded->monitor)) {
@@ -230,12 +236,18 @@ zend_bool pthreads_store_isset(zval *object, zval *key, int has_set_exists) {
 
 /* {{{ */
 int pthreads_store_read(zval *object, zval *key, int type, zval *read) {
+	return _pthreads_store_read(object, key, type, read, 1);
+}
+
+int _pthreads_store_read(zval *object, zval *key, int type, zval *read, int std_obj_sync) {
+	pthreads_object_t *threaded = PTHREADS_FETCH_FROM(Z_OBJ_P(object));
 	int result = FAILURE;
 	zval member, *property = NULL;
-	pthreads_object_t *threaded = PTHREADS_FETCH_FROM(Z_OBJ_P(object));
 	zend_bool coerced = pthreads_store_coerce(threaded->store.props, key, &member);
 
-	rebuild_object_properties(&threaded->std);
+	if(std_obj_sync) {
+		rebuild_object_properties(&threaded->std);
+	}
 
 	if (Z_TYPE(member) == IS_LONG) {
 		property = zend_hash_index_find(threaded->std.properties, Z_LVAL(member));
@@ -249,7 +261,7 @@ int pthreads_store_read(zval *object, zval *key, int type, zval *read) {
 				storage = zend_hash_index_find_ptr(threaded->store.props, Z_LVAL(member));
 			} else storage = zend_hash_find_ptr(threaded->store.props, Z_STR(member));
 
-			if (storage && storage->type == IS_PTHREADS) {
+			if (storage && (storage->type == IS_PTHREADS || storage->type == IS_MAP)) {
 				pthreads_object_t* threadedStorage = PTHREADS_FETCH_FROM(storage->data);
 				pthreads_object_t *threadedProperty = PTHREADS_FETCH_FROM(Z_OBJ_P(property));
 
@@ -274,8 +286,10 @@ int pthreads_store_read(zval *object, zval *key, int type, zval *read) {
 	if (pthreads_monitor_lock(threaded->monitor)) {
 		pthreads_storage *storage;
 
-		/* synchronize property stores */
-		pthreads_store_sync(object);
+		if(std_obj_sync) {
+			/* synchronize property stores */
+			pthreads_store_sync(object);
+		}
 
 		if (Z_TYPE(member) == IS_LONG) {
 			storage = zend_hash_index_find_ptr(threaded->store.props, Z_LVAL(member));
@@ -290,7 +304,7 @@ int pthreads_store_read(zval *object, zval *key, int type, zval *read) {
 	if (result != SUCCESS) {
 		ZVAL_NULL(read);
 	} else {
-		if (IS_PTHREADS_OBJECT(read)) {
+		if (std_obj_sync && IS_PTHREADS_OBJECT(read)) {
 			rebuild_object_properties(&threaded->std);
 			if (Z_TYPE(member) == IS_LONG) {
 				zend_hash_index_update(threaded->std.properties, Z_LVAL(member), read);
@@ -307,11 +321,14 @@ int pthreads_store_read(zval *object, zval *key, int type, zval *read) {
 
 /* {{{ */
 int pthreads_store_write(zval *object, zval *key, zval *write) {
+	return _pthreads_store_write(object, key, write, 1);
+}
+
+int _pthreads_store_write(zval *object, zval *key, zval *write, int std_obj_sync) {
+	pthreads_object_t *threaded = PTHREADS_FETCH_FROM(Z_OBJ_P(object));
 	int result = FAILURE;
 	pthreads_storage *storage;
 	zval vol, member, *property = NULL, *read = NULL;
-	pthreads_object_t *threaded = 
-		PTHREADS_FETCH_FROM(Z_OBJ_P(object));
 	zend_bool coerced = 0;
 
 	if (Z_TYPE_P(write) == IS_ARRAY) {
@@ -357,13 +374,13 @@ int pthreads_store_write(zval *object, zval *key, zval *write) {
 	if (result != SUCCESS) {
 		pthreads_store_storage_dtor(storage);
 	} else {
-		if (IS_PTHREADS_OBJECT(write) || IS_PTHREADS_CLOSURE(write)) {
+		if (std_obj_sync && (IS_PTHREADS_OBJECT(write) || IS_PTHREADS_CLOSURE(write))) {
 			/*
 				This could be a volatile object, but, we don't want to break
 				normal refcounting, we'll read the reference only at volatile objects
 			*/
 			rebuild_object_properties(&threaded->std);
-			
+
 			if(IS_PTHREADS_VOLATILE(object)) {
 				pthreads_store_sync(object);
 			}
@@ -378,13 +395,14 @@ int pthreads_store_write(zval *object, zval *key, zval *write) {
 				}
 				zend_string_release(keyed);
 			}
+
 			Z_ADDREF_P(write);
 		}
 	}
-	
+
 	if (coerced)
 		zval_ptr_dtor(&member);
-	
+
 	return result;
 } /* }}} */
 
@@ -648,6 +666,10 @@ pthreads_storage* pthreads_store_create(zval *unstore, zend_bool complex){
 			if (instanceof_function(Z_OBJCE_P(unstore), pthreads_threaded_entry)) {
 				storage->type = IS_PTHREADS;
 				storage->data = Z_OBJ_P(unstore);
+
+				if (instanceof_function(Z_OBJCE_P(unstore), pthreads_volatile_map_entry)) {
+					storage->type = IS_MAP;
+				}
 				break;
 			}
 
@@ -731,6 +753,7 @@ int pthreads_store_convert(pthreads_storage *storage, zval *pzval){
 			efree(name);
 		} break;
 
+		case IS_MAP:
 		case IS_PTHREADS: {
 			pthreads_object_t* threaded = PTHREADS_FETCH_FROM(storage->data);
 
@@ -874,6 +897,90 @@ static int pthreads_store_tozval(zval *pzval, char *pstring, size_t slength) {
 	
 	return result;
 } /* }}} */
+
+/* {{{ */
+/*
+int pthreads_store_unshift(zval *object, zval *args) {
+	pthreads_object_t *threaded = PTHREADS_FETCH_FROM(Z_OBJ_P(object));
+	HashTable new_hash;
+	zval *pzval;
+	pthreads_storage *storage;
+	int i;
+
+	if (Z_TYPE_P(args) != IS_ARRAY &&
+		Z_TYPE_P(args) != IS_OBJECT) {
+		return FAILURE;
+	}
+
+	zend_hash_init(&new_hash, zend_hash_num_elements(threaded->store.props) + argc, NULL, NULL, 0);
+
+	ZEND_HASH_FOREACH_VAL(args, pzval) {
+		storage = pthreads_store_create(pzval, 1);
+		zend_hash_next_index_insert_ptr(&new_hash, storage);
+	}
+	rebuild_object_properties(&threaded->std);
+
+	if (pthreads_monitor_lock(threaded->monitor)) {
+		zend_string *key = NULL;
+		pthreads_storage *storage;
+
+		pthreads_store_sync(object);
+
+		ZEND_HASH_FOREACH_STR_KEY_PTR(threaded->store.props, key, storage) {
+			if (key) {
+				zend_hash_add_new_ptr(&new_hash, key, storage);
+			} else {
+				zend_hash_next_index_insert_ptr(&new_hash, storage);
+			}
+		} ZEND_HASH_FOREACH_END();
+
+		zend_hash_copy(threaded->store.props, &new_hash, NULL);
+
+		zend_hash_destroy(&new_hash);
+
+		pthreads_monitor_unlock(threaded->monitor);
+
+		return SUCCESS;
+	}
+	return FAILURE;
+}  }}} */
+
+/* {{{ */
+/*
+int pthreads_store_clear(zval *object) {
+	pthreads_object_t* threaded = PTHREADS_FETCH_FROM(Z_OBJ_P(object));
+
+	rebuild_object_properties(&threaded->std);
+
+	if (pthreads_monitor_lock(threaded->monitor)) {
+		HashPosition position;
+		pthreads_storage *storage;
+
+		zend_hash_internal_pointer_reset_ex(threaded->store.props, &position);
+		while(storage = zend_hash_get_current_data_ptr_ex(threaded->store.props, &position)) {
+			zval key;
+
+			zend_hash_get_current_key_zval_ex(threaded->store.props, &key, &position);
+
+			if (!pthreads_store_is_immutable(object, &key)) {
+				if (Z_TYPE(key) == IS_LONG) {
+					zend_hash_index_del(threaded->store.props, Z_LVAL(key));
+					zend_hash_index_del(threaded->std.properties, Z_LVAL(key));
+				} else {
+					zend_hash_del(threaded->store.props, Z_STR(key));
+					zend_hash_del(threaded->std.properties, Z_STR(key));
+				}
+			};
+
+			zend_hash_move_forward_ex(threaded->store.props, &position);
+		}
+		pthreads_monitor_unlock(threaded->monitor);
+
+		return SUCCESS;
+	}
+
+    return FAILURE;
+}  }}} */
 
 /* {{{ */
 int pthreads_store_merge(zval *destination, zval *from, zend_bool overwrite) {

--- a/src/store.h
+++ b/src/store.h
@@ -24,27 +24,17 @@
 
 #define IS_CLOSURE  (IS_PTR + 1)
 #define IS_PTHREADS (IS_PTR + 2)
-
-typedef HashTable pthreads_store_t;
-
-typedef struct _pthreads_storage {
-	zend_uchar 	type;
-	size_t 	length;
-	zend_bool 	exists;
-	union {
-		zend_long   lval;
-		double     dval;
-	} simple;
-	void    	*data;
-} pthreads_storage;
+#define IS_MAP      (IS_PTR + 3)
 
 pthreads_store_t* pthreads_store_alloc();
 void pthreads_store_sync(zval *object);
 int pthreads_store_merge(zval *destination, zval *from, zend_bool overwrite);
 int pthreads_store_delete(zval *object, zval *key);
+int _pthreads_store_delete(zval *object, zval *key, int std_obj_sync);
 int pthreads_store_read(zval *object, zval *key, int type, zval *read);
 zend_bool pthreads_store_isset(zval *object, zval *key, int has_set_exists);
 int pthreads_store_write(zval *object, zval *key, zval *write);
+int _pthreads_store_write(zval *object, zval *key, zval *write, int std_obj_sync);
 int pthreads_store_separate(zval *pzval, zval *seperated, zend_bool complex);
 void pthreads_store_separate_zval(zval *pzval);
 void pthreads_store_tohash(zval *object, HashTable *hash);
@@ -53,6 +43,8 @@ int pthreads_store_chunk(zval *object, zend_long size, zend_bool preserve, zval 
 int pthreads_store_pop(zval *object, zval *member);
 int pthreads_store_count(zval *object, zend_long *count);
 void pthreads_store_free(pthreads_store_t *store);
+//int pthreads_store_unshift(zval *object, zval *args);
+//int pthreads_store_clear(zval *object);
 
 /* {{{ * iteration helpers */
 void pthreads_store_reset(zval *object, HashPosition *position);

--- a/src/streams.c
+++ b/src/streams.c
@@ -1,0 +1,2059 @@
+/*
+  +----------------------------------------------------------------------+
+  | pthreads                                                             |
+  +----------------------------------------------------------------------+
+  | Copyright (c) Joe Watkins 2018                                       |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | http://www.php.net/license/3_01.txt                                  |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors: Bastian Schneider <b.schneider@badnoob.com>                 |
+  | Borrowed code from php-src                                           |
+  +----------------------------------------------------------------------+
+ */
+#ifndef HAVE_PTHREADS_STREAMS
+#define HAVE_PTHREADS_STREAMS
+
+#ifndef HAVE_PTHREADS_H
+#	include <src/pthreads.h>
+#endif
+
+#ifndef HAVE_PTHREADS_STREAM_H
+#	include <src/streams.h>
+#endif
+
+#ifndef HAVE_PTHREADS_HASH_H
+#	include <src/hash.h>
+#endif
+
+#ifndef HAVE_PTHREADS_STREAMS_INTERNAL_H
+#	include <src/streams/internal.h>
+#endif
+
+#ifndef HAVE_PTHREADS_STREAMS_WRAPPERS_FOPEN_WRAPPER_H
+#	include <src/streams/wrappers/fopen_wrapper.h>
+#endif
+
+#ifndef HAVE_PTHREADS_STREAMS_MEMORY_H
+#	include <src/streams/memory.h>
+#endif
+
+#ifndef HAVE_PTHREADS_OBJECT_H
+#	include <src/object.h>
+#endif
+
+#ifndef HAVE_PTHREADS_NETWORK_H
+#	include <src/network.h>
+#endif
+
+#ifndef FLOCK_COMPAT_H
+#	include <ext/standard/flock_compat.h>
+#endif
+
+pthreads_streams_t* pthreads_streams_alloc(void) {
+	return (pthreads_streams_t*) ecalloc(1, sizeof(pthreads_streams_t));
+}
+
+void pthreads_streams_free(pthreads_streams_t *streams) {
+	efree(streams);
+}
+
+int pthreads_streams_aquire_double_lock(pthreads_object_t *object_one, pthreads_object_t *object_two) {
+	if(!object_one) {
+		return 0;
+	}
+
+	while(1) {
+		if(pthreads_monitor_trylock(object_one->monitor)) {
+			if(object_two) {
+				if(!pthreads_monitor_trylock(object_two->monitor)) {
+					pthreads_monitor_unlock(object_one->monitor);
+
+					continue;
+				}
+			}
+			return 1;
+		}
+	}
+}
+
+void pthreads_streams_release_double_lock(pthreads_object_t *object_one, pthreads_object_t *object_two) {
+	if(object_one) {
+		pthreads_monitor_unlock(object_one->monitor);
+	}
+
+	if(object_two) {
+		pthreads_monitor_unlock(object_two->monitor);
+	}
+}
+
+pthreads_stream_t *pthreads_stream_set_parent(pthreads_stream_t *threaded_target, pthreads_stream_t *threaded_parent) {
+	pthreads_stream_t *orig = NULL;
+
+	if(stream_lock(threaded_target)) {
+		orig = pthreads_get_parent_stream(threaded_target);
+		pthreads_set_parent_stream(threaded_target, threaded_parent);
+		stream_unlock(threaded_target);
+	}
+	return orig;
+}
+
+void pthreads_init_streams() {
+	INIT_GLOBAL_WRAPPER(stream_php_wrapper		, pthreads_stdio_wops				, NULL, 0);
+	INIT_GLOBAL_WRAPPER(stream_rfc2397_wrapper	, pthreads_stream_rfc2397_wops		, NULL, 1);
+	INIT_GLOBAL_WRAPPER(plain_files_wrapper		, pthreads_plain_files_wrapper_ops	, NULL, 0);
+	INIT_GLOBAL_WRAPPER(glob_stream_wrapper		, pthreads_glob_stream_wrapper_ops	, NULL, 0);
+	INIT_GLOBAL_WRAPPER(stream_http_wrapper		, pthreads_http_stream_wops			, NULL, 1);
+	INIT_GLOBAL_WRAPPER(stream_ftp_wrapper		, pthreads_ftp_stream_wops			, NULL, 1);
+
+	pthreads_init_stream_filters();
+	pthreads_init_stream_wrappers();
+	pthreads_init_stream_transports();
+
+	zend_declare_class_constant_long(pthreads_streams_entry, ZEND_STRL("STREAM_NOTIFY_CONNECT")			, PTHREADS_STREAM_NOTIFY_CONNECT);
+	zend_declare_class_constant_long(pthreads_streams_entry, ZEND_STRL("STREAM_NOTIFY_AUTH_REQUIRED")	, PTHREADS_STREAM_NOTIFY_AUTH_REQUIRED);
+	zend_declare_class_constant_long(pthreads_streams_entry, ZEND_STRL("STREAM_NOTIFY_AUTH_RESULT")		, PTHREADS_STREAM_NOTIFY_AUTH_RESULT);
+	zend_declare_class_constant_long(pthreads_streams_entry, ZEND_STRL("STREAM_NOTIFY_MIME_TYPE_IS")	, PTHREADS_STREAM_NOTIFY_MIME_TYPE_IS);
+	zend_declare_class_constant_long(pthreads_streams_entry, ZEND_STRL("STREAM_NOTIFY_FILE_SIZE_IS")	, PTHREADS_STREAM_NOTIFY_FILE_SIZE_IS);
+	zend_declare_class_constant_long(pthreads_streams_entry, ZEND_STRL("STREAM_NOTIFY_REDIRECTED")		, PTHREADS_STREAM_NOTIFY_REDIRECTED);
+	zend_declare_class_constant_long(pthreads_streams_entry, ZEND_STRL("STREAM_NOTIFY_PROGRESS")		, PTHREADS_STREAM_NOTIFY_PROGRESS);
+	zend_declare_class_constant_long(pthreads_streams_entry, ZEND_STRL("STREAM_NOTIFY_FAILURE")			, PTHREADS_STREAM_NOTIFY_FAILURE);
+	zend_declare_class_constant_long(pthreads_streams_entry, ZEND_STRL("STREAM_NOTIFY_COMPLETED")		, PTHREADS_STREAM_NOTIFY_COMPLETED);
+	zend_declare_class_constant_long(pthreads_streams_entry, ZEND_STRL("STREAM_NOTIFY_RESOLVE")			, PTHREADS_STREAM_NOTIFY_RESOLVE);
+
+	zend_declare_class_constant_long(pthreads_streams_entry, ZEND_STRL("STREAM_NOTIFY_SEVERITY_INFO")	, PTHREADS_STREAM_NOTIFY_SEVERITY_INFO);
+	zend_declare_class_constant_long(pthreads_streams_entry, ZEND_STRL("STREAM_NOTIFY_SEVERITY_WARN")	, PTHREADS_STREAM_NOTIFY_SEVERITY_WARN);
+	zend_declare_class_constant_long(pthreads_streams_entry, ZEND_STRL("STREAM_NOTIFY_SEVERITY_ERR")	, PTHREADS_STREAM_NOTIFY_SEVERITY_ERR);
+
+	zend_declare_class_constant_long(pthreads_streams_entry, ZEND_STRL("STREAM_FILTER_READ")			, PTHREADS_STREAM_FILTER_READ);
+	zend_declare_class_constant_long(pthreads_streams_entry, ZEND_STRL("STREAM_FILTER_WRITE")			, PTHREADS_STREAM_FILTER_WRITE);
+	zend_declare_class_constant_long(pthreads_streams_entry, ZEND_STRL("STREAM_FILTER_ALL")				, PTHREADS_STREAM_FILTER_ALL);
+
+	zend_declare_class_constant_long(pthreads_streams_entry, ZEND_STRL("STREAM_CLIENT_ASYNC_CONNECT")	, PTHREADS_STREAM_CLIENT_ASYNC_CONNECT);
+	zend_declare_class_constant_long(pthreads_streams_entry, ZEND_STRL("STREAM_CLIENT_CONNECT")			, PTHREADS_STREAM_CLIENT_CONNECT);
+
+	zend_declare_class_constant_long(pthreads_streams_entry, ZEND_STRL("STREAM_CRYPTO_METHOD_ANY_CLIENT")		, PTHREADS_STREAM_CRYPTO_METHOD_ANY_CLIENT);
+	zend_declare_class_constant_long(pthreads_streams_entry, ZEND_STRL("STREAM_CRYPTO_METHOD_SSLv2_CLIENT")		, PTHREADS_STREAM_CRYPTO_METHOD_SSLv2_CLIENT);
+	zend_declare_class_constant_long(pthreads_streams_entry, ZEND_STRL("STREAM_CRYPTO_METHOD_SSLv3_CLIENT")		, PTHREADS_STREAM_CRYPTO_METHOD_SSLv3_CLIENT);
+	zend_declare_class_constant_long(pthreads_streams_entry, ZEND_STRL("STREAM_CRYPTO_METHOD_SSLv23_CLIENT")	, PTHREADS_STREAM_CRYPTO_METHOD_SSLv23_CLIENT);
+	zend_declare_class_constant_long(pthreads_streams_entry, ZEND_STRL("STREAM_CRYPTO_METHOD_TLS_CLIENT")		, PTHREADS_STREAM_CRYPTO_METHOD_TLS_CLIENT);
+	zend_declare_class_constant_long(pthreads_streams_entry, ZEND_STRL("STREAM_CRYPTO_METHOD_TLSv1_0_CLIENT")	, PTHREADS_STREAM_CRYPTO_METHOD_TLSv1_0_CLIENT);
+	zend_declare_class_constant_long(pthreads_streams_entry, ZEND_STRL("STREAM_CRYPTO_METHOD_TLSv1_1_CLIENT")	, PTHREADS_STREAM_CRYPTO_METHOD_TLSv1_1_CLIENT);
+	zend_declare_class_constant_long(pthreads_streams_entry, ZEND_STRL("STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT")	, PTHREADS_STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT);
+	zend_declare_class_constant_long(pthreads_streams_entry, ZEND_STRL("STREAM_CRYPTO_METHOD_ANY_SERVER")		, PTHREADS_STREAM_CRYPTO_METHOD_ANY_SERVER);
+	zend_declare_class_constant_long(pthreads_streams_entry, ZEND_STRL("STREAM_CRYPTO_METHOD_SSLv2_SERVER")		, PTHREADS_STREAM_CRYPTO_METHOD_SSLv2_SERVER);
+	zend_declare_class_constant_long(pthreads_streams_entry, ZEND_STRL("STREAM_CRYPTO_METHOD_SSLv3_SERVER")		, PTHREADS_STREAM_CRYPTO_METHOD_SSLv3_SERVER);
+	zend_declare_class_constant_long(pthreads_streams_entry, ZEND_STRL("STREAM_CRYPTO_METHOD_SSLv23_SERVER")	, PTHREADS_STREAM_CRYPTO_METHOD_SSLv23_SERVER);
+	zend_declare_class_constant_long(pthreads_streams_entry, ZEND_STRL("STREAM_CRYPTO_METHOD_TLS_SERVER")		, PTHREADS_STREAM_CRYPTO_METHOD_TLS_SERVER);
+	zend_declare_class_constant_long(pthreads_streams_entry, ZEND_STRL("STREAM_CRYPTO_METHOD_TLSv1_0_SERVER")	, PTHREADS_STREAM_CRYPTO_METHOD_TLSv1_0_SERVER);
+	zend_declare_class_constant_long(pthreads_streams_entry, ZEND_STRL("STREAM_CRYPTO_METHOD_TLSv1_1_SERVER")	, PTHREADS_STREAM_CRYPTO_METHOD_TLSv1_1_SERVER);
+	zend_declare_class_constant_long(pthreads_streams_entry, ZEND_STRL("STREAM_CRYPTO_METHOD_TLSv1_2_SERVER")	, PTHREADS_STREAM_CRYPTO_METHOD_TLSv1_2_SERVER);
+
+	zend_declare_class_constant_long(pthreads_streams_entry, ZEND_STRL("STREAM_CRYPTO_PROTO_SSLv3")				, PTHREADS_STREAM_CRYPTO_METHOD_SSLv3_SERVER);
+	zend_declare_class_constant_long(pthreads_streams_entry, ZEND_STRL("STREAM_CRYPTO_PROTO_TLSv1_0")			, PTHREADS_STREAM_CRYPTO_METHOD_TLSv1_0_SERVER);
+	zend_declare_class_constant_long(pthreads_streams_entry, ZEND_STRL("STREAM_CRYPTO_PROTO_TLSv1_1")			, PTHREADS_STREAM_CRYPTO_METHOD_TLSv1_1_SERVER);
+	zend_declare_class_constant_long(pthreads_streams_entry, ZEND_STRL("STREAM_CRYPTO_PROTO_TLSv1_2")			, PTHREADS_STREAM_CRYPTO_METHOD_TLSv1_2_SERVER);
+
+	zend_declare_class_constant_long(pthreads_streams_entry, ZEND_STRL("STREAM_SHUT_RD")	, PTHREADS_STREAM_SHUT_RD);
+	zend_declare_class_constant_long(pthreads_streams_entry, ZEND_STRL("STREAM_SHUT_WR")	, PTHREADS_STREAM_SHUT_WR);
+	zend_declare_class_constant_long(pthreads_streams_entry, ZEND_STRL("STREAM_SHUT_RDWR")	, PTHREADS_STREAM_SHUT_RDWR);
+
+#ifdef PF_INET
+	zend_declare_class_constant_long(pthreads_streams_entry, ZEND_STRL("STREAM_PF_INET"), PF_INET);
+#elif defined(AF_INET)
+	zend_declare_class_constant_long(pthreads_streams_entry, ZEND_STRL("STREAM_PF_INET"), AF_INET);
+#endif
+
+#if HAVE_IPV6
+# ifdef PF_INET6
+	zend_declare_class_constant_long(pthreads_streams_entry, ZEND_STRL("STREAM_PF_INET6"), PF_INET6);
+# elif defined(AF_INET6)
+	zend_declare_class_constant_long(pthreads_streams_entry, ZEND_STRL("STREAM_PF_INET6"), AF_INET6);
+# endif
+#endif
+
+#ifdef PF_UNIX
+	zend_declare_class_constant_long(pthreads_streams_entry, ZEND_STRL("STREAM_PF_UNIX"), PF_UNIX);
+#elif defined(AF_UNIX)
+	zend_declare_class_constant_long(pthreads_streams_entry, ZEND_STRL("STREAM_PF_UNIX"), AF_UNIX);
+#endif
+
+#ifdef IPPROTO_IP
+	/* most people will use this one when calling socket() or socketpair() */
+	zend_declare_class_constant_long(pthreads_streams_entry, ZEND_STRL("STREAM_IPPROTO_IP"), IPPROTO_IP);
+#endif
+
+#if defined(IPPROTO_TCP) || defined(PHP_WIN32)
+	zend_declare_class_constant_long(pthreads_streams_entry, ZEND_STRL("STREAM_IPPROTO_TCP"), IPPROTO_TCP);
+#endif
+
+#if defined(IPPROTO_UDP) || defined(PHP_WIN32)
+	zend_declare_class_constant_long(pthreads_streams_entry, ZEND_STRL("STREAM_IPPROTO_UDP"), IPPROTO_UDP);
+#endif
+
+#if defined(IPPROTO_ICMP) || defined(PHP_WIN32)
+	zend_declare_class_constant_long(pthreads_streams_entry, ZEND_STRL("STREAM_IPPROTO_ICMP"), IPPROTO_ICMP);
+#endif
+
+#if defined(IPPROTO_RAW) || defined(PHP_WIN32)
+	zend_declare_class_constant_long(pthreads_streams_entry, ZEND_STRL("STREAM_IPPROTO_RAW"), IPPROTO_RAW);
+#endif
+
+	zend_declare_class_constant_long(pthreads_streams_entry, ZEND_STRL("STREAM_SOCK_STREAM"), SOCK_STREAM);
+	zend_declare_class_constant_long(pthreads_streams_entry, ZEND_STRL("STREAM_SOCK_DGRAM"), SOCK_DGRAM);
+
+#ifdef SOCK_RAW
+	zend_declare_class_constant_long(pthreads_streams_entry, ZEND_STRL("STREAM_SOCK_RAW"), SOCK_RAW);
+#endif
+
+#ifdef SOCK_SEQPACKET
+	zend_declare_class_constant_long(pthreads_streams_entry, ZEND_STRL("STREAM_SOCK_SEQPACKET"), SOCK_SEQPACKET);
+#endif
+
+#ifdef SOCK_RDM
+	zend_declare_class_constant_long(pthreads_streams_entry, ZEND_STRL("STREAM_SOCK_RDM"), SOCK_RDM);
+#endif
+
+	zend_declare_class_constant_long(pthreads_streams_entry, ZEND_STRL("STREAM_PEEK"), PTHREADS_STREAM_PEEK);
+	zend_declare_class_constant_long(pthreads_streams_entry, ZEND_STRL("STREAM_OOB"), PTHREADS_STREAM_OOB);
+
+	zend_declare_class_constant_long(pthreads_streams_entry, ZEND_STRL("STREAM_SERVER_BIND"), PTHREADS_STREAM_XPORT_BIND);
+	zend_declare_class_constant_long(pthreads_streams_entry, ZEND_STRL("STREAM_SERVER_LISTEN"), PTHREADS_STREAM_XPORT_LISTEN);
+}
+
+void pthreads_shutdown_streams() {
+	pthreads_shutdown_stream_wrappers();
+	pthreads_shutdown_stream_filters();
+}
+
+zend_bool stream_lock(pthreads_stream_t *threaded_stream) {
+	pthreads_stream *stream = PTHREADS_FETCH_STREAMS_STREAM(threaded_stream);
+	int locked;
+
+	if(!stream) {
+		PTHREADS_STREAM_CORRUPTED();
+	}
+	PTHREADS_STREAM_PRE_CHECK(stream);
+	//printf("stream_lock requested (%i) \n", (ulong) pthread_self());
+	locked = MONITOR_LOCK(threaded_stream);
+
+	//printf("gathered stream_lock (%i) \n", (ulong) pthread_self());
+	if(locked) {
+		PTHREADS_STREAM_POST_CHECK(threaded_stream, stream);
+	}
+	return locked;
+}
+
+pthreads_stream_t *_pthreads_stream_new(const pthreads_stream_ops *ops, void *abstract, const char *mode, zend_class_entry *stream_ce) {
+	pthreads_stream_t *threaded_stream = NULL;
+	pthreads_stream *stream = NULL;
+	pthreads_hashtable *streams_list;
+	zend_string *str;
+
+	if(stream_ce == NULL) {
+		stream_ce = pthreads_stream_entry;
+	}
+
+	if(!instanceof_function(stream_ce, pthreads_stream_entry)) {
+		php_error_docref(NULL, E_WARNING, "Class \"%s\" must be an instance of Stream", ZSTR_VAL(stream_ce->name));
+		return NULL;
+	}
+	threaded_stream = pthreads_object_init(stream_ce);
+	stream = pthreads_stream_alloc(ops, abstract, mode);
+
+	pthreads_stream_set_readfilters(threaded_stream, pthreads_object_init(pthreads_volatile_map_entry));
+	pthreads_stream_set_writefilters(threaded_stream, pthreads_object_init(pthreads_volatile_map_entry));
+
+	pthreads_chain_set_stream(pthreads_stream_get_readfilters(threaded_stream), threaded_stream);
+
+	/* Unwanted addref by pthreads_chain_set_stream */
+	pthreads_ptr_dtor(threaded_stream);
+
+	pthreads_chain_set_stream(pthreads_stream_get_writefilters(threaded_stream), threaded_stream);
+
+	/* Unwanted addref by pthreads_chain_set_stream */
+	pthreads_ptr_dtor(threaded_stream);
+
+	PTHREADS_FETCH_STREAMS_STREAM(threaded_stream) = stream;
+
+	pthreads_set_parent_stream(threaded_stream, NULL);
+	pthreads_stream_set_context(threaded_stream, NULL);
+
+	return threaded_stream;
+}
+
+pthreads_stream_filter_t *pthreads_stream_filter_new(const pthreads_stream_filter_ops *fops, void *abstract) {
+	pthreads_object_t *threaded_filter = pthreads_stream_filter_init();
+	PTHREADS_FETCH_STREAMS_FILTER(threaded_filter) = pthreads_stream_filter_alloc(fops, abstract);
+
+	return threaded_filter;
+}
+
+pthreads_stream_filter_t *pthreads_stream_filter_init() {
+	return pthreads_object_init(pthreads_stream_filter_entry);
+}
+
+pthreads_stream_bucket_t *pthreads_stream_bucket_new(char *buf, size_t buflen) {
+	pthreads_object_t *threaded_bucket = pthreads_stream_bucket_init();
+	PTHREADS_FETCH_STREAMS_BUCKET(threaded_bucket) = pthreads_stream_bucket_alloc(buf, buflen);
+
+	return threaded_bucket;
+}
+
+pthreads_stream_bucket_t *pthreads_stream_bucket_init() {
+	return pthreads_object_init(pthreads_stream_bucket_entry);
+}
+
+pthreads_stream_bucket_brigade_t *pthreads_stream_bucket_brigade_new() {
+	return pthreads_object_init(pthreads_stream_brigade_entry);
+}
+
+pthreads_stream_wrapper_t *pthreads_stream_wrapper_new() {
+	return pthreads_object_init(pthreads_stream_wrapper_entry);
+}
+
+pthreads_stream_context_t *pthreads_stream_context_new() {
+	return pthreads_object_init(pthreads_stream_context_entry);
+}
+
+int pthreads_stream_has_threaded_property(pthreads_object_t *threaded, int property) {
+	return pthreads_stream_read_threaded_property(threaded, property) == NULL ? 0 : 1;
+}
+
+int pthreads_stream_count_threaded_properties(pthreads_object_t *threaded) {
+	zval obj;
+	zend_long count;
+	ZVAL_OBJ(&obj, PTHREADS_STD_P(threaded));
+
+	pthreads_store_count(&obj, &count);
+
+	return count;
+}
+
+pthreads_object_t *pthreads_stream_read_threaded_property(pthreads_object_t *threaded, int property) {
+	pthreads_object_t * result = NULL;
+	zval key, read, obj;
+
+	ZVAL_NULL(&read);
+	ZVAL_LONG(&key, property);
+	ZVAL_OBJ(&obj, PTHREADS_STD_P(threaded));
+
+	if(_pthreads_store_read(&obj, &key, 0, &read, !(EG(flags) & EG_FLAGS_IN_SHUTDOWN)) == SUCCESS && !ZVAL_IS_NULL(&read)) {
+		result = PTHREADS_FETCH_FROM(Z_OBJ(read));
+
+		if(IS_PTHREADS_OBJECT(&read)) {
+			zval_ptr_dtor(&read);
+		}
+	}
+	return result;
+}
+
+int pthreads_stream_write_threaded_property(pthreads_object_t *threaded, int property, pthreads_object_t *val) {
+	zval key, write, obj;
+
+	if(val == NULL) {
+		return pthreads_stream_delete_threaded_property(threaded, property);
+	}
+	ZVAL_LONG(&key, property);
+	ZVAL_OBJ(&write, PTHREADS_STD_P(val));
+	ZVAL_OBJ(&obj, PTHREADS_STD_P(threaded));
+
+	return _pthreads_store_write(&obj, &key, &write, !(EG(flags) & EG_FLAGS_IN_SHUTDOWN));
+}
+
+int pthreads_stream_delete_threaded_property(pthreads_object_t *threaded, int property) {
+	zval key, obj;
+	ZVAL_LONG(&key, property);
+	ZVAL_OBJ(&obj, PTHREADS_STD_P(threaded));
+
+	return _pthreads_store_delete(&obj, &key, !(EG(flags) & EG_FLAGS_IN_SHUTDOWN));
+}
+
+/* {{{ context API */
+
+void pthreads_stream_notification_notify(pthreads_stream_context_t *threaded_context, int notifycode, int severity,
+		char *xmsg, int xcode, size_t bytes_sofar, size_t bytes_max, void * ptr)
+{
+	pthreads_stream_context *context = PTHREADS_FETCH_STREAMS_CONTEXT(threaded_context);
+
+	if(MONITOR_LOCK(threaded_context)) {
+		if (context && context->notifier) {
+			context->notifier->func(context, notifycode, severity, xmsg, xcode, bytes_sofar, bytes_max, ptr);
+		}
+		MONITOR_UNLOCK(threaded_context);
+	}
+}
+
+pthreads_stream_context *pthreads_stream_context_alloc(void)
+{
+	pthreads_stream_context *context;
+
+	context = calloc(1, sizeof(pthreads_stream_context));
+	context->notifier = NULL;
+	context->options = pthreads_object_init(pthreads_volatile_map_entry);
+
+	return context;
+}
+
+void pthreads_stream_context_free(pthreads_stream_context *context) {
+	if (context->options != NULL) {
+		zval options;
+		ZVAL_OBJ(&options, PTHREADS_STD_P(context->options));
+		zval_ptr_dtor(&options);
+		context->options = NULL;
+	}
+	if (context->notifier) {
+		pthreads_stream_notification_free(context->notifier);
+		context->notifier = NULL;
+	}
+	free(context);
+}
+
+pthreads_stream_notifier *pthreads_stream_notification_alloc(void) {
+	return calloc(1, sizeof(pthreads_stream_notifier));
+}
+
+void pthreads_stream_notification_free(pthreads_stream_notifier *notifier) {
+	if (notifier->dtor) {
+		notifier->dtor(notifier);
+	}
+	free(notifier);
+}
+
+pthreads_stream_context_t *pthreads_stream_context_set(pthreads_stream_t *threaded_stream, pthreads_stream_context_t *threaded_context) {
+	pthreads_stream *stream = PTHREADS_FETCH_STREAMS_STREAM(threaded_stream);
+	pthreads_stream_context_t *oldcontext = pthreads_stream_get_context(threaded_stream);
+
+	pthreads_stream_set_context(threaded_stream, threaded_context);
+
+	if (oldcontext) {
+		zval ctx;
+		ZVAL_OBJ(&ctx, PTHREADS_STD_P(oldcontext));
+		Z_DELREF(ctx);
+	}
+
+	return oldcontext;
+}
+
+zval *pthreads_stream_context_get_option(pthreads_stream_context_t *threaded_context, const char *wrappername, const char *optionname) {
+	pthreads_stream_context *context = PTHREADS_FETCH_STREAMS_CONTEXT(threaded_context);
+	pthreads_object_t *threaded_options = NULL;
+	zval *wrapperhash, *result;
+	zval rv, ret, options;
+
+	ZVAL_NULL(&rv);
+	ZVAL_NULL(&ret);
+
+	if (MONITOR_LOCK(threaded_context)) {
+		threaded_options = context->options;
+		ZVAL_OBJ(&options, PTHREADS_STD_P(threaded_options));
+
+		wrapperhash = zend_read_property(pthreads_volatile_entry, &options, wrappername, strlen(wrappername), 1, &rv);
+
+		if (NULL == wrapperhash || Z_ISNULL_P(wrapperhash)) {
+			result = NULL;
+		} else {
+			result = zend_read_property(pthreads_volatile_entry, wrapperhash, optionname, strlen(optionname), 1, &ret);
+
+			if (NULL != result && Z_ISNULL_P(result)) {
+				result = NULL;
+			}
+		}
+		MONITOR_UNLOCK(threaded_context);
+	}
+	return result;
+}
+
+int pthreads_stream_context_set_option(pthreads_stream_context_t *threaded_context, const char *wrappername, const char *optionname, zval *optionvalue) {
+	pthreads_stream_context *context = PTHREADS_FETCH_STREAMS_CONTEXT(threaded_context);
+	pthreads_object_t *threaded_options = NULL;
+	zval *wrapperhash, *category;
+	zval rv, options;
+
+	ZVAL_NULL(&rv);
+
+	if (MONITOR_LOCK(threaded_context)) {
+		threaded_options = context->options;
+		ZVAL_OBJ(&options, PTHREADS_STD_P(threaded_options));
+
+		wrapperhash = zend_read_property(pthreads_volatile_map_entry, &options, wrappername, strlen(wrappername), 1, &rv);
+
+		if (NULL == wrapperhash || Z_ISNULL_P(wrapperhash)) {
+			ZVAL_OBJ(wrapperhash, PTHREADS_STD_P(pthreads_object_init(pthreads_volatile_map_entry)));
+			zend_update_property(pthreads_volatile_map_entry, &options, (char*)wrappername, strlen(wrappername), wrapperhash);
+		}
+		ZVAL_DEREF(optionvalue);
+		Z_TRY_ADDREF_P(optionvalue);
+		zend_update_property(pthreads_volatile_map_entry, wrapperhash, optionname, strlen(optionname), optionvalue);
+
+		MONITOR_UNLOCK(threaded_context);
+	}
+	return SUCCESS;
+}
+
+void pthreads_stream_notify_info(pthreads_stream_context_t *threaded_context, int code, char *xmsg, int xcode) {
+	pthreads_stream_context *context;
+
+	if(!threaded_context) {
+		return;
+	}
+	context = PTHREADS_FETCH_STREAMS_CONTEXT(threaded_context);
+
+	if(MONITOR_LOCK(threaded_context)) {
+		if (context && context->notifier) {
+			pthreads_stream_notification_notify(threaded_context, code, PTHREADS_STREAM_NOTIFY_SEVERITY_INFO, xmsg, xcode, 0, 0, NULL);
+		}
+		MONITOR_UNLOCK(threaded_context);
+	}
+}
+
+void pthreads_stream_notify_progress(pthreads_stream_context_t *threaded_context, size_t bsofar, size_t bmax) {
+	pthreads_stream_context *context;
+
+	if(!threaded_context) {
+		return;
+	}
+	context = PTHREADS_FETCH_STREAMS_CONTEXT(threaded_context);
+
+	if(MONITOR_LOCK(threaded_context)) {
+		if (context && context->notifier) {
+			pthreads_stream_notification_notify(threaded_context, PTHREADS_STREAM_NOTIFY_PROGRESS, PTHREADS_STREAM_NOTIFY_SEVERITY_INFO, NULL, 0, bsofar, bmax, NULL);
+		}
+		MONITOR_UNLOCK(threaded_context);
+	}
+}
+
+void pthreads_stream_notify_progress_init(pthreads_stream_context_t *threaded_context, size_t sofar, size_t bmax) {
+	pthreads_stream_context *context;
+
+	if(!threaded_context) {
+		return;
+	}
+	context = PTHREADS_FETCH_STREAMS_CONTEXT(threaded_context);
+
+	if(MONITOR_LOCK(threaded_context)) {
+		if (context && context->notifier) {
+			context->notifier->progress = sofar;
+			context->notifier->progress_max = bmax;
+			context->notifier->mask |= PTHREADS_STREAM_NOTIFIER_PROGRESS;
+
+			pthreads_stream_notify_progress(threaded_context, sofar, bmax);
+		}
+		MONITOR_UNLOCK(threaded_context);
+	}
+}
+
+void pthreads_stream_notify_progress_increment(pthreads_stream_context_t *threaded_context, size_t sofar, size_t max) {
+	pthreads_stream_context *context;
+
+	if(!threaded_context) {
+		return;
+	}
+	context = PTHREADS_FETCH_STREAMS_CONTEXT(threaded_context);
+
+	if(MONITOR_LOCK(threaded_context)) {
+		if (context && context->notifier && context->notifier->mask & PTHREADS_STREAM_NOTIFIER_PROGRESS) {
+			context->notifier->progress += sofar;
+			context->notifier->progress_max += max;
+
+			pthreads_stream_notify_progress(threaded_context, context->notifier->progress, context->notifier->progress_max);
+		}
+		MONITOR_UNLOCK(threaded_context);
+	}
+}
+
+void pthreads_stream_notify_file_size(pthreads_stream_context_t *threaded_context, size_t file_size, char *xmsg, int xcode) {
+	pthreads_stream_context *context;
+
+	if(!threaded_context) {
+		return;
+	}
+	context = PTHREADS_FETCH_STREAMS_CONTEXT(threaded_context);
+
+	if(MONITOR_LOCK(threaded_context)) {
+		if (context && context->notifier) {
+			pthreads_stream_notification_notify(threaded_context, PTHREADS_STREAM_NOTIFY_FILE_SIZE_IS, PTHREADS_STREAM_NOTIFY_SEVERITY_INFO, xmsg, xcode, 0, file_size, NULL);
+		}
+		MONITOR_UNLOCK(threaded_context);
+	}
+}
+
+void pthreads_stream_notify_error(pthreads_stream_context_t *threaded_context, int code, char *xmsg, int xcode) {
+	pthreads_stream_context *context;
+
+	if(!threaded_context) {
+		return;
+	}
+	context = PTHREADS_FETCH_STREAMS_CONTEXT(threaded_context);
+
+	if(MONITOR_LOCK(threaded_context)) {
+		if (context && context->notifier) {
+			pthreads_stream_notification_notify(threaded_context, code, PTHREADS_STREAM_NOTIFY_SEVERITY_ERR, xmsg, xcode, 0, 0, NULL);
+		}
+		MONITOR_UNLOCK(threaded_context);
+	}
+}
+/* }}} */
+
+/* {{{ allocate a new stream for a particular ops */
+pthreads_stream *_pthreads_stream_alloc(const pthreads_stream_ops *ops, void *abstract, const char *mode)
+{
+	pthreads_stream *ret = (pthreads_stream*) pemalloc(sizeof(pthreads_stream), 1);
+
+	memset(ret, 0, sizeof(pthreads_stream));
+
+#if STREAM_DEBUG
+fprintf(stderr, "stream_alloc: %s:%p\n", ops->label, ret);
+#endif
+
+	ret->state = PTHREADS_STREAM_STATE_OPEN;
+	ret->ops = ops;
+	ret->abstract = abstract;
+	ret->chunk_size = FG(def_chunk_size);
+
+	if (FG(auto_detect_line_endings)) {
+		ret->flags |= PTHREADS_STREAM_FLAG_DETECT_EOL;
+	}
+
+	strlcpy(ret->mode, mode, sizeof(ret->mode));
+
+	ret->wrapper          = NULL;
+	ret->wrapperthis      = NULL;
+	ret->stdiocast        = NULL;
+	ret->orig_path        = NULL;
+	ret->readbuf          = NULL;
+
+	return ret;
+}
+/* }}} */
+
+/* {{{ */
+int _pthreads_stream_close_ignore_parent(pthreads_stream_t *threaded_stream_enclosed, int close_options) {
+	return pthreads_stream_close(threaded_stream_enclosed,
+		close_options | PTHREADS_STREAM_FREE_IGNORE_PARENT);
+}
+/* }}} */
+
+#if PTHREADS_STREAM_DEBUG
+static const char *_pthreads_stream_pretty_free_options(int close_options, char *out) {
+	if (close_options & PTHREADS_STREAM_FREE_CALL_DTOR)
+		strcat(out, "CALL_DTOR, ");
+	if (close_options & PTHREADS_STREAM_FREE_PRESERVE_HANDLE)
+		strcat(out, "PREVERSE_HANDLE, ");
+	if (close_options & PTHREADS_STREAM_FREE_IGNORE_PARENT)
+		strcat(out, "IGNORE_PARENT, ");
+	if (out[0] != '\0')
+		out[strlen(out) - 2] = '\0';
+	return out;
+}
+#endif
+
+/* {{{ */
+int _pthreads_stream_close(pthreads_stream_t *threaded_stream, int close_options, int skip_check) {
+	pthreads_stream *stream = PTHREADS_FETCH_STREAMS_STREAM(threaded_stream);
+	pthreads_stream_t *parent_stream;
+	pthreads_hashtable *streams_list;
+	zend_string *str;
+	int ret = 1;
+	int preserve_handle = close_options & PTHREADS_STREAM_FREE_PRESERVE_HANDLE ? 1 : 0;
+
+	if(skip_check ? MONITOR_LOCK(threaded_stream) : stream_lock(threaded_stream)) {
+		stream->state |= PTHREADS_STREAM_STATE_CLOSING;
+
+		if (stream->flags & PTHREADS_STREAM_FLAG_NO_CLOSE) {
+			preserve_handle = 1;
+		}
+		stream->preserve_handle = preserve_handle;
+
+#if PTHREADS_STREAM_DEBUG
+		{
+			char out[200] = "";
+			fprintf(stderr, "stream_close: %s:%p[%s] in_free=%d opts=%s\n",
+				stream->ops->label, stream, stream->orig_path, stream->in_free, _pthreads_stream_pretty_free_options(close_options, out));
+		}
+
+#endif
+
+		if (stream->in_free) {
+			/* hopefully called recursively from the enclosing stream; the pointer was NULLed below */
+			stream_unlock(threaded_stream);
+			return 1; /* recursion protection */
+		}
+		stream->in_free++;
+
+		parent_stream = pthreads_get_parent_stream(threaded_stream);
+
+		/* force correct order on enclosing/enclosed stream destruction */
+		if (parent_stream != NULL && !PTHREADS_IS_STREAM_CLOSING(PTHREADS_FETCH_STREAMS_STREAM(parent_stream)) &&
+				threaded_stream != parent_stream && !(close_options & PTHREADS_STREAM_FREE_IGNORE_PARENT) &&
+				(close_options & PTHREADS_STREAM_FREE_CALL_DTOR)) { /* always? */
+			pthreads_delete_parent_stream(stream);
+
+			/* remove closing state, otherwise ops->close() can not close this innerstream */
+			stream->state &= ~PTHREADS_STREAM_STATE_CLOSING;
+
+			ret = pthreads_stream_close(parent_stream,
+							(close_options | PTHREADS_STREAM_FREE_CALL_DTOR));
+
+			/**
+			 * Scenario (innerstream gets closed before linked parent stream)
+			 * 1. pthreads_stream_close(innerstream)
+			 * 2. innerstream has parent
+			 * 3. innerstream -> pthreads_stream_close(parent_stream)
+			 * 4. parent_stream -> ops->close()
+			 * 5. ops->close() -> pthreads_stream_close_ignore_parent(innerstream)
+			 * 6. close innerstream properly
+			 */
+
+			stream_unlock(threaded_stream);
+			/* we force PTHREADS_STREAM_CALL_DTOR because that's from where the
+			 * enclosing stream can free this stream. */
+			return ret;
+		}
+
+		/* if we are releasing the stream only (and preserving the underlying handle),
+		 * we need to do things a little differently.
+		 * We are only ever called like this when the stream is cast to a FILE*
+		 * for include (or other similar) purposes.
+		 * */
+		if (preserve_handle) {
+			if (stream->fclose_stdiocast == PTHREADS_STREAM_FCLOSE_FOPENCOOKIE) {
+				/* If the stream was fopencookied, we must NOT touch anything
+				 * here, as the cookied stream relies on it all.
+				 * Instead, mark the stream as OK to auto-clean */
+				stream->in_free--;
+				stream->state = PTHREADS_STREAM_STATE_CLOSED;
+
+				stream_unlock(threaded_stream);
+				return 0;
+			}
+			/* otherwise, make sure that we don't close the FILE* from a cast */
+		}
+
+#if PTHREADS_STREAM_DEBUG
+fprintf(stderr, "stream_close: %s:%p[%s] preserve_handle=%d\n",
+		stream->ops->label, stream, stream->orig_path, preserve_handle);
+#endif
+
+		if (stream->flags & PTHREADS_STREAM_FLAG_WAS_WRITTEN) {
+			/* make sure everything is saved */
+			_pthreads_stream_flush(threaded_stream, 1);
+		}
+
+		if (close_options & PTHREADS_STREAM_FREE_CALL_DTOR) {
+			if (!preserve_handle && stream->fclose_stdiocast == PTHREADS_STREAM_FCLOSE_FOPENCOOKIE) {
+				/* calling fclose on an fopencookied stream will ultimately
+					call this very same function.  If we were called via fclose,
+					the cookie_closer unsets the fclose_stdiocast flags, so
+					we can be sure that we only reach here when PHP code calls
+					pthreads_stream_close.
+					Lets let the cookie code clean it all up.
+				 */
+				stream->in_free = 0;
+
+				ret = fclose(stream->stdiocast);
+
+				stream_unlock(threaded_stream);
+				return ret;
+			}
+			ret = stream->ops->close(threaded_stream, preserve_handle ? 0 : 1);
+
+			/* tidy up any FILE* that might have been fdopened */
+			if (!preserve_handle && stream->fclose_stdiocast == PTHREADS_STREAM_FCLOSE_FDOPEN && stream->stdiocast) {
+				fclose(stream->stdiocast);
+				stream->stdiocast = NULL;
+				stream->fclose_stdiocast = PTHREADS_STREAM_FCLOSE_NONE;
+			}
+		}
+		stream->state |= PTHREADS_STREAM_STATE_CLOSED;
+		stream_unlock(threaded_stream);
+
+		zval sobj;
+		ZVAL_OBJ(&sobj, PTHREADS_STD_P(threaded_stream));
+		zval_ptr_dtor(&sobj);
+	}
+
+	return ret;
+}
+/* }}} */
+
+/* {{{ */
+void _pthreads_stream_free(pthreads_stream_t *threaded_stream) {
+	pthreads_stream *stream = PTHREADS_FETCH_STREAMS_STREAM(threaded_stream);
+	pthreads_stream_context_t *threaded_context = NULL;
+	pthreads_stream_filter_t *threaded_filter = NULL;
+	pthreads_stream_wrapper *wrapper = NULL;
+
+	if(stream && MONITOR_LOCK(threaded_stream)) {
+
+#if PTHREADS_STREAM_DEBUG
+fprintf(stderr, "stream_free: %s:%p[%s] preserve_handle=%d\n",
+		stream->ops->label, stream, stream->orig_path, stream->preserve_handle);
+#endif
+		stream->ops->free(threaded_stream, stream->preserve_handle ? 0 : 1);
+		stream->abstract = NULL;
+
+		threaded_context = pthreads_stream_get_context(threaded_stream);
+
+		pthreads_chain_set_stream(pthreads_stream_get_readfilters(threaded_stream), NULL);
+		pthreads_chain_set_stream(pthreads_stream_get_writefilters(threaded_stream), NULL);
+
+		while ((threaded_filter = pthreads_chain_get_head(pthreads_stream_get_readfilters(threaded_stream))) != NULL) {
+			pthreads_stream_filter_remove(threaded_filter);
+		}
+
+		while ((threaded_filter = pthreads_chain_get_head(pthreads_stream_get_writefilters(threaded_stream))) != NULL) {
+			pthreads_stream_filter_remove(threaded_filter);
+		}
+		pthreads_ptr_dtor(pthreads_stream_get_readfilters(threaded_stream));
+		pthreads_ptr_dtor(pthreads_stream_get_writefilters(threaded_stream));
+
+		pthreads_stream_set_readfilters(threaded_stream, NULL);
+		pthreads_stream_set_writefilters(threaded_stream, NULL);
+
+		if(stream->wrapper) {
+			wrapper = PTHREADS_FETCH_STREAMS_WRAPPER(stream->wrapper);
+			if (wrapper && wrapper->wops && wrapper->wops->stream_closer) {
+				wrapper->wops->stream_closer(stream->wrapper, threaded_stream);
+				stream->wrapper = NULL;
+			}
+		}
+
+		if (pthreads_stream_has_wrapperdata(threaded_stream)) {
+			pthreads_ptr_dtor(pthreads_stream_get_wrapperdata(threaded_stream));
+			pthreads_stream_set_wrapperdata(threaded_stream, NULL);
+		}
+
+		if (stream->readbuf) {
+			free(stream->readbuf);
+			stream->readbuf = NULL;
+		}
+
+		if (stream->orig_path) {
+			free(stream->orig_path);
+			stream->orig_path = NULL;
+		}
+
+		if(threaded_context) {
+			if(pthreads_is_default_context(threaded_context)) {
+				pthreads_add_ref(threaded_context);
+			}
+			pthreads_stream_delete_context(threaded_stream);
+		}
+
+		free(stream);
+
+		PTHREADS_FETCH_STREAMS_STREAM(threaded_stream) = NULL;
+
+		MONITOR_UNLOCK(threaded_stream);
+	}
+}
+/* }}} */
+
+/* {{{ generic stream operations */
+void _pthreads_stream_fill_read_buffer(pthreads_stream_t *threaded_stream, size_t size) {
+	pthreads_stream *stream = PTHREADS_FETCH_STREAMS_STREAM(threaded_stream);
+
+	/* allocate/fill the buffer */
+
+	if(stream_lock(threaded_stream)) {
+		if (pthreads_chain_has_head(pthreads_stream_get_readfilters(threaded_stream))) {
+			char *chunk_buf;
+			int err_flag = 0;
+			pthreads_stream_bucket_brigade_t *brig_inp = pthreads_stream_bucket_brigade_new(),
+					*brig_outp = pthreads_stream_bucket_brigade_new(), *brig_swap;
+
+			/* Invalidate the existing cache, otherwise reads can fail, see note in
+			   src/streams/filters.c::_pthreads_stream_filter_append */
+			stream->writepos = stream->readpos = 0;
+
+			/* allocate a buffer for reading chunks */
+			chunk_buf = emalloc(stream->chunk_size);
+
+			while (!stream->eof && !err_flag && (stream->writepos - stream->readpos < (zend_off_t)size)) {
+				size_t justread = 0;
+				int flags;
+				pthreads_stream_bucket_t *threaded_bucket;
+				pthreads_stream_filter_t *threaded_filter;
+				pthreads_stream_filter_status_t status = PTHREADS_SFS_ERR_FATAL;
+				pthreads_stream_bucket *bucket;
+
+				/* read a chunk into a bucket */
+				justread = stream->ops->read(threaded_stream, chunk_buf, stream->chunk_size);
+				if (justread && justread != (size_t)-1) {
+					threaded_bucket = pthreads_stream_bucket_new(chunk_buf, justread);
+
+					/* after this call, bucket is owned by the brigade */
+					pthreads_stream_bucket_append(brig_inp, threaded_bucket, 0);
+
+					flags = PTHREADS_SFS_FLAG_NORMAL;
+				} else {
+					flags = stream->eof ? PTHREADS_SFS_FLAG_FLUSH_CLOSE : PTHREADS_SFS_FLAG_FLUSH_INC;
+				}
+
+				/* wind the handle... */
+				for (threaded_filter = pthreads_chain_get_head(pthreads_stream_get_readfilters(threaded_stream)); threaded_filter; threaded_filter = pthreads_filter_get_next(threaded_filter)) {
+					status = PTHREADS_FETCH_STREAMS_FILTER(threaded_filter)->fops->filter(threaded_stream, threaded_filter, brig_inp, brig_outp, NULL, flags);
+
+					if (status != PTHREADS_SFS_PASS_ON) {
+						break;
+					}
+
+					/* brig_out becomes brig_in.
+					 * brig_in will always be empty here, as the filter MUST attach any un-consumed buckets
+					 * to its own brigade */
+					brig_swap = brig_inp;
+					brig_inp = brig_outp;
+					brig_outp = brig_swap;
+					memset(PTHREADS_FETCH_STREAMS_BRIGADE(brig_outp), 0, sizeof(*PTHREADS_FETCH_STREAMS_BRIGADE(brig_outp)));
+				}
+
+				switch (status) {
+					case PTHREADS_SFS_PASS_ON:
+						/* we get here when the last filter in the chain has data to pass on.
+						 * in this situation, we are passing the brig_in brigade into the
+						 * stream read buffer */
+						while ((threaded_bucket = PTHREADS_FETCH_STREAMS_BRIGADE(brig_inp)->head) != NULL) {
+							pthreads_stream_bucket_sync_properties(threaded_bucket);
+							bucket = PTHREADS_FETCH_STREAMS_BUCKET(threaded_bucket);
+							/* grow buffer to hold this bucket
+							 * TODO: this can fail for persistent streams */
+							if (stream->readbuflen - stream->writepos < bucket->buflen) {
+								stream->readbuflen += bucket->buflen;
+								stream->readbuf = realloc(stream->readbuf, stream->readbuflen);
+							}
+							memcpy(stream->readbuf + stream->writepos, bucket->buf, bucket->buflen);
+							stream->writepos += bucket->buflen;
+
+							pthreads_stream_bucket_destroy(threaded_bucket);
+						}
+						break;
+
+					case PTHREADS_SFS_FEED_ME:
+						/* when a filter needs feeding, there is no brig_out to deal with.
+						 * we simply continue the loop; if the caller needs more data,
+						 * we will read again, otherwise out job is done here */
+						if (justread == 0) {
+							/* there is no data */
+							err_flag = 1;
+							break;
+						}
+						continue;
+
+					case PTHREADS_SFS_ERR_FATAL:
+						/* some fatal error. Theoretically, the stream is borked, so all
+						 * further reads should fail. */
+						err_flag = 1;
+						break;
+				}
+
+				if (justread == 0 || justread == (size_t)-1) {
+					break;
+				}
+			}
+			pthreads_ptr_dtor(brig_inp);
+			pthreads_ptr_dtor(brig_outp);
+
+			efree(chunk_buf);
+
+		} else {
+			/* is there enough data in the buffer ? */
+			if (stream->writepos - stream->readpos < (zend_off_t)size) {
+				size_t justread = 0;
+
+				/* reduce buffer memory consumption if possible, to avoid a realloc */
+				if (stream->readbuf && stream->readbuflen - stream->writepos < stream->chunk_size) {
+					if (stream->writepos > stream->readpos) {
+						memmove(stream->readbuf, stream->readbuf + stream->readpos, stream->writepos - stream->readpos);
+					}
+					stream->writepos -= stream->readpos;
+					stream->readpos = 0;
+				}
+
+				/* grow the buffer if required
+				 * TODO: this can fail for persistent streams */
+				if (stream->readbuflen - stream->writepos < stream->chunk_size) {
+					stream->readbuflen += stream->chunk_size;
+					stream->readbuf = realloc(stream->readbuf, stream->readbuflen);
+				}
+
+				justread = stream->ops->read(threaded_stream, (char*)stream->readbuf + stream->writepos,
+						stream->readbuflen - stream->writepos
+						);
+
+				if (justread != (size_t)-1) {
+					stream->writepos += justread;
+				}
+			}
+		}
+		stream_unlock(threaded_stream);
+	}
+}
+
+size_t _pthreads_stream_read(pthreads_stream_t *threaded_stream, char *buf, size_t size) {
+	pthreads_stream *stream = PTHREADS_FETCH_STREAMS_STREAM(threaded_stream);
+	size_t toread = 0, didread = 0;
+
+	if(stream_lock(threaded_stream)) {
+		while (size > 0) {
+
+			/* take from the read buffer first.
+			 * It is possible that a buffered stream was switched to non-buffered, so we
+			 * drain the remainder of the buffer before using the "raw" read mode for
+			 * the excess */
+			if (stream->writepos > stream->readpos) {
+
+				toread = stream->writepos - stream->readpos;
+				if (toread > size) {
+					toread = size;
+				}
+
+				memcpy(buf, stream->readbuf + stream->readpos, toread);
+				stream->readpos += toread;
+				size -= toread;
+				buf += toread;
+				didread += toread;
+			}
+
+			/* ignore eof here; the underlying state might have changed */
+			if (size == 0) {
+				break;
+			}
+
+			if (!pthreads_chain_has_head(pthreads_stream_get_readfilters(threaded_stream)) && (stream->flags & PTHREADS_STREAM_FLAG_NO_BUFFER || stream->chunk_size == 1)) {
+				toread = stream->ops->read(threaded_stream, buf, size);
+				if (toread == (size_t) -1) {
+					/* e.g. underlying read(2) returned -1 */
+					break;
+				}
+			} else {
+				pthreads_stream_fill_read_buffer(threaded_stream, size);
+
+				toread = stream->writepos - stream->readpos;
+				if (toread > size) {
+					toread = size;
+				}
+
+				if (toread > 0) {
+					memcpy(buf, stream->readbuf + stream->readpos, toread);
+					stream->readpos += toread;
+				}
+			}
+			if (toread > 0) {
+				didread += toread;
+				buf += toread;
+				size -= toread;
+			} else {
+				/* EOF, or temporary end of data (for non-blocking mode). */
+				break;
+			}
+
+			/* just break anyway, to avoid greedy read for file://, php://memory, and php://temp */
+			if ((stream->wrapper != PTHREADS_STREAMG(plain_files_wrapper)) &&
+				(stream->ops != &pthreads_stream_memory_ops) &&
+				(stream->ops != &pthreads_stream_temp_ops)) {
+				break;
+			}
+		}
+
+		if (didread > 0) {
+			stream->position += didread;
+		}
+		stream_unlock(threaded_stream);
+	}
+
+	return didread;
+}
+
+int _pthreads_stream_eof(pthreads_stream_t *threaded_stream) {
+	pthreads_stream *stream = PTHREADS_FETCH_STREAMS_STREAM(threaded_stream);
+
+	if(stream_lock(threaded_stream)) {
+		/* if there is data in the buffer, it's not EOF */
+		if (stream->writepos - stream->readpos > 0) {
+			stream_unlock(threaded_stream);
+			return 0;
+		}
+
+		/* use the configured timeout when checking eof */
+		if (!stream->eof && PTHREADS_STREAM_OPTION_RETURN_ERR ==
+				pthreads_stream_set_option(threaded_stream, PTHREADS_STREAM_OPTION_CHECK_LIVENESS,
+				0, NULL)) {
+			stream->eof = 1;
+		}
+		stream_unlock(threaded_stream);
+	}
+	return stream->eof;
+}
+
+int _pthreads_stream_putc(pthreads_stream_t *threaded_stream, int c) {
+	unsigned char buf = c;
+
+	if (pthreads_stream_write(threaded_stream, (char*)&buf, 1) > 0) {
+		return 1;
+	}
+	return EOF;
+}
+
+int _pthreads_stream_getc(pthreads_stream_t *threaded_stream) {
+	char buf;
+
+	if (pthreads_stream_read(threaded_stream, &buf, 1) > 0) {
+		return buf & 0xff;
+	}
+	return EOF;
+}
+
+int _pthreads_stream_puts(pthreads_stream_t *threaded_stream, const char *buf) {
+	size_t len;
+	char newline[2] = "\n"; /* is this OK for Win? */
+	len = strlen(buf);
+
+	if(stream_lock(threaded_stream)) {
+		if (len > 0 && pthreads_stream_write(threaded_stream, buf, len) && pthreads_stream_write(threaded_stream, newline, 1)) {
+			stream_unlock(threaded_stream);
+			return 1;
+		}
+		stream_unlock(threaded_stream);
+	}
+	return 0;
+}
+
+int _pthreads_stream_stat(pthreads_stream_t *threaded_stream, pthreads_stream_statbuf *ssb) {
+	pthreads_stream *stream = PTHREADS_FETCH_STREAMS_STREAM(threaded_stream);
+	pthreads_stream_wrapper *wrapper = NULL;
+
+	memset(ssb, 0, sizeof(*ssb));
+
+	if(stream_lock(threaded_stream)) {
+		/* if the stream was wrapped, allow the wrapper to stat it */
+		if(stream->wrapper) {
+			wrapper = PTHREADS_FETCH_STREAMS_WRAPPER(stream->wrapper);
+
+			if (wrapper && wrapper->wops->stream_stat != NULL) {
+				stream_unlock(threaded_stream);
+
+				return wrapper->wops->stream_stat(stream->wrapper, threaded_stream, ssb);
+			}
+		}
+
+		/* if the stream doesn't directly support stat-ing, return with failure.
+		 * We could try and emulate this by casting to a FD and fstat-ing it,
+		 * but since the fd might not represent the actual underlying content
+		 * this would give bogus results. */
+		if (stream->ops->stat == NULL) {
+			stream_unlock(threaded_stream);
+			return -1;
+		}
+		stream_unlock(threaded_stream);
+	}
+	return (stream->ops->stat)(threaded_stream, ssb);
+}
+
+const char *pthreads_stream_locate_eol(pthreads_stream_t *threaded_stream, zend_string *buf) {
+	pthreads_stream *stream = PTHREADS_FETCH_STREAMS_STREAM(threaded_stream);
+	size_t avail;
+	const char *cr, *lf, *eol = NULL;
+	const char *readptr;
+
+	if(stream_lock(threaded_stream)) {
+		if (!buf) {
+			readptr = (char*)stream->readbuf + stream->readpos;
+			avail = stream->writepos - stream->readpos;
+		} else {
+			readptr = ZSTR_VAL(buf);
+			avail = ZSTR_LEN(buf);
+		}
+
+		/* Look for EOL */
+		if (stream->flags & PTHREADS_STREAM_FLAG_DETECT_EOL) {
+			cr = memchr(readptr, '\r', avail);
+			lf = memchr(readptr, '\n', avail);
+
+			if (cr && lf != cr + 1 && !(lf && lf < cr)) {
+				/* mac */
+				stream->flags ^= PTHREADS_STREAM_FLAG_DETECT_EOL;
+				stream->flags |= PTHREADS_STREAM_FLAG_EOL_MAC;
+				eol = cr;
+			} else if ((cr && lf && cr == lf - 1) || (lf)) {
+				/* dos or unix endings */
+				stream->flags ^= PTHREADS_STREAM_FLAG_DETECT_EOL;
+				eol = lf;
+			}
+		} else if (stream->flags & PTHREADS_STREAM_FLAG_EOL_MAC) {
+			eol = memchr(readptr, '\r', avail);
+		} else {
+			/* unix (and dos) line endings */
+			eol = memchr(readptr, '\n', avail);
+		}
+		stream_unlock(threaded_stream);
+	}
+	return eol;
+}
+
+/* If buf == NULL, the buffer will be allocated automatically and will be of an
+ * appropriate length to hold the line, regardless of the line length, memory
+ * permitting */
+char *_pthreads_stream_get_line(pthreads_stream_t *threaded_stream, char *buf, size_t maxlen, size_t *returned_len) {
+	pthreads_stream *stream = PTHREADS_FETCH_STREAMS_STREAM(threaded_stream);
+	size_t avail = 0;
+	size_t current_buf_size = 0;
+	size_t total_copied = 0;
+	int grow_mode = 0;
+	char *bufstart = buf;
+
+	if (buf == NULL) {
+		grow_mode = 1;
+	} else if (maxlen == 0) {
+		return NULL;
+	}
+
+	/*
+	 * If the underlying stream operations block when no new data is readable,
+	 * we need to take extra precautions.
+	 *
+	 * If there is buffered data available, we check for a EOL. If it exists,
+	 * we pass the data immediately back to the caller. This saves a call
+	 * to the read implementation and will not block where blocking
+	 * is not necessary at all.
+	 *
+	 * If the stream buffer contains more data than the caller requested,
+	 * we can also avoid that costly step and simply return that data.
+	 */
+	if(stream_lock(threaded_stream)) {
+		for (;;) {
+			avail = stream->writepos - stream->readpos;
+
+			if (avail > 0) {
+				size_t cpysz = 0;
+				char *readptr;
+				const char *eol;
+				int done = 0;
+
+				readptr = (char*)stream->readbuf + stream->readpos;
+				eol = pthreads_stream_locate_eol(threaded_stream, NULL);
+
+				if (eol) {
+					cpysz = eol - readptr + 1;
+					done = 1;
+				} else {
+					cpysz = avail;
+				}
+
+				if (grow_mode) {
+					/* allow room for a NUL. If this realloc is really a realloc
+					 * (ie: second time around), we get an extra byte. In most
+					 * cases, with the default chunk size of 8K, we will only
+					 * incur that overhead once.  When people have lines longer
+					 * than 8K, we waste 1 byte per additional 8K or so.
+					 * That seems acceptable to me, to avoid making this code
+					 * hard to follow */
+					bufstart = realloc(bufstart, current_buf_size + cpysz + 1);
+					current_buf_size += cpysz + 1;
+					buf = bufstart + total_copied;
+				} else {
+					if (cpysz >= maxlen - 1) {
+						cpysz = maxlen - 1;
+						done = 1;
+					}
+				}
+
+				memcpy(buf, readptr, cpysz);
+
+				stream->position += cpysz;
+				stream->readpos += cpysz;
+				buf += cpysz;
+				maxlen -= cpysz;
+				total_copied += cpysz;
+
+				if (done) {
+					break;
+				}
+			} else if (stream->eof) {
+				break;
+			} else {
+				/* XXX: Should be fine to always read chunk_size */
+				size_t toread;
+
+				if (grow_mode) {
+					toread = stream->chunk_size;
+				} else {
+					toread = maxlen - 1;
+					if (toread > stream->chunk_size) {
+						toread = stream->chunk_size;
+					}
+				}
+
+				pthreads_stream_fill_read_buffer(threaded_stream, toread);
+
+				if (stream->writepos - stream->readpos == 0) {
+					break;
+				}
+			}
+		}
+		stream_unlock(threaded_stream);
+	}
+
+	if (total_copied == 0) {
+		if (grow_mode) {
+			assert(bufstart == NULL);
+		}
+		return NULL;
+	}
+
+	buf[0] = '\0';
+	if (returned_len) {
+		*returned_len = total_copied;
+	}
+
+	return bufstart;
+}
+
+#define PTHREADS_STREAM_BUFFERED_AMOUNT(stream) \
+	((size_t)(((stream)->writepos) - (stream)->readpos))
+
+static const char *_pthreads_stream_search_delim(	pthreads_stream_t *threaded_stream,
+													size_t maxlen,
+													size_t skiplen,
+													const char *delim, /* non-empty! */
+													size_t delim_len) {
+	pthreads_stream *stream = PTHREADS_FETCH_STREAMS_STREAM(threaded_stream);
+	size_t	seek_len;
+
+	/* set the maximum number of bytes we're allowed to read from buffer */
+	seek_len = MIN(PTHREADS_STREAM_BUFFERED_AMOUNT(stream), maxlen);
+	if (seek_len <= skiplen) {
+		return NULL;
+	}
+	const char * result = NULL;
+
+	if (delim_len == 1) {
+		if(stream_lock(threaded_stream)) {
+			result = memchr(&stream->readbuf[stream->readpos + skiplen], delim[0], seek_len - skiplen);
+			stream_unlock(threaded_stream);
+		}
+	} else {
+		if(stream_lock(threaded_stream)) {
+			result = php_memnstr((char*)&stream->readbuf[stream->readpos + skiplen], delim, delim_len,
+				(char*)&stream->readbuf[stream->readpos + seek_len]);
+			stream_unlock(threaded_stream);
+		}
+	}
+	return result;
+}
+
+zend_string *pthreads_stream_get_record(pthreads_stream_t *threaded_stream, size_t maxlen, const char *delim, size_t delim_len) {
+	pthreads_stream *stream = PTHREADS_FETCH_STREAMS_STREAM(threaded_stream);
+	zend_string	*ret_buf;				/* returned buffer */
+	const char *found_delim = NULL;
+	size_t	buffered_len,
+			tent_ret_len;			/* tentative returned length */
+	int	has_delim = delim_len > 0;
+
+	if (maxlen == 0) {
+		return NULL;
+	}
+
+	if(stream_lock(threaded_stream)) {
+		if (has_delim) {
+			found_delim = _pthreads_stream_search_delim(threaded_stream, maxlen, 0, delim, delim_len);
+		}
+
+		buffered_len = PTHREADS_STREAM_BUFFERED_AMOUNT(stream);
+		/* try to read up to maxlen length bytes while we don't find the delim */
+		while (!found_delim && buffered_len < maxlen) {
+			size_t	just_read,
+					to_read_now;
+
+			to_read_now = MIN(maxlen - buffered_len, stream->chunk_size);
+
+			pthreads_stream_fill_read_buffer(threaded_stream, buffered_len + to_read_now);
+
+			just_read = PTHREADS_STREAM_BUFFERED_AMOUNT(stream) - buffered_len;
+
+			/* Assume the stream is temporarily or permanently out of data */
+			if (just_read == 0) {
+				break;
+			}
+
+			if (has_delim) {
+				/* search for delimiter, but skip buffered_len (the number of bytes
+				 * buffered before this loop iteration), as they have already been
+				 * searched for the delimiter.
+				 * The left part of the delimiter may still remain in the buffer,
+				 * so subtract up to <delim_len - 1> from buffered_len, which is
+				 * the amount of data we skip on this search  as an optimization
+				 */
+				found_delim = _pthreads_stream_search_delim(
+					threaded_stream, maxlen,
+					buffered_len >= (delim_len - 1)
+							? buffered_len - (delim_len - 1)
+							: 0,
+					delim, delim_len);
+				if (found_delim) {
+					break;
+				}
+			}
+			buffered_len += just_read;
+		}
+
+		if (has_delim && found_delim) {
+			tent_ret_len = found_delim - (char*)&stream->readbuf[stream->readpos];
+		} else if (!has_delim && PTHREADS_STREAM_BUFFERED_AMOUNT(stream) >= maxlen) {
+			tent_ret_len = maxlen;
+		} else {
+			/* return with error if the delimiter string (if any) was not found, we
+			 * could not completely fill the read buffer with maxlen bytes and we
+			 * don't know we've reached end of file. Added with non-blocking streams
+			 * in mind, where this situation is frequent */
+			if (PTHREADS_STREAM_BUFFERED_AMOUNT(stream) < maxlen && !stream->eof) {
+				stream_unlock(threaded_stream);
+				return NULL;
+			} else if (PTHREADS_STREAM_BUFFERED_AMOUNT(stream) == 0 && stream->eof) {
+				/* refuse to return an empty string just because by accident
+				 * we knew of EOF in a read that returned no data */
+				stream_unlock(threaded_stream);
+				return NULL;
+			} else {
+				tent_ret_len = MIN(PTHREADS_STREAM_BUFFERED_AMOUNT(stream), maxlen);
+			}
+		}
+
+		ret_buf = zend_string_alloc(tent_ret_len, 0);
+		/* pthreads_stream_read will not call ops->read here because the necessary
+		 * data is guaranteedly buffered */
+		ZSTR_LEN(ret_buf) = pthreads_stream_read(threaded_stream, ZSTR_VAL(ret_buf), tent_ret_len);
+
+		if (found_delim) {
+			stream->readpos += delim_len;
+			stream->position += delim_len;
+		}
+		stream_unlock(threaded_stream);
+	}
+	ZSTR_VAL(ret_buf)[ZSTR_LEN(ret_buf)] = '\0';
+	return ret_buf;
+}
+
+/* Writes a buffer directly to a stream, using multiple of the chunk size */
+static size_t _pthreads_stream_write_buffer(pthreads_stream_t *threaded_stream, const char *buf, size_t count) {
+	pthreads_stream *stream = PTHREADS_FETCH_STREAMS_STREAM(threaded_stream);
+
+	size_t didwrite = 0, towrite, justwrote;
+
+	if(stream_lock(threaded_stream)) {
+		/* if we have a seekable stream we need to ensure that data is written at the
+		 * current stream->position. This means invalidating the read buffer and then
+		 * performing a low-level seek */
+		if (stream->ops->seek && (stream->flags & PTHREADS_STREAM_FLAG_NO_SEEK) == 0 && stream->readpos != stream->writepos) {
+			stream->readpos = stream->writepos = 0;
+
+			stream->ops->seek(threaded_stream, stream->position, SEEK_SET, &stream->position);
+		}
+
+		while (count > 0) {
+			towrite = count;
+			if (towrite > stream->chunk_size)
+				towrite = stream->chunk_size;
+
+			justwrote = stream->ops->write(threaded_stream, buf, towrite);
+
+			/* convert justwrote to an integer, since normally it is unsigned */
+			if ((int)justwrote > 0) {
+				buf += justwrote;
+				count -= justwrote;
+				didwrite += justwrote;
+
+				/* Only screw with the buffer if we can seek, otherwise we lose data
+				 * buffered from fifos and sockets */
+				if (stream->ops->seek && (stream->flags & PTHREADS_STREAM_FLAG_NO_SEEK) == 0) {
+					stream->position += justwrote;
+				}
+			} else {
+				break;
+			}
+		}
+		stream_unlock(threaded_stream);
+	}
+	return didwrite;
+
+}
+
+/* push some data through the write filter chain.
+ * buf may be NULL, if flags are set to indicate a flush.
+ * This may trigger a real write to the stream.
+ * Returns the number of bytes consumed from buf by the first filter in the chain.
+ * */
+static size_t _pthreads_stream_write_filtered(pthreads_stream_t *threaded_stream, const char *buf, size_t count, int flags) {
+	pthreads_stream *stream = PTHREADS_FETCH_STREAMS_STREAM(threaded_stream);
+	size_t consumed = 0;
+	pthreads_stream_bucket *bucket;
+	pthreads_stream_bucket_t *threaded_bucket;
+	pthreads_stream_bucket_brigade_t *brig_inp = pthreads_stream_bucket_brigade_new(),
+			*brig_outp = pthreads_stream_bucket_brigade_new(), *brig_swap;
+	pthreads_stream_filter_status_t status = PTHREADS_SFS_ERR_FATAL;
+	pthreads_stream_filter_t *threaded_filter;
+	pthreads_stream_filter *filter;
+
+	if (buf) {
+		threaded_bucket = pthreads_stream_bucket_new((char *)buf, count);
+		pthreads_stream_bucket_append(brig_inp, threaded_bucket, 0);
+	}
+
+	if(stream_lock(threaded_stream)) {
+		for (threaded_filter = pthreads_chain_get_head(pthreads_stream_get_writefilters(threaded_stream)); threaded_filter; threaded_filter = pthreads_filter_get_next(threaded_filter)) {
+			filter = PTHREADS_FETCH_STREAMS_FILTER(threaded_filter);
+			/* for our return value, we are interested in the number of bytes consumed from
+			 * the first filter in the chain */
+
+			status = filter->fops->filter(threaded_stream, threaded_filter, brig_inp, brig_outp,
+					!pthreads_object_compare(threaded_filter, pthreads_chain_get_head(pthreads_stream_get_writefilters(threaded_stream))) ? &consumed : NULL, flags);
+
+
+			if (status != PTHREADS_SFS_PASS_ON) {
+				break;
+			}
+			/* brig_out becomes brig_in.
+			 * brig_in will always be empty here, as the filter MUST attach any un-consumed buckets
+			 * to its own brigade */
+			brig_swap = brig_inp;
+			brig_inp = brig_outp;
+			brig_outp = brig_swap;
+			memset(PTHREADS_FETCH_STREAMS_BRIGADE(brig_outp), 0, sizeof(*PTHREADS_FETCH_STREAMS_BRIGADE(brig_outp)));
+		}
+
+		switch (status) {
+			case PTHREADS_SFS_PASS_ON:
+				/* filter chain generated some output; push it through to the
+				 * underlying stream */
+				while ((threaded_bucket = PTHREADS_FETCH_STREAMS_BRIGADE(brig_inp)->head) != NULL) {
+					pthreads_stream_bucket_sync_properties(threaded_bucket);
+					bucket = PTHREADS_FETCH_STREAMS_BUCKET(threaded_bucket);
+					_pthreads_stream_write_buffer(threaded_stream, bucket->buf, bucket->buflen);
+					/* Potential error situation - eg: no space on device. Perhaps we should keep this brigade
+					 * hanging around and try to write it later.
+					 * At the moment, we just drop it on the floor
+					 * */
+					pthreads_stream_bucket_destroy(threaded_bucket);
+				}
+				break;
+			case PTHREADS_SFS_FEED_ME:
+				/* need more data before we can push data through to the stream */
+				pthreads_stream_bucket_destroy(threaded_bucket);
+				break;
+
+			case PTHREADS_SFS_ERR_FATAL:
+				/* some fatal error.  Theoretically, the stream is borked, so all
+				 * further writes should fail. */
+				pthreads_stream_bucket_destroy(threaded_bucket);
+				break;
+		}
+		stream_unlock(threaded_stream);
+	}
+	pthreads_ptr_dtor(brig_inp);
+	pthreads_ptr_dtor(brig_outp);
+
+	return consumed;
+}
+
+int _pthreads_stream_flush(pthreads_stream_t *threaded_stream, int closing) {
+	pthreads_stream *stream = PTHREADS_FETCH_STREAMS_STREAM(threaded_stream);
+	int ret = 0;
+
+	if(stream_lock(threaded_stream)) {
+		if (pthreads_chain_has_head(pthreads_stream_get_writefilters(threaded_stream))) {
+			_pthreads_stream_write_filtered(threaded_stream, NULL, 0, closing ? PTHREADS_SFS_FLAG_FLUSH_CLOSE : PTHREADS_SFS_FLAG_FLUSH_INC );
+		}
+
+		stream->flags &= ~PTHREADS_STREAM_FLAG_WAS_WRITTEN;
+
+		if (stream->ops->flush) {
+			ret = stream->ops->flush(threaded_stream);
+		}
+		stream_unlock(threaded_stream);
+	}
+	return ret;
+}
+
+size_t _pthreads_stream_write(pthreads_stream_t *threaded_stream, const char *buf, size_t count) {
+	pthreads_stream *stream = PTHREADS_FETCH_STREAMS_STREAM(threaded_stream);
+	size_t bytes;
+
+	if (buf == NULL || count == 0 || stream->ops->write == NULL) {
+		return 0;
+	}
+
+	if(stream_lock(threaded_stream)) {
+		if (pthreads_chain_has_head(pthreads_stream_get_writefilters(threaded_stream))) {
+			bytes = _pthreads_stream_write_filtered(threaded_stream, buf, count, PTHREADS_SFS_FLAG_NORMAL);
+		} else {
+			bytes = _pthreads_stream_write_buffer(threaded_stream, buf, count);
+		}
+
+		if (bytes) {
+			stream->flags |= PTHREADS_STREAM_FLAG_WAS_WRITTEN;
+		}
+		stream_unlock(threaded_stream);
+	}
+	return bytes;
+}
+
+size_t _pthreads_stream_printf(pthreads_stream_t *threaded_stream, const char *fmt, ...) {
+	size_t count;
+	char *buf;
+	va_list ap;
+
+	va_start(ap, fmt);
+	count = vspprintf(&buf, 0, fmt, ap);
+	va_end(ap);
+
+	if (!buf) {
+		return 0; /* error condition */
+	}
+
+	count = pthreads_stream_write(threaded_stream, buf, count);
+	efree(buf);
+
+	return count;
+}
+
+zend_off_t _pthreads_stream_tell(pthreads_stream_t *threaded_stream) {
+	pthreads_stream *stream = PTHREADS_FETCH_STREAMS_STREAM(threaded_stream);
+	zend_off_t result;
+
+	if(stream_lock(threaded_stream)) {
+		result = stream->position;
+		stream_unlock(threaded_stream);
+	}
+	return result;
+}
+
+int _pthreads_stream_seek(pthreads_stream_t *threaded_stream, zend_off_t offset, int whence) {
+	pthreads_stream *stream = PTHREADS_FETCH_STREAMS_STREAM(threaded_stream);
+
+	if(stream_lock(threaded_stream)) {
+		if (stream->fclose_stdiocast == PTHREADS_STREAM_FCLOSE_FOPENCOOKIE) {
+			/* flush to commit data written to the fopencookie FILE* */
+			fflush(stream->stdiocast);
+		}
+
+		/* handle the case where we are in the buffer */
+		if ((stream->flags & PTHREADS_STREAM_FLAG_NO_BUFFER) == 0) {
+			switch(whence) {
+				case SEEK_CUR:
+					if (offset > 0 && offset <= stream->writepos - stream->readpos) {
+						stream->readpos += offset; /* if offset = ..., then readpos = writepos */
+						stream->position += offset;
+						stream->eof = 0;
+
+						stream_unlock(threaded_stream);
+						return 0;
+					}
+					break;
+				case SEEK_SET:
+					if (offset > stream->position &&
+							offset <= stream->position + stream->writepos - stream->readpos) {
+						stream->readpos += offset - stream->position;
+						stream->position = offset;
+						stream->eof = 0;
+
+						stream_unlock(threaded_stream);
+						return 0;
+					}
+					break;
+			}
+		}
+
+		if (stream->ops->seek && (stream->flags & PTHREADS_STREAM_FLAG_NO_SEEK) == 0) {
+			int ret;
+
+			if (pthreads_chain_has_head(pthreads_stream_get_writefilters(threaded_stream))) {
+				_pthreads_stream_flush(threaded_stream, 0);
+			}
+
+			switch(whence) {
+				case SEEK_CUR:
+					offset = stream->position + offset;
+					whence = SEEK_SET;
+					break;
+			}
+			ret = stream->ops->seek(threaded_stream, offset, whence, &stream->position);
+
+			if (((stream->flags & PTHREADS_STREAM_FLAG_NO_SEEK) == 0) || ret == 0) {
+				if (ret == 0) {
+					stream->eof = 0;
+				}
+
+				/* invalidate the buffer contents */
+				stream->readpos = stream->writepos = 0;
+				stream_unlock(threaded_stream);
+
+				return ret;
+			}
+			/* else the stream has decided that it can't support seeking after all;
+			 * fall through to attempt emulation */
+		}
+
+		/* emulate forward moving seeks with reads */
+		if (whence == SEEK_CUR && offset >= 0) {
+			char tmp[1024];
+			size_t didread;
+			while(offset > 0) {
+				if ((didread = pthreads_stream_read(threaded_stream, tmp, MIN(offset, sizeof(tmp)))) == 0) {
+					stream_unlock(threaded_stream);
+					return -1;
+				}
+				offset -= didread;
+			}
+			stream->eof = 0;
+			stream_unlock(threaded_stream);
+			return 0;
+		}
+		stream_unlock(threaded_stream);
+	}
+	php_error_docref(NULL, E_WARNING, "stream does not support seeking");
+
+	return -1;
+}
+
+int _pthreads_stream_set_option(pthreads_stream_t *threaded_stream, int option, int value, void *ptrparam) {
+	pthreads_stream *stream = PTHREADS_FETCH_STREAMS_STREAM(threaded_stream);
+	int ret = PTHREADS_STREAM_OPTION_RETURN_NOTIMPL;
+
+	if(stream_lock(threaded_stream)) {
+		if (stream->ops->set_option) {
+			ret = stream->ops->set_option(threaded_stream, option, value, ptrparam);
+		}
+
+		if (ret == PTHREADS_STREAM_OPTION_RETURN_NOTIMPL) {
+			switch(option) {
+				case PTHREADS_STREAM_OPTION_SET_CHUNK_SIZE:
+					/* XXX chunk size itself is of size_t, that might be ok or not for a particular case*/
+					ret = stream->chunk_size > INT_MAX ? INT_MAX : (int)stream->chunk_size;
+					stream->chunk_size = value;
+					stream_unlock(threaded_stream);
+					return ret;
+
+				case PTHREADS_STREAM_OPTION_READ_BUFFER:
+					/* try to match the buffer mode as best we can */
+					if (value == PTHREADS_STREAM_BUFFER_NONE) {
+						stream->flags |= PTHREADS_STREAM_FLAG_NO_BUFFER;
+					} else if (stream->flags & PTHREADS_STREAM_FLAG_NO_BUFFER) {
+						stream->flags ^= PTHREADS_STREAM_FLAG_NO_BUFFER;
+					}
+					ret = PTHREADS_STREAM_OPTION_RETURN_OK;
+					break;
+
+				default:
+					;
+			}
+		}
+		stream_unlock(threaded_stream);
+	}
+	return ret;
+}
+
+int _pthreads_stream_truncate_set_size(pthreads_stream_t *threaded_stream, size_t newsize) {
+	return pthreads_stream_set_option(threaded_stream, PTHREADS_STREAM_OPTION_TRUNCATE_API, PTHREADS_STREAM_TRUNCATE_SET_SIZE, &newsize);
+}
+
+size_t _pthreads_stream_passthru(pthreads_stream_t * threaded_stream) {
+	size_t bcount = 0;
+	char buf[8192];
+	size_t b;
+
+	if(stream_lock(threaded_stream)) {
+		if (pthreads_stream_mmap_possible(threaded_stream)) {
+			char *p;
+			size_t mapped;
+
+			p = pthreads_stream_mmap_range(threaded_stream, pthreads_stream_tell(threaded_stream), PTHREADS_STREAM_MMAP_ALL, PTHREADS_STREAM_MAP_MODE_SHARED_READONLY, &mapped);
+
+			if (p) {
+				do {
+					/* output functions return int, so pass in int max */
+					if (0 < (b = PHPWRITE(p + bcount, MIN(mapped - bcount, INT_MAX)))) {
+						bcount += b;
+					}
+				} while (b > 0 && mapped > bcount);
+
+				pthreads_stream_mmap_unmap_ex(threaded_stream, mapped);
+
+				return bcount;
+			}
+		}
+
+		while ((b = pthreads_stream_read(threaded_stream, buf, sizeof(buf))) > 0) {
+			PHPWRITE(buf, b);
+			bcount += b;
+		}
+		stream_unlock(threaded_stream);
+	}
+	return bcount;
+}
+
+zend_string *_pthreads_stream_copy_to_mem(pthreads_stream_t *threaded_src, size_t maxlen, int persistent) {
+	size_t ret = 0;
+	char *ptr;
+	size_t len = 0, max_len;
+	int step = CHUNK_SIZE;
+	int min_room = CHUNK_SIZE / 4;
+	pthreads_stream_statbuf ssbuf;
+	zend_string *result;
+
+	if (maxlen == 0) {
+		return ZSTR_EMPTY_ALLOC();
+	}
+
+	if (maxlen == PTHREADS_STREAM_COPY_ALL) {
+		maxlen = 0;
+	}
+
+	if(stream_lock(threaded_src)) {
+		if (maxlen > 0) {
+			result = zend_string_alloc(maxlen, persistent);
+			ptr = ZSTR_VAL(result);
+			while ((len < maxlen) && !pthreads_stream_eof(threaded_src)) {
+				ret = pthreads_stream_read(threaded_src, ptr, maxlen - len);
+				if (!ret) {
+					break;
+				}
+				len += ret;
+				ptr += ret;
+			}
+			if (len) {
+				*ptr = '\0';
+				ZSTR_LEN(result) = len;
+			} else {
+				zend_string_free(result);
+				result = NULL;
+			}
+			stream_unlock(threaded_src);
+			return result;
+		}
+
+		/* avoid many reallocs by allocating a good sized chunk to begin with, if
+		 * we can.  Note that the stream may be filtered, in which case the stat
+		 * result may be inaccurate, as the filter may inflate or deflate the
+		 * number of bytes that we can read.  In order to avoid an upsize followed
+		 * by a downsize of the buffer, overestimate by the step size (which is
+		 * 2K).  */
+		if (pthreads_stream_stat(threaded_src, &ssbuf) == 0 && ssbuf.sb.st_size > 0) {
+			max_len = ssbuf.sb.st_size + step;
+		} else {
+			max_len = step;
+		}
+
+		result = zend_string_alloc(max_len, persistent);
+		ptr = ZSTR_VAL(result);
+
+		while ((ret = pthreads_stream_read(threaded_src, ptr, max_len - len)))	{
+			len += ret;
+			if (len + min_room >= max_len) {
+				result = zend_string_extend(result, max_len + step, persistent);
+				max_len += step;
+				ptr = ZSTR_VAL(result) + len;
+			} else {
+				ptr += ret;
+			}
+		}
+		stream_unlock(threaded_src);
+	}
+
+	if (len) {
+		result = zend_string_truncate(result, len, persistent);
+		ZSTR_VAL(result)[len] = '\0';
+	} else {
+		zend_string_free(result);
+		result = NULL;
+	}
+
+	return result;
+}
+
+/* Returns SUCCESS/FAILURE and sets *len to the number of bytes moved */
+int _pthreads_stream_copy_to_stream_ex(pthreads_stream_t *threaded_src, pthreads_stream_t *threaded_dest, size_t maxlen, size_t *len) {
+	char buf[CHUNK_SIZE];
+	size_t readchunk;
+	size_t haveread = 0;
+	size_t didread, didwrite, towrite;
+	size_t dummy;
+	pthreads_stream_statbuf ssbuf;
+	int eof;
+
+	if (!len) {
+		len = &dummy;
+	}
+
+	if (maxlen == 0) {
+		*len = 0;
+		return SUCCESS;
+	}
+
+	if (maxlen == PTHREADS_STREAM_COPY_ALL) {
+		maxlen = 0;
+	}
+
+	if (pthreads_stream_stat(threaded_src, &ssbuf) == 0) {
+		if (ssbuf.sb.st_size == 0
+#ifdef S_ISREG
+			&& S_ISREG(ssbuf.sb.st_mode)
+#endif
+		) {
+			*len = 0;
+			return SUCCESS;
+		}
+	}
+
+	if(pthreads_streams_aquire_double_lock(threaded_src, threaded_dest)) {
+		if (pthreads_stream_mmap_possible(threaded_src)) {
+			char *p;
+			size_t mapped;
+
+			p = pthreads_stream_mmap_range(threaded_src, pthreads_stream_tell(threaded_src), maxlen, PTHREADS_STREAM_MAP_MODE_SHARED_READONLY, &mapped);
+
+			if (p) {
+				didwrite = pthreads_stream_write(threaded_dest, p, mapped);
+
+				pthreads_stream_mmap_unmap_ex(threaded_src, mapped);
+
+				*len = didwrite;
+
+				/* we've got at least 1 byte to read
+				 * less than 1 is an error
+				 * AND read bytes match written */
+				if (mapped > 0 && mapped == didwrite) {
+					pthreads_streams_release_double_lock(threaded_src, threaded_dest);
+					return SUCCESS;
+				}
+				pthreads_streams_release_double_lock(threaded_src, threaded_dest);
+				return FAILURE;
+			}
+		}
+
+		while(1) {
+			readchunk = sizeof(buf);
+
+			if (maxlen && (maxlen - haveread) < readchunk) {
+				readchunk = maxlen - haveread;
+			}
+
+			didread = pthreads_stream_read(threaded_src, buf, readchunk);
+
+			if (didread) {
+				/* extra paranoid */
+				char *writeptr;
+
+				towrite = didread;
+				writeptr = buf;
+				haveread += didread;
+
+				while(towrite) {
+					didwrite = pthreads_stream_write(threaded_dest, writeptr, towrite);
+					if (didwrite == 0) {
+						*len = haveread - (didread - towrite);
+						pthreads_streams_release_double_lock(threaded_src, threaded_dest);
+						return FAILURE;
+					}
+
+					towrite -= didwrite;
+					writeptr += didwrite;
+				}
+			} else {
+				break;
+			}
+
+			if (maxlen - haveread == 0) {
+				break;
+			}
+		}
+		eof = PTHREADS_FETCH_STREAMS_STREAM(threaded_src)->eof;
+
+		pthreads_streams_release_double_lock(threaded_src, threaded_dest);
+	}
+	*len = haveread;
+
+	/* we've got at least 1 byte to read.
+	 * less than 1 is an error */
+
+	if (haveread > 0 || eof) {
+		return SUCCESS;
+	}
+	return FAILURE;
+}
+
+
+/* {{{ pthreads_stream_scandir */
+int _pthreads_stream_scandir(const char *dirname, zend_string **namelist[], int flags, pthreads_stream_context_t *threaded_context,
+			  int (*compare) (const zend_string **a, const zend_string **b)) {
+	pthreads_stream_t *threaded_stream;
+	pthreads_stream_dirent sdp;
+	zend_string **vector = NULL;
+	unsigned int vector_size = 0;
+	unsigned int nfiles = 0;
+
+	if (!namelist) {
+		return FAILURE;
+	}
+
+	if(MONITOR_LOCK(threaded_context)) {
+		threaded_stream = pthreads_stream_opendir(dirname, PTHREADS_REPORT_ERRORS, threaded_context);
+		if (!threaded_stream) {
+			return FAILURE;
+		}
+		if(stream_lock(threaded_stream)) {
+			while (pthreads_stream_readdir(threaded_stream, &sdp)) {
+				if (nfiles == vector_size) {
+					if (vector_size == 0) {
+						vector_size = 10;
+					} else {
+						if(vector_size*2 < vector_size) {
+							/* overflow */
+							pthreads_stream_closedir(threaded_stream);
+							free(vector);
+							return FAILURE;
+						}
+						vector_size *= 2;
+					}
+					vector = (zend_string **) realloc(vector, zend_safe_address_guarded(vector_size, sizeof(char *), 0));
+				}
+
+				vector[nfiles] = zend_string_init(sdp.d_name, strlen(sdp.d_name), 1);
+
+				nfiles++;
+				if(vector_size < 10 || nfiles == 0) {
+					/* overflow */
+					pthreads_stream_closedir(threaded_stream);
+					free(vector);
+					return FAILURE;
+				}
+			}
+			pthreads_stream_closedir(threaded_stream);
+
+			stream_unlock(threaded_stream);
+		}
+		MONITOR_UNLOCK(threaded_context);
+	}
+
+	*namelist = vector;
+
+	if (nfiles > 0 && compare) {
+		qsort(*namelist, nfiles, sizeof(zend_string *), (int(*)(const void *, const void *))compare);
+	}
+	return nfiles;
+}
+/* }}} */
+
+#ifndef HAVE_PTHREADS_API_CONTEXT
+#	include "src/streams/context_api.c"
+#endif
+
+#ifndef HAVE_PTHREADS_STREAMS_STREAMS_API
+#	include "src/streams/streams_api.c"
+#endif
+
+#endif

--- a/src/streams.h
+++ b/src/streams.h
@@ -1,0 +1,708 @@
+/*
+  +----------------------------------------------------------------------+
+  | pthreads                                                             |
+  +----------------------------------------------------------------------+
+  | Copyright (c) Joe Watkins 2018                                       |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | http://www.php.net/license/3_01.txt                                  |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors: Bastian Schneider <b.schneider@badnoob.com>                 |
+  | Borrowed code from php-src                                           |
+  +----------------------------------------------------------------------+
+ */
+#ifndef HAVE_PTHREADS_STREAMS_H
+#define HAVE_PTHREADS_STREAMS_H
+
+#ifdef HAVE_CONFIG_H
+#	include <config.h>
+#endif
+
+#ifdef HAVE_SYS_TIME_H
+#include <sys/time.h>
+#endif
+#include <sys/types.h>
+#include <sys/stat.h>
+
+#ifndef FILE_H
+#	include <ext/standard/file.h>
+#endif
+
+#ifndef HAVE_PTHREADS_UTILS_H
+#	include <src/utils.h>
+#endif
+
+typedef struct _pthreads_stream                 pthreads_stream;
+typedef struct _pthreads_stream_wrapper         pthreads_stream_wrapper;
+typedef struct _pthreads_stream_context         pthreads_stream_context;
+typedef struct _pthreads_stream_filter          pthreads_stream_filter;
+typedef struct _pthreads_stream_bucket          pthreads_stream_bucket;
+typedef struct _pthreads_stream_bucket_brigade	pthreads_stream_bucket_brigade;
+
+typedef struct _pthreads_object_t pthreads_stream_t;
+typedef struct _pthreads_object_t pthreads_stream_wrapper_t;
+typedef struct _pthreads_object_t pthreads_stream_context_t;
+typedef struct _pthreads_object_t pthreads_stream_filter_t;
+typedef struct _pthreads_object_t pthreads_stream_bucket_t;
+typedef struct _pthreads_object_t pthreads_stream_bucket_brigade_t;
+
+typedef struct _pthreads_object_t pthreads_stream_filter_chain_t;
+
+#define PTHREADS_FETCH_STREAMS_STREAM(object)  ((object)->store.streams->stream)
+#define PTHREADS_FETCH_STREAMS_CONTEXT(object) ((object)->store.streams->context)
+#define PTHREADS_FETCH_STREAMS_FILTER(object)  ((object)->store.streams->filter)
+#define PTHREADS_FETCH_STREAMS_BUCKET(object)  ((object)->store.streams->bucket)
+#define PTHREADS_FETCH_STREAMS_BRIGADE(object) ((object)->store.streams->brigade)
+#define PTHREADS_FETCH_STREAMS_WRAPPER(object) ((object)->store.streams->wrapper)
+
+#ifndef HAVE_PTHREADS_STREAMS_FILTERS_H
+#	include "src/streams/filters.h"
+#endif
+
+#ifndef HAVE_PTHREADS_FILE_H
+#	include <src/file/file.h>
+#endif
+
+typedef struct _pthreads_stream_statbuf {
+	zend_stat_t sb; /* regular info */
+	/* extended info to go here some day: content-type etc. etc. */
+} pthreads_stream_statbuf;
+
+typedef struct _pthreads_stream_dirent {
+	char d_name[MAXPATHLEN];
+} pthreads_stream_dirent;
+
+typedef union _pthreads_streams_t {
+	pthreads_stream 				*stream;
+	pthreads_stream_context			*context;
+	pthreads_stream_filter			*filter;
+	pthreads_stream_bucket			*bucket;
+	pthreads_stream_bucket_brigade	*brigade;
+	pthreads_stream_wrapper         *wrapper;
+} pthreads_streams_t;
+
+/* operations on streams that are file-handles */
+typedef struct _pthreads_stream_ops  {
+	/* stdio like functions - these are mandatory! */
+	size_t (*write)(pthreads_stream_t *threaded_stream, const char *buf, size_t count);
+	size_t (*read)(pthreads_stream_t *threaded_stream, char *buf, size_t count);
+	int    (*close)(pthreads_stream_t *threaded_stream, int close_handle);
+	void   (*free)(pthreads_stream_t *threaded_stream, int close_handle);
+	int    (*flush)(pthreads_stream_t *threaded_stream);
+
+	const char *label; /* label for this ops structure */
+
+	/* these are optional */
+	int (*seek)(pthreads_stream_t *threaded_stream, zend_off_t offset, int whence, zend_off_t *newoffset);
+	int (*cast)(pthreads_stream_t *threaded_stream, int castas, void **ret);
+	int (*stat)(pthreads_stream_t *threaded_stream, pthreads_stream_statbuf *ssb);
+	int (*set_option)(pthreads_stream_t *threaded_stream, int option, int value, void *ptrparam);
+} pthreads_stream_ops;
+
+typedef struct _pthreads_stream_wrapper_ops {
+	/* open/create a wrapped stream */
+	pthreads_stream_t *(*stream_opener)(pthreads_stream_wrapper_t *threaded_wrapper, const char *filename, const char *mode,
+			int options, zend_string **opened_path, pthreads_stream_context_t *threaded_context, zend_class_entry *ce);
+	/* close/destroy a wrapped stream */
+	int (*stream_closer)(pthreads_stream_wrapper_t *threaded_wrapper, pthreads_stream_t *stream);
+	/* stat a wrapped stream */
+	int (*stream_stat)(pthreads_stream_wrapper_t *threaded_wrapper, pthreads_stream_t *stream, pthreads_stream_statbuf *ssb);
+	/* stat a URL */
+	int (*url_stat)(pthreads_stream_wrapper_t *threaded_wrapper, const char *url, int flags, pthreads_stream_statbuf *ssb, pthreads_stream_context_t *threaded_context);
+	/* open a "directory" stream */
+	pthreads_stream_t *(*dir_opener)(pthreads_stream_wrapper_t *wrapper, const char *filename, const char *mode,
+			int options, zend_string **opened_path, pthreads_stream_context_t *threaded_context, zend_class_entry *ce);
+
+	const char *label;
+
+	/* delete a file */
+	int (*unlink)(pthreads_stream_wrapper_t *threaded_wrapper, const char *url, int options, pthreads_stream_context_t *threaded_context);
+
+	/* rename a file */
+	int (*rename)(pthreads_stream_wrapper_t *threaded_wrapper, const char *url_from, const char *url_to, int options, pthreads_stream_context_t *threaded_context);
+
+	/* Create/Remove directory */
+	int (*stream_mkdir)(pthreads_stream_wrapper_t *threaded_wrapper, const char *url, int mode, int options, pthreads_stream_context_t *threaded_context);
+	int (*stream_rmdir)(pthreads_stream_wrapper_t *threaded_wrapper, const char *url, int options, pthreads_stream_context_t *threaded_context);
+	/* Metadata handling */
+	int (*stream_metadata)(pthreads_stream_wrapper_t *threaded_wrapper, const char *url, int options, void *value, pthreads_stream_context_t *threaded_context);
+} pthreads_stream_wrapper_ops;
+
+struct _pthreads_stream_wrapper	{
+	const pthreads_stream_wrapper_ops *wops;	/* operations the wrapper can perform */
+	void *abstract;					/* context for the wrapper */
+	int is_url;						/* so that PG(allow_url_fopen) can be respected */
+};
+
+struct _pthreads_stream  {
+	const pthreads_stream_ops *ops;
+	void *abstract;			/* convenience pointer for abstraction */
+
+	pthreads_stream_wrapper_t *wrapper; /* which wrapper was used to open the stream */
+	void *wrapperthis;		/* convenience pointer for a instance of a wrapper */
+
+	uint8_t state:3;
+	uint8_t in_free:2;			/* to prevent recursion during free */
+	uint8_t eof:1;
+	uint8_t preserve_handle:1;
+
+	/* so we know how to clean it up correctly.  This should be set to
+	 * PTHREADS_STREAM_FCLOSE_XXX as appropriate */
+	uint8_t fclose_stdiocast:2;
+
+	uint8_t fgetss_state;		/* for fgetss to handle multiline tags */
+
+	char mode[16];			/* "rwb" etc. ala stdio */
+
+	uint32_t flags;	/* PTHREADS_STREAM_FLAG_XXX */
+
+	FILE *stdiocast;    /* cache this, otherwise we might leak! */
+	char *orig_path;
+
+	/* buffer */
+	zend_off_t position; /* of underlying stream */
+	unsigned char *readbuf;
+	size_t readbuflen;
+	zend_off_t readpos;
+	zend_off_t writepos;
+
+	/* how much data to read when filling buffer */
+	size_t chunk_size;
+
+}; /* pthreads_stream */
+
+#ifndef HAVE_PTHREADS_STREAMS_CONTEXT_H
+#	include "src/streams/context.h"
+#endif
+
+#ifndef HAVE_PTHREADS_STREAMS_WRAPPERS_H
+#	include "src/streams/wrappers.h"
+#endif
+
+#ifndef HAVE_PTHREADS_STREAM_GLOBALS_H
+#	include "src/streams/streamglobals.h"
+#endif
+
+#define PTHREADS_STREAM_STATE_OPEN 			0
+#define PTHREADS_STREAM_STATE_CLOSING		1
+#define PTHREADS_STREAM_STATE_CLOSED		2
+
+#define PTHREADS_IS_STREAM_CLOSING(stream) 	(((stream)->state & PTHREADS_STREAM_STATE_CLOSING) == PTHREADS_STREAM_STATE_CLOSING)
+#define PTHREADS_IS_INVALID_STREAM(stream) 	((stream) == NULL || ((stream)->state & PTHREADS_STREAM_STATE_CLOSED) == PTHREADS_STREAM_STATE_CLOSED)
+#define PTHREADS_IS_VALID_STREAM(stream) 	!PTHREADS_IS_INVALID_STREAM(stream)
+
+#define PTHREADS_STREAM_PRE_CHECK(stream) do { \
+	if (PTHREADS_IS_INVALID_STREAM(stream)) { \
+		zend_throw_exception_ex(spl_ce_RuntimeException, 0, \
+			"stream found in invalid state(%i)", (stream)->state); \
+		return; \
+	} \
+} while(0)
+
+#define PTHREADS_STREAM_POST_CHECK(threaded_stream, stream) do { \
+	if (PTHREADS_IS_INVALID_STREAM(stream)) { \
+		MONITOR_UNLOCK((threaded_stream)); \
+		zend_throw_exception_ex(spl_ce_RuntimeException, 0, \
+			"stream found in invalid state(%i)", (stream)->state); \
+		return; \
+	} \
+} while(0)
+
+#define PTHREADS_STREAM_CORRUPTED()  do { \
+	zend_throw_exception_ex(spl_ce_RuntimeException, 0, "stream corrupted"); \
+	return; \
+} while(0)
+
+#define PTHREADS_STREAM_FLAG_NO_SEEK					0x1
+#define PTHREADS_STREAM_FLAG_NO_BUFFER					0x2
+
+#define PTHREADS_STREAM_FLAG_EOL_UNIX					0x0 /* also includes DOS */
+#define PTHREADS_STREAM_FLAG_DETECT_EOL					0x4
+#define PTHREADS_STREAM_FLAG_EOL_MAC					0x8
+
+/* set this when the stream might represent "interactive" data.
+ * When set, the read buffer will avoid certain operations that
+ * might otherwise cause the read to block for much longer than
+ * is strictly required. */
+#define PTHREADS_STREAM_FLAG_AVOID_BLOCKING				0x10
+#define PTHREADS_STREAM_FLAG_NO_CLOSE					0x20
+#define PTHREADS_STREAM_FLAG_IS_DIR						0x40
+#define PTHREADS_STREAM_FLAG_NO_FCLOSE					0x80
+#define PTHREADS_STREAM_FLAG_WAS_WRITTEN				0x80000000
+
+#define PTHREADS_STREAM_STORAGE_KEY_STREAM_CONTEXT		1
+#define PTHREADS_STREAM_STORAGE_KEY_STREAM_INNERSTREAM	2
+#define PTHREADS_STREAM_STORAGE_KEY_STREAM_PARENT		3
+#define PTHREADS_STREAM_STORAGE_KEY_STREAM_READFILTERS	4
+#define PTHREADS_STREAM_STORAGE_KEY_STREAM_WRITEFILTERS	5
+#define PTHREADS_STREAM_STORAGE_KEY_STREAM_WRAPPERDATA	6
+
+#define PTHREADS_STREAM_STORAGE_KEY_CHAIN_HEAD			7
+#define PTHREADS_STREAM_STORAGE_KEY_CHAIN_TAIL			8
+#define PTHREADS_STREAM_STORAGE_KEY_CHAIN_STREAM		9
+
+#define PTHREADS_STREAM_STORAGE_KEY_FILTER_PREV			10
+#define PTHREADS_STREAM_STORAGE_KEY_FILTER_NEXT			11
+#define PTHREADS_STREAM_STORAGE_KEY_FILTER_CHAIN		12
+
+
+#define PTHREADS_GET_CTX_OPT(threaded_stream, wrapper, name, val) (pthreads_stream_get_context(threaded_stream) && NULL != (val = pthreads_stream_context_get_option(pthreads_stream_get_context(threaded_stream), wrapper, name)))
+
+/**
+ * Stream
+ */
+#define pthreads_stream_get_readfilters(threaded_stream) \
+	((pthreads_stream_t*) pthreads_stream_read_threaded_property((threaded_stream), PTHREADS_STREAM_STORAGE_KEY_STREAM_READFILTERS))
+
+#define pthreads_stream_set_readfilters(threaded_stream, threaded_chain) \
+	(pthreads_stream_write_threaded_property((threaded_stream), PTHREADS_STREAM_STORAGE_KEY_STREAM_READFILTERS, (threaded_chain)))
+
+#define pthreads_stream_get_writefilters(threaded_stream) \
+	((pthreads_stream_t*) pthreads_stream_read_threaded_property((threaded_stream), PTHREADS_STREAM_STORAGE_KEY_STREAM_WRITEFILTERS))
+
+#define pthreads_stream_set_writefilters(threaded_stream, threaded_chain) \
+	(pthreads_stream_write_threaded_property((threaded_stream), PTHREADS_STREAM_STORAGE_KEY_STREAM_WRITEFILTERS, (threaded_chain)))
+
+#define pthreads_stream_has_wrapperdata(threaded_stream) \
+	(pthreads_stream_has_threaded_property((threaded_stream), PTHREADS_STREAM_STORAGE_KEY_STREAM_WRAPPERDATA))
+
+#define pthreads_stream_get_wrapperdata(threaded_stream) \
+	((pthreads_stream_t*) pthreads_stream_read_threaded_property((threaded_stream), PTHREADS_STREAM_STORAGE_KEY_STREAM_WRAPPERDATA))
+
+#define pthreads_stream_set_wrapperdata(threaded_stream, wrapperdata) \
+	(pthreads_stream_write_threaded_property((threaded_stream), PTHREADS_STREAM_STORAGE_KEY_STREAM_WRAPPERDATA, (wrapperdata)))
+
+
+/**
+ * Context
+ */
+#define pthreads_stream_get_context(threaded_stream) \
+	((pthreads_stream_context_t*) pthreads_stream_read_threaded_property((threaded_stream), PTHREADS_STREAM_STORAGE_KEY_STREAM_CONTEXT))
+
+#define pthreads_stream_set_context(threaded_stream, threaded_context) \
+	(pthreads_stream_write_threaded_property((threaded_stream), PTHREADS_STREAM_STORAGE_KEY_STREAM_CONTEXT, (threaded_context)))
+
+#define pthreads_stream_delete_context(threaded_stream) \
+	(pthreads_stream_delete_threaded_property((threaded_stream), PTHREADS_STREAM_STORAGE_KEY_STREAM_CONTEXT))
+
+/**
+ * Inner Stream
+ */
+#define pthreads_get_inner_stream(threaded_stream) \
+	((pthreads_stream_t*) pthreads_stream_read_threaded_property((threaded_stream), PTHREADS_STREAM_STORAGE_KEY_STREAM_INNERSTREAM))
+
+#define pthreads_set_inner_stream(threaded_stream, threaded_innerstream) \
+	(pthreads_stream_write_threaded_property((threaded_stream), PTHREADS_STREAM_STORAGE_KEY_STREAM_INNERSTREAM, (threaded_innerstream)))
+
+/**
+ * Parent Stream
+ */
+#define pthreads_get_parent_stream(threaded_stream) \
+	((pthreads_stream_t*) pthreads_stream_read_threaded_property((threaded_stream), PTHREADS_STREAM_STORAGE_KEY_STREAM_PARENT))
+
+#define pthreads_set_parent_stream(threaded_stream, threaded_parent_stream) \
+	(pthreads_stream_write_threaded_property((threaded_stream), PTHREADS_STREAM_STORAGE_KEY_STREAM_PARENT, (threaded_parent_stream)))
+
+/**
+ * Chain
+ */
+#define pthreads_chain_has_head(threaded_chain) \
+	(pthreads_stream_has_threaded_property((threaded_chain), PTHREADS_STREAM_STORAGE_KEY_CHAIN_HEAD))
+
+#define pthreads_chain_get_head(threaded_chain) \
+	((pthreads_stream_filter_t*) pthreads_stream_read_threaded_property((threaded_chain), PTHREADS_STREAM_STORAGE_KEY_CHAIN_HEAD))
+
+#define pthreads_chain_set_head(threaded_chain, threaded_filter) \
+	(pthreads_stream_write_threaded_property((threaded_chain), PTHREADS_STREAM_STORAGE_KEY_CHAIN_HEAD, (threaded_filter)))
+
+#define pthreads_chain_has_tail(threaded_chain) \
+	(pthreads_stream_has_threaded_property((threaded_chain), PTHREADS_STREAM_STORAGE_KEY_CHAIN_TAIL))
+
+#define pthreads_chain_get_tail(threaded_chain) \
+	((pthreads_stream_filter_t*) pthreads_stream_read_threaded_property((threaded_chain), PTHREADS_STREAM_STORAGE_KEY_CHAIN_TAIL))
+
+#define pthreads_chain_set_tail(threaded_chain, threaded_filter) \
+	(pthreads_stream_write_threaded_property((threaded_chain), PTHREADS_STREAM_STORAGE_KEY_CHAIN_TAIL, (threaded_filter)))
+
+#define pthreads_chain_num_elements(threaded_chain) \
+	(pthreads_stream_count_threaded_properties((threaded_chain)))
+
+#define pthreads_chain_get_stream(threaded_chain) \
+	((pthreads_stream_filter_t*) pthreads_stream_read_threaded_property((threaded_chain), PTHREADS_STREAM_STORAGE_KEY_CHAIN_STREAM))
+
+#define pthreads_chain_set_stream(threaded_chain, threaded_stream) \
+	(pthreads_stream_write_threaded_property((threaded_chain), PTHREADS_STREAM_STORAGE_KEY_CHAIN_STREAM, (threaded_stream)))
+
+
+/**
+ * Filter
+ */
+#define pthreads_filter_get_next(threaded_filter) \
+	((pthreads_stream_filter_t*) pthreads_stream_read_threaded_property((threaded_filter), PTHREADS_STREAM_STORAGE_KEY_FILTER_NEXT))
+
+#define pthreads_filter_set_next(threaded_filter, threaded_next_filter) \
+	(pthreads_stream_write_threaded_property((threaded_filter), PTHREADS_STREAM_STORAGE_KEY_FILTER_NEXT, (threaded_next_filter)))
+
+#define pthreads_filter_get_prev(threaded_filter) \
+	((pthreads_stream_filter_t*) pthreads_stream_read_threaded_property((threaded_filter), PTHREADS_STREAM_STORAGE_KEY_FILTER_PREV))
+
+#define pthreads_filter_set_prev(threaded_filter, threaded_prev_filter) \
+	(pthreads_stream_write_threaded_property((threaded_filter), PTHREADS_STREAM_STORAGE_KEY_FILTER_PREV, (threaded_prev_filter)))
+
+#define pthreads_filter_has_chain(threaded_filter) \
+	(pthreads_stream_has_threaded_property((threaded_filter), PTHREADS_STREAM_STORAGE_KEY_FILTER_CHAIN))
+
+#define pthreads_filter_get_chain(threaded_filter) \
+	((pthreads_stream_filter_chain_t*) pthreads_stream_read_threaded_property((threaded_filter), PTHREADS_STREAM_STORAGE_KEY_FILTER_CHAIN))
+
+#define pthreads_filter_set_chain(threaded_filter, threaded_chain) \
+	(pthreads_stream_write_threaded_property((threaded_filter), PTHREADS_STREAM_STORAGE_KEY_FILTER_CHAIN, (threaded_chain)))
+
+
+void pthreads_init_streams();
+void pthreads_shutdown_streams();
+
+zend_bool stream_lock(pthreads_stream_t *threaded_stream);
+#define stream_unlock(threaded_stream) \
+	(MONITOR_UNLOCK(threaded_stream))
+
+pthreads_stream_t *_pthreads_stream_new(const pthreads_stream_ops *ops, void *abstract, const char *mode, zend_class_entry *stream_ce);
+#define PTHREADS_STREAM_NEW(ops, abstract, mode) _pthreads_stream_new((ops), (abstract), (mode), pthreads_stream_entry)
+#define PTHREADS_STREAM_CLASS_NEW(ops, abstract, mode, ce) _pthreads_stream_new((ops), (abstract), (mode), (ce))
+pthreads_stream_filter_t *pthreads_stream_filter_new(const pthreads_stream_filter_ops *fops, void *abstract);
+pthreads_stream_filter_t *pthreads_stream_filter_init();
+pthreads_stream_bucket_t *pthreads_stream_bucket_new(char *buf, size_t buflen);
+pthreads_stream_bucket_t *pthreads_stream_bucket_init();
+pthreads_stream_bucket_brigade_t *pthreads_stream_bucket_brigade_new();
+pthreads_stream_wrapper_t *pthreads_stream_wrapper_new();
+pthreads_stream_context_t *pthreads_stream_context_new();
+
+int pthreads_stream_has_threaded_property(pthreads_object_t *threaded, int property);
+int pthreads_stream_count_threaded_properties(pthreads_object_t *threaded);
+pthreads_object_t *pthreads_stream_read_threaded_property(pthreads_object_t *threaded, int property);
+int pthreads_stream_write_threaded_property(pthreads_object_t *threaded, int property, pthreads_object_t *val);
+int pthreads_stream_delete_threaded_property(pthreads_object_t *threaded, int property);
+
+int pthreads_streams_aquire_double_lock(pthreads_object_t *object_one, pthreads_object_t *object_two);
+void pthreads_streams_release_double_lock(pthreads_object_t *object_one, pthreads_object_t *object_two);
+
+/* state definitions when closing down; these are private to streams.c */
+#define PTHREADS_STREAM_FCLOSE_NONE 0
+#define PTHREADS_STREAM_FCLOSE_FDOPEN	1
+#define PTHREADS_STREAM_FCLOSE_FOPENCOOKIE 2
+
+
+/* allocate a new stream for a particular ops */
+
+/* Threaded streams container */
+pthreads_streams_t* pthreads_streams_alloc(void);
+void pthreads_streams_free(pthreads_streams_t *streams);
+
+/* Plain stream object */
+pthreads_stream *_pthreads_stream_alloc(const pthreads_stream_ops *ops, void *abstract, const char *mode);
+
+#define pthreads_stream_alloc(ops, thisptr, mode)	_pthreads_stream_alloc((ops), (thisptr), (mode))
+
+/* use this to assign the stream to a zval and tell the stream that is
+ * has been exported to the engine; it will expect to be closed automatically
+ * when the resources are auto-destructed */
+#define pthreads_stream_to_zval(threaded_stream, zval)	{ ZVAL_OBJ(zval, PTHREADS_STD_P((threaded_stream))); }
+
+pthreads_stream_t *pthreads_stream_set_parent(pthreads_stream_t *threaded_target, pthreads_stream_t *threaded_parent);
+#define pthreads_stream_close_ignore_parent(threaded_stream_enclosed, close_options) _pthreads_stream_close_ignore_parent((threaded_stream_enclosed), (close_options))
+int _pthreads_stream_close_ignore_parent(pthreads_stream_t *threaded_stream_enclosed, int close_options);
+
+#define PTHREADS_STREAM_FREE_CALL_DTOR			1 /* call ops->close */
+#define PTHREADS_STREAM_FREE_PRESERVE_HANDLE	4 /* tell ops->close to not close it's underlying handle */
+#define PTHREADS_STREAM_FREE_IGNORE_PARENT		8 /* don't close the enclosing stream instead */
+#define PTHREADS_STREAM_FREE_CLOSE				(PTHREADS_STREAM_FREE_CALL_DTOR)
+#define PTHREADS_STREAM_FREE_CLOSE_CASTED		(PTHREADS_STREAM_FREE_CLOSE | PTHREADS_STREAM_FREE_PRESERVE_HANDLE)
+
+void _pthreads_stream_free(pthreads_stream_t *threaded_stream);
+#define pthreads_stream_free(threaded_stream)	_pthreads_stream_free((threaded_stream))
+int _pthreads_stream_close(pthreads_stream_t *threaded_stream, int close_options, int skip_check);
+#define pthreads_stream_close(threaded_stream, close_options)	_pthreads_stream_close((threaded_stream), (close_options), 0) // PTHREADS_STREAM_FREE_CLOSE
+#define pthreads_stream_close_unsafe(threaded_stream, close_options)	_pthreads_stream_close((threaded_stream), (close_options), 1)
+
+int _pthreads_stream_seek(pthreads_stream_t *threaded_stream, zend_off_t offset, int whence);
+#define pthreads_stream_rewind(threaded_stream)	_pthreads_stream_seek((threaded_stream), 0L, SEEK_SET)
+#define pthreads_stream_seek(threaded_stream, offset, whence)	_pthreads_stream_seek((threaded_stream), (offset), (whence))
+
+zend_off_t _pthreads_stream_tell(pthreads_stream_t *threaded_stream);
+#define pthreads_stream_tell(threaded_stream)	_pthreads_stream_tell((threaded_stream))
+
+size_t _pthreads_stream_read(pthreads_stream_t *threaded_stream, char *buf, size_t count);
+#define pthreads_stream_read(threaded_stream, buf, count)	_pthreads_stream_read((threaded_stream), (buf), (count))
+
+size_t _pthreads_stream_write(pthreads_stream_t *threaded_stream, const char *buf, size_t count);
+#define pthreads_stream_write_string(threaded_stream, str)	_pthreads_stream_write(threaded_stream, str, strlen(str))
+#define pthreads_stream_write(threaded_stream, buf, count)	_pthreads_stream_write(threaded_stream, (buf), (count))
+
+void _pthreads_stream_fill_read_buffer(pthreads_stream_t *threaded_stream, size_t size);
+#define pthreads_stream_fill_read_buffer(threaded_stream, size)	_pthreads_stream_fill_read_buffer((threaded_stream), (size))
+
+size_t _pthreads_stream_printf(pthreads_stream_t *threaded_stream, const char *fmt, ...) PHP_ATTRIBUTE_FORMAT(printf, 2, 3);
+
+/* pthreads_stream_printf macro & function require */
+#define pthreads_stream_printf _pthreads_stream_printf
+
+int _pthreads_stream_eof(pthreads_stream_t *threaded_stream);
+#define pthreads_stream_eof(threaded_stream)	_pthreads_stream_eof((threaded_stream))
+
+int _pthreads_stream_getc(pthreads_stream_t *threaded_stream);
+#define pthreads_stream_getc(threaded_stream)	_pthreads_stream_getc((threaded_stream))
+
+int _pthreads_stream_putc(pthreads_stream_t *threaded_stream, int c);
+#define pthreads_stream_putc(threaded_stream, c)	_pthreads_stream_putc((threaded_stream), (c))
+
+int _pthreads_stream_flush(pthreads_stream_t *threaded_stream, int closing);
+#define pthreads_stream_flush(threaded_stream)	_pthreads_stream_flush((threaded_stream), 0)
+
+char *_pthreads_stream_get_line(pthreads_stream_t *threaded_stream, char *buf, size_t maxlen, size_t *returned_len);
+#define pthreads_stream_gets(threaded_stream, buf, maxlen)	_pthreads_stream_get_line((threaded_stream), (buf), (maxlen), NULL)
+
+#define pthreads_stream_get_line(threaded_stream, buf, maxlen, retlen) _pthreads_stream_get_line((threaded_stream), (buf), (maxlen), (retlen))
+zend_string *pthreads_stream_get_record(pthreads_stream_t *threaded_stream, size_t maxlen, const char *delim, size_t delim_len);
+
+/* CAREFUL! this is equivalent to puts NOT fputs! */
+int _pthreads_stream_puts(pthreads_stream_t *threaded_stream, const char *buf);
+#define pthreads_stream_puts(threaded_stream, buf)	_pthreads_stream_puts((threaded_stream), (buf))
+
+int _pthreads_stream_stat(pthreads_stream_t *threaded_stream, pthreads_stream_statbuf *ssb);
+#define pthreads_stream_stat(threaded_stream, ssb)	_pthreads_stream_stat((threaded_stream), (ssb))
+
+#define pthreads_stream_closedir(threaded_dirstream)	pthreads_stream_close((threaded_dirstream), PTHREADS_STREAM_FREE_CLOSE)
+#define pthreads_stream_rewinddir(threaded_dirstream)	pthreads_stream_rewind((threaded_dirstream))
+
+int pthreads_stream_dirent_alphasort(const zend_string **a, const zend_string **b);
+int pthreads_stream_dirent_alphasortr(const zend_string **a, const zend_string **b);
+
+int _pthreads_stream_scandir(const char *dirname, zend_string **namelist[], int flags, pthreads_stream_context_t *threaded_context,
+			int (*compare) (const zend_string **a, const zend_string **b));
+#define pthreads_stream_scandir(dirname, namelist, threaded_context, compare) _pthreads_stream_scandir((dirname), (namelist), 0, (threaded_context), (compare))
+
+int _pthreads_stream_set_option(pthreads_stream_t *threaded_stream, int option, int value, void *ptrparam);
+#define pthreads_stream_set_option(threaded_stream, option, value, ptrvalue)	_pthreads_stream_set_option((threaded_stream), (option), (value), (ptrvalue))
+
+#define pthreads_stream_set_chunk_size(threaded_stream, size) _pthreads_stream_set_option((threaded_stream), PTHREADS_STREAM_OPTION_SET_CHUNK_SIZE, (size), NULL)
+
+/* Flags for mkdir method in wrapper ops */
+#define PTHREADS_STREAM_MKDIR_RECURSIVE		1
+/* define REPORT ERRORS 8 (below) */
+
+/* Flags for rmdir method in wrapper ops */
+/* define REPORT_ERRORS 8 (below) */
+
+/* Flags for url_stat method in wrapper ops */
+#define PTHREADS_STREAM_URL_STAT_LINK		1
+#define PTHREADS_STREAM_URL_STAT_QUIET		2
+#define PTHREADS_STREAM_URL_STAT_NOCACHE	4
+
+/* change the blocking mode of stream: value == 1 => blocking, value == 0 => non-blocking. */
+#define PTHREADS_STREAM_OPTION_BLOCKING	1
+
+/* change the buffering mode of stream. value is a PTHREADS_STREAM_BUFFER_XXXX value, ptrparam is a ptr to a size_t holding
+ * the required buffer size */
+#define PTHREADS_STREAM_OPTION_READ_BUFFER	2
+#define PTHREADS_STREAM_OPTION_WRITE_BUFFER	3
+
+#define PTHREADS_STREAM_BUFFER_NONE	0	/* unbuffered */
+#define PTHREADS_STREAM_BUFFER_LINE	1	/* line buffered */
+#define PTHREADS_STREAM_BUFFER_FULL	2	/* fully buffered */
+
+/* whether or not locking is supported */
+#define PTHREADS_STREAM_LOCK_SUPPORTED			1
+
+/* set the timeout duration for reads on the stream. ptrparam is a pointer to a struct timeval * */
+#define PTHREADS_STREAM_OPTION_READ_TIMEOUT		4
+#define PTHREADS_STREAM_OPTION_SET_CHUNK_SIZE	5
+
+/* set or release lock on a stream */
+#define PTHREADS_STREAM_OPTION_LOCKING			6
+
+#define pthreads_stream_supports_lock(threaded_stream)	(_pthreads_stream_set_option((threaded_stream), PTHREADS_STREAM_OPTION_LOCKING, 0, (void *) PTHREADS_STREAM_LOCK_SUPPORTED) == 0 ? 1 : 0)
+#define pthreads_stream_lock(threaded_stream, mode)		_pthreads_stream_set_option((threaded_stream), PTHREADS_STREAM_OPTION_LOCKING, (mode), (void *) NULL)
+
+/* option code used by the pthreads_stream_xport_XXX api */
+#define PTHREADS_STREAM_OPTION_XPORT_API			7 /* see transport.h */
+#define PTHREADS_STREAM_OPTION_CRYPTO_API		8 /* see transport.h */
+#define PTHREADS_STREAM_OPTION_MMAP_API			9 /* see mmap.h */
+#define PTHREADS_STREAM_OPTION_TRUNCATE_API		10
+#define PTHREADS_STREAM_OPTION_META_DATA_API	11 /* ptrparam is a zval* to which to add meta data information */
+
+/* Check if the stream is still "live"; for sockets/pipes this means the socket
+ * is still connected; for files, this does not really have meaning */
+#define PTHREADS_STREAM_OPTION_CHECK_LIVENESS	12 /* no parameters */
+
+/* Enable/disable blocking reads on anonymous pipes on Windows. */
+#define PTHREADS_STREAM_OPTION_PIPE_BLOCKING	13
+
+#define PTHREADS_STREAM_TRUNCATE_SUPPORTED		0
+#define PTHREADS_STREAM_TRUNCATE_SET_SIZE		1	/* ptrparam is a pointer to a size_t */
+
+#define PTHREADS_STREAM_OPTION_RETURN_OK		 0 /* option set OK */
+#define PTHREADS_STREAM_OPTION_RETURN_ERR		-1 /* problem setting option */
+#define PTHREADS_STREAM_OPTION_RETURN_NOTIMPL	-2 /* underlying stream does not implement; streams can handle it instead */
+
+#define pthreads_stream_truncate_supported(threaded_stream)	(_pthreads_stream_set_option((threaded_stream), PTHREADS_STREAM_OPTION_TRUNCATE_API, PTHREADS_STREAM_TRUNCATE_SUPPORTED, NULL) == PTHREADS_STREAM_OPTION_RETURN_OK ? 1 : 0)
+
+
+int _pthreads_stream_truncate_set_size(pthreads_stream_t *threaded_stream, size_t newsize);
+#define pthreads_stream_truncate_set_size(threaded_stream, size)	_pthreads_stream_truncate_set_size((threaded_stream), (size))
+
+#define pthreads_stream_populate_meta_data(threaded_stream, zv)	(_pthreads_stream_set_option((threaded_stream), PTHREADS_STREAM_OPTION_META_DATA_API, 0, zv) == PTHREADS_STREAM_OPTION_RETURN_OK ? 1 : 0)
+
+/* copy up to maxlen bytes from src to dest.  If maxlen is PTHREADS_STREAM_COPY_ALL, copy until eof(src). */
+#define PTHREADS_STREAM_COPY_ALL	((size_t)-1)
+
+/* output all data from a stream */
+PHPAPI size_t _pthreads_stream_passthru(pthreads_stream_t * threaded_src);
+#define pthreads_stream_passthru(threaded_stream)	_pthreads_stream_passthru((threaded_stream))
+
+/* read all data from stream and put into a buffer. Caller must free buffer when done. */
+zend_string *_pthreads_stream_copy_to_mem(pthreads_stream_t *threaded_src, size_t maxlen, int persistent);
+#define pthreads_stream_copy_to_mem(threaded_src, maxlen, persistent) _pthreads_stream_copy_to_mem((threaded_src), (maxlen), (persistent))
+
+int _pthreads_stream_copy_to_stream_ex(pthreads_stream_t *threaded_src, pthreads_stream_t *threaded_dest, size_t maxlen, size_t *len);
+#define pthreads_stream_copy_to_stream_ex(threaded_src, threaded_dest, maxlen, len)	_pthreads_stream_copy_to_stream_ex((threaded_src), (threaded_dest), (maxlen), (len))
+
+#ifndef HAVE_PTHREADS_STREAMS_TRANSPORTS_H
+#	include <src/streams/transports.h>
+#endif
+
+#ifndef HAVE_PTHREADS_STREAMS_WRAPPERS_PLAIN_WRAPPER_H
+#	include <src/streams/wrappers/plain_wrapper.h>
+#endif
+
+#ifndef HAVE_PTHREADS_STREAMS_WRAPPERS_GLOB_WRAPPER_H
+#	include <src/streams/wrappers/glob_wrapper.h>
+#endif
+
+#ifndef HAVE_PTHREADS_STREAMS_WRAPPERS_USER_WRAPPER_H
+#	include <src/streams/wrappers/user_wrapper.h>
+#endif
+
+#ifndef HAVE_PTHREADS_STREAMS_MMAP_H
+#	include <src/streams/mmap.h>
+#endif
+
+#ifndef HAVE_PTHREADS_STREAMS_BUCKETS_H
+#	include <src/streams/buckets.h>
+#endif
+
+/* coerce the stream into some other form */
+/* cast as a stdio FILE * */
+#define PTHREADS_STREAM_AS_STDIO     0
+/* cast as a POSIX fd or socketd */
+#define PTHREADS_STREAM_AS_FD		1
+/* cast as a socketd */
+#define PTHREADS_STREAM_AS_SOCKETD	2
+/* cast as fd/socket for select purposes */
+#define PTHREADS_STREAM_AS_FD_FOR_SELECT 3
+
+/* try really, really hard to make sure the cast happens (avoid using this flag if possible) */
+#define PTHREADS_STREAM_CAST_TRY_HARD	0x80000000
+#define PTHREADS_STREAM_CAST_RELEASE	0x40000000	/* stream becomes invalid on success */
+#define PTHREADS_STREAM_CAST_INTERNAL	0x20000000	/* stream cast for internal use */
+#define PTHREADS_STREAM_CAST_MASK		(PTHREADS_STREAM_CAST_TRY_HARD | PTHREADS_STREAM_CAST_RELEASE | PTHREADS_STREAM_CAST_INTERNAL)
+
+int _pthreads_stream_cast(pthreads_stream_t *threaded_stream, int castas, void **ret, int show_err);
+
+/* use this to check if a stream can be cast into another form */
+#define pthreads_stream_can_cast(threaded_stream, as)	_pthreads_stream_cast((threaded_stream), (as), NULL, 0)
+#define pthreads_stream_cast(threaded_stream, as, ret, show_err)	_pthreads_stream_cast((threaded_stream), (as), (ret), (show_err))
+
+/* use this to check if a stream is of a particular type:
+ * int pthreads_stream_is(pthreads_stream_t *threaded_stream, pthreads_stream_ops *ops); */
+#define pthreads_stream_is(threaded_stream, anops)		(PTHREADS_FETCH_STREAMS_STREAM((threaded_stream))->ops == anops)
+#define PTHREADS_STREAM_IS_STDIO &pthreads_stream_stdio_ops
+
+/* Wrappers support */
+
+#define PTHREADS_IGNORE_PATH                     0x00000000
+#define PTHREADS_USE_PATH                        0x00000001
+#define PTHREADS_IGNORE_URL                      0x00000002
+#define PTHREADS_REPORT_ERRORS                   0x00000008
+
+/* If you don't need to write to the stream, but really need to
+ * be able to seek, use this flag in your options. */
+#define PTHREADS_STREAM_MUST_SEEK                0x00000010
+/* If you are going to end up casting the stream into a FILE* or
+ * a socket, pass this flag and the streams/wrappers will not use
+ * buffering mechanisms while reading the headers, so that HTTP
+ * wrapped streams will work consistently.
+ * If you omit this flag, streams will use buffering and should end
+ * up working more optimally.
+ * */
+#define PTHREADS_STREAM_WILL_CAST                0x00000020
+
+/* this flag applies to pthreads_stream_locate_url_wrapper */
+#define PTHREADS_STREAM_LOCATE_WRAPPERS_ONLY     0x00000040
+
+/* this flag is only used by include/require functions */
+#define PTHREADS_STREAM_OPEN_FOR_INCLUDE         0x00000080
+
+/* this flag tells streams to ONLY open urls */
+#define PTHREADS_STREAM_USE_URL                  0x00000100
+
+/* this flag is used when only the headers from HTTP request are to be fetched */
+#define PTHREADS_STREAM_ONLY_GET_HEADERS         0x00000200
+
+/* don't apply open_basedir checks */
+#define PTHREADS_STREAM_DISABLE_OPEN_BASEDIR     0x00000400
+
+/* get (or create) a persistent version of the stream */
+#define PTHREADS_STREAM_OPEN_PERSISTENT          0x00000800
+
+/* use glob stream for directory open in plain files stream */
+#define PTHREADS_STREAM_USE_GLOB_DIR_OPEN        0x00001000
+
+/* don't check allow_url_fopen and allow_url_include */
+#define PTHREADS_STREAM_DISABLE_URL_PROTECTION   0x00002000
+
+/* assume the path passed in exists and is fully expanded, avoiding syscalls */
+#define PTHREADS_STREAM_ASSUME_REALPATH          0x00004000
+
+/* Allow blocking reads on anonymous pipes on Windows. */
+#define PTHREADS_STREAM_USE_BLOCKING_PIPE        0x00008000
+
+const char *pthreads_stream_locate_eol(pthreads_stream_t *threaded_stream, zend_string *buf);
+
+#define PTHREADS_STREAM_UNCHANGED			0 /* orig stream was seekable anyway */
+#define PTHREADS_STREAM_RELEASED			1 /* newstream should be used; origstream is no longer valid */
+#define PTHREADS_STREAM_FAILED				2 /* an error occurred while attempting conversion */
+#define PTHREADS_STREAM_CRITICAL			3 /* an error occurred; origstream is in an unknown state; you should close origstream */
+#define PTHREADS_STREAM_NO_PREFERENCE		0
+#define PTHREADS_STREAM_PREFER_STDIO		1
+#define PTHREADS_STREAM_FORCE_CONVERSION	2
+
+/* DO NOT call this on streams that are referenced by resources! */
+int _pthreads_stream_make_seekable(pthreads_stream_t *threaded_origstream, pthreads_stream_t **threaded_newstream, int flags);
+#define pthreads_stream_make_seekable(threaded_origstream, threaded_newstream, flags)	_pthreads_stream_make_seekable((threaded_origstream), (threaded_newstream), (flags))
+
+/* Give other modules access to the url_stream_wrappers_hash and stream_filters_hash */
+pthreads_hashtable *_pthreads_stream_get_url_stream_wrappers_hash(void);
+#define pthreads_stream_get_url_stream_wrappers_hash()	_pthreads_stream_get_url_stream_wrappers_hash()
+
+/* Definitions for user streams */
+#define PTHREADS_STREAM_IS_URL		1
+
+/* Stream metadata definitions */
+/* Create if referred resource does not exist */
+#define PTHREADS_STREAM_META_TOUCH		1
+#define PTHREADS_STREAM_META_OWNER_NAME	2
+#define PTHREADS_STREAM_META_OWNER		3
+#define PTHREADS_STREAM_META_GROUP_NAME	4
+#define PTHREADS_STREAM_META_GROUP		5
+#define PTHREADS_STREAM_META_ACCESS		6
+
+/* Flags for stream_socket_client */
+#define PTHREADS_STREAM_CLIENT_ASYNC_CONNECT	2
+#define PTHREADS_STREAM_CLIENT_CONNECT			4
+
+#endif

--- a/src/streams/buckets.c
+++ b/src/streams/buckets.c
@@ -1,0 +1,210 @@
+/*
+  +----------------------------------------------------------------------+
+  | pthreads                                                             |
+  +----------------------------------------------------------------------+
+  | Copyright (c) Joe Watkins 2018                                       |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | http://www.php.net/license/3_01.txt                                  |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors: Bastian Schneider <b.schneider@badnoob.com>                 |
+  | Borrowed code from php-src                                           |
+  +----------------------------------------------------------------------+
+ */
+#ifndef HAVE_PTHREADS_STREAMS_BUCKETS
+#define HAVE_PTHREADS_STREAMS_BUCKETS
+
+#ifndef HAVE_PTHREADS_H
+#	include <src/pthreads.h>
+#endif
+
+#ifndef HAVE_PTHREADS_STREAM_H
+#	include <src/streams.h>
+#endif
+
+#ifndef HAVE_PTHREADS_STREAMS_BUCKETS_H
+#	include <src/streams/buckets.h>
+#endif
+
+pthreads_stream_bucket_brigade *pthreads_stream_bucket_brigade_alloc() {
+	pthreads_stream_bucket_brigade *brigade;
+
+	brigade = (pthreads_stream_bucket_brigade*)malloc(sizeof(pthreads_stream_bucket_brigade));
+	brigade->head = brigade->tail = NULL;
+
+	return brigade;
+}
+
+void pthreads_stream_bucket_brigade_free(pthreads_stream_bucket_brigade *brigade) {
+	free(brigade);
+}
+
+pthreads_stream_bucket *pthreads_stream_bucket_alloc(char *buf, size_t buflen) {
+	pthreads_stream_bucket *bucket;
+
+	bucket = (pthreads_stream_bucket*)malloc(sizeof(pthreads_stream_bucket));
+	bucket->next = bucket->prev = NULL;
+
+	/* all data in a persistent bucket must also be persistent */
+	bucket->buf = malloc(buflen);
+	memcpy(bucket->buf, buf, buflen);
+	bucket->buflen = buflen;
+	bucket->brigade = NULL;
+
+	return bucket;
+}
+
+void pthreads_stream_bucket_free(pthreads_stream_bucket *bucket) {
+	if (bucket->buf) {
+		free(bucket->buf);
+	}
+	free(bucket);
+}
+
+void pthreads_stream_bucket_sync_properties(pthreads_stream_bucket_t *threaded_bucket) {
+	pthreads_stream_bucket *bucket = PTHREADS_FETCH_STREAMS_BUCKET(threaded_bucket);
+	zval *pzdata;
+	zval rv, obj;
+
+	ZVAL_NULL(&rv);
+
+	if(MONITOR_LOCK(threaded_bucket)) {
+		ZVAL_OBJ(&obj, PTHREADS_STD_P(threaded_bucket));
+
+		pzdata = zend_read_property(NULL, &obj, PTHREADS_STREAM_BUCKET_PROP_DATA, strlen(PTHREADS_STREAM_BUCKET_PROP_DATA), 1, &rv);
+
+		if (Z_TYPE_P(pzdata) == IS_STRING) {
+			if(bucket->buflen != Z_STRLEN_P(pzdata)) {
+				bucket->buf = realloc(bucket->buf, Z_STRLEN_P(pzdata));
+				bucket->buflen = Z_STRLEN_P(pzdata);
+			}
+			memcpy(bucket->buf, Z_STRVAL_P(pzdata), bucket->buflen);
+		}
+		zval_ptr_dtor(pzdata);
+
+		MONITOR_UNLOCK(threaded_bucket);
+	}
+}
+
+pthreads_stream_bucket *pthreads_stream_bucket_fetch(pthreads_stream_bucket_t *threaded_bucket) {
+	pthreads_stream_bucket_unlink(threaded_bucket);
+	return PTHREADS_FETCH_STREAMS_BUCKET(threaded_bucket);
+}
+
+void pthreads_stream_bucket_prepend(pthreads_stream_bucket_brigade_t *threaded_brigade, pthreads_stream_bucket_t *threaded_bucket, int separate) {
+	pthreads_stream_bucket_brigade *brigade = PTHREADS_FETCH_STREAMS_BRIGADE(threaded_brigade);
+	pthreads_stream_bucket *bucket = PTHREADS_FETCH_STREAMS_BUCKET(threaded_bucket);
+	pthreads_stream_bucket *head = NULL;
+
+	if(pthreads_streams_aquire_double_lock(threaded_bucket, threaded_brigade)) {
+		if(bucket->brigade != NULL) {
+			if(separate) {
+				pthreads_stream_bucket_sync_properties(threaded_bucket);
+				pthreads_stream_bucket_prepend(threaded_brigade, pthreads_stream_bucket_new(bucket->buf, bucket->buflen), 0);
+			} else {
+				php_error_docref(NULL, E_WARNING, "StreamBucket already part of any StreamBucketBrigade");
+			}
+			pthreads_streams_release_double_lock(threaded_bucket, threaded_brigade);
+			return;
+		}
+		bucket->next = brigade->head;
+		bucket->prev = NULL;
+
+		if(brigade->head != NULL) {
+			head = PTHREADS_FETCH_STREAMS_BUCKET(brigade->head);
+		}
+
+		if (head) {
+			head->prev = threaded_bucket;
+		} else {
+			brigade->tail = threaded_bucket;
+		}
+		pthreads_add_ref(threaded_bucket);
+
+		brigade->head = threaded_bucket;
+		bucket->brigade = threaded_brigade;
+
+		pthreads_streams_release_double_lock(threaded_bucket, threaded_brigade);
+	}
+}
+
+void pthreads_stream_bucket_append(pthreads_stream_bucket_brigade_t *threaded_brigade, pthreads_stream_bucket_t *threaded_bucket, int separate) {
+	pthreads_stream_bucket_brigade *brigade = PTHREADS_FETCH_STREAMS_BRIGADE(threaded_brigade);
+	pthreads_stream_bucket *bucket = PTHREADS_FETCH_STREAMS_BUCKET(threaded_bucket);
+	pthreads_stream_bucket *tail = NULL;
+	pthreads_stream_bucket_t *threaded_tail;
+
+	if(pthreads_streams_aquire_double_lock(threaded_bucket, threaded_brigade)) {
+		if(bucket->brigade != NULL || brigade->tail == threaded_bucket) {
+			if(separate) {
+				pthreads_stream_bucket_sync_properties(threaded_bucket);
+				pthreads_stream_bucket_append(threaded_brigade, pthreads_stream_bucket_new(bucket->buf, bucket->buflen), 0);
+			} else {
+				php_error_docref(NULL, E_WARNING, "StreamBucket already part of any StreamBucketBrigade");
+			}
+			pthreads_streams_release_double_lock(threaded_bucket, threaded_brigade);
+			return;
+		}
+		bucket->prev = brigade->tail;
+		bucket->next = NULL;
+
+		if(brigade->tail != NULL) {
+			tail = PTHREADS_FETCH_STREAMS_BUCKET(brigade->tail);
+		}
+
+		if (tail) {
+			tail->next = threaded_bucket;
+		} else {
+			brigade->head = threaded_bucket;
+		}
+		pthreads_add_ref(threaded_bucket);
+
+		brigade->tail = threaded_bucket;
+		bucket->brigade = threaded_brigade;
+
+		pthreads_streams_release_double_lock(threaded_bucket, threaded_brigade);
+	}
+}
+
+void pthreads_stream_bucket_unlink(pthreads_stream_bucket_t *threaded_bucket) {
+	pthreads_stream_bucket *bucket = PTHREADS_FETCH_STREAMS_BUCKET(threaded_bucket);
+	pthreads_stream_bucket_brigade_t *threaded_brigade = bucket->brigade;
+
+	if(pthreads_streams_aquire_double_lock(threaded_bucket, threaded_brigade)) {
+		if (bucket->prev) {
+			PTHREADS_FETCH_STREAMS_BUCKET(bucket->prev)->next = bucket->next;
+		} else if (bucket->brigade) {
+			PTHREADS_FETCH_STREAMS_BRIGADE(bucket->brigade)->head = bucket->next;
+		}
+		if (bucket->next) {
+			PTHREADS_FETCH_STREAMS_BUCKET(bucket->next)->prev = bucket->prev;
+		} else if (bucket->brigade) {
+			PTHREADS_FETCH_STREAMS_BRIGADE(bucket->brigade)->tail = bucket->prev;
+		}
+		bucket->brigade = NULL;
+		bucket->next = bucket->prev = NULL;
+
+		pthreads_streams_release_double_lock(threaded_bucket, threaded_brigade);
+
+		pthreads_del_ref(threaded_bucket);
+	}
+}
+
+void pthreads_stream_bucket_destroy(pthreads_stream_bucket_t *threaded_bucket) {
+	zval obj;
+	ZVAL_OBJ(&obj, PTHREADS_STD_P(threaded_bucket));
+
+	zend_unset_property(pthreads_volatile_entry, &obj, PTHREADS_STREAM_BUCKET_PROP_DATA, strlen(PTHREADS_STREAM_BUCKET_PROP_DATA));
+	zend_unset_property(pthreads_volatile_entry, &obj, PTHREADS_STREAM_BUCKET_PROP_DATALEN, strlen(PTHREADS_STREAM_BUCKET_PROP_DATALEN));
+
+	pthreads_stream_bucket_unlink(threaded_bucket);
+
+	pthreads_ptr_dtor(threaded_bucket);
+}
+
+#endif

--- a/src/streams/buckets.h
+++ b/src/streams/buckets.h
@@ -1,0 +1,51 @@
+/*
+  +----------------------------------------------------------------------+
+  | pthreads                                                             |
+  +----------------------------------------------------------------------+
+  | Copyright (c) Joe Watkins 2018                                       |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | http://www.php.net/license/3_01.txt                                  |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors: Bastian Schneider <b.schneider@badnoob.com>                 |
+  | Borrowed code from php-src                                           |
+  +----------------------------------------------------------------------+
+ */
+#ifndef HAVE_PTHREADS_STREAMS_BUCKETS_H
+#define HAVE_PTHREADS_STREAMS_BUCKETS_H
+
+#ifndef HAVE_PTHREADS_STREAMS_H
+#	include <src/streams.h>
+#endif
+
+struct _pthreads_stream_bucket {
+	pthreads_stream_bucket_t *next, *prev;
+	pthreads_stream_bucket_brigade_t *brigade;
+
+	char *buf;
+	size_t buflen;
+};
+
+struct _pthreads_stream_bucket_brigade {
+	pthreads_stream_bucket_t *head, *tail;
+};
+
+/* Buckets API. */
+pthreads_stream_bucket_brigade *pthreads_stream_bucket_brigade_alloc();
+void pthreads_stream_bucket_brigade_free(pthreads_stream_bucket_brigade *brigade);
+void pthreads_stream_bucket_sync_properties(pthreads_stream_bucket_t *threaded_bucket);
+pthreads_stream_bucket *pthreads_stream_bucket_alloc(char *buf, size_t buflen);
+void pthreads_stream_bucket_free(pthreads_stream_bucket *bucket);
+pthreads_stream_bucket *pthreads_stream_bucket_fetch(pthreads_stream_bucket_t *threaded_bucket);
+
+void pthreads_stream_bucket_prepend(pthreads_stream_bucket_brigade_t *threaded_brigade, pthreads_stream_bucket_t *threaded_bucket, int separate);
+void pthreads_stream_bucket_append(pthreads_stream_bucket_brigade_t *threaded_brigade, pthreads_stream_bucket_t *threaded_bucket, int separate);
+void pthreads_stream_bucket_unlink(pthreads_stream_bucket_t *threaded_bucket);
+void pthreads_stream_bucket_destroy(pthreads_stream_bucket_t *threaded_bucket);
+
+#endif

--- a/src/streams/cast.c
+++ b/src/streams/cast.c
@@ -1,0 +1,418 @@
+/*
+  +----------------------------------------------------------------------+
+  | pthreads                                                             |
+  +----------------------------------------------------------------------+
+  | Copyright (c) Joe Watkins 2018                                       |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | http://www.php.net/license/3_01.txt                                  |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors: Bastian Schneider <b.schneider@badnoob.com>                 |
+  | Borrowed code from php-src                                           |
+  +----------------------------------------------------------------------+
+ */
+#ifndef HAVE_PTHREADS_STREAMS_CAST
+#define HAVE_PTHREADS_STREAMS_CAST
+
+#ifndef HAVE_PTHREADS_H
+#	include <src/pthreads.h>
+#endif
+
+#ifndef HAVE_PTHREADS_STREAM_H
+#	include <src/streams.h>
+#endif
+
+#ifndef HAVE_PTHREADS_STREAMS_MEMORY_H
+#	include <src/streams/memory.h>
+#endif
+
+/* Under BSD, emulate fopencookie using funopen */
+#if defined(HAVE_FUNOPEN) && !defined(HAVE_PTHREADS_FOPENCOOKIE)
+
+/* NetBSD 6.0+ uses off_t instead of fpos_t in funopen */
+# if defined(__NetBSD__) && (__NetBSD_Version__ >= 600000000)
+#  define PHP_FPOS_T off_t
+# else
+#  define PHP_FPOS_T fpos_t
+# endif
+
+typedef struct {
+	int (*reader)(void *, char *, int);
+	int (*writer)(void *, const char *, int);
+	PHP_FPOS_T (*seeker)(void *, PHP_FPOS_T, int);
+	int (*closer)(void *);
+} COOKIE_IO_FUNCTIONS_T;
+
+FILE *fopencookie(void *cookie, const char *mode, COOKIE_IO_FUNCTIONS_T *funcs)
+{
+	return funopen(cookie, funcs->reader, funcs->writer, funcs->seeker, funcs->closer);
+}
+# define HAVE_PTHREADS_FOPENCOOKIE 1
+# define EMULATE_FOPENCOOKIE 1
+# define PHP_STREAM_COOKIE_FUNCTIONS	&stream_cookie_functions
+#elif defined(HAVE_PTHREADS_FOPENCOOKIE)
+# define PHP_STREAM_COOKIE_FUNCTIONS	stream_cookie_functions
+#endif
+
+/* {{{ STDIO with fopencookie */
+#if defined(EMULATE_FOPENCOOKIE)
+/* use our fopencookie emulation */
+static int pthreads_stream_cookie_reader(void *cookie, char *buffer, int size)
+{
+	int ret;
+
+	ret = pthreads_stream_read((pthreads_stream_t*)cookie, buffer, size);
+	return ret;
+}
+
+static int pthreads_stream_cookie_writer(void *cookie, const char *buffer, int size)
+{
+
+	return pthreads_stream_write((pthreads_stream_t *)cookie, (char *)buffer, size);
+}
+
+static PHP_FPOS_T pthreads_stream_cookie_seeker(void *cookie, zend_off_t position, int whence)
+{
+
+	return (PHP_FPOS_T)pthreads_stream_seek((pthreads_stream_t *)cookie, position, whence);
+}
+
+static int pthreads_stream_cookie_closer(void *cookie)
+{
+	pthreads_stream_t *threaded_stream = (pthreads_stream_t*)cookie;
+	pthreads_stream *stream = PTHREADS_FETCH_STREAMS_STREAM(threaded_stream);
+
+	/* prevent recursion */
+	stream->fclose_stdiocast = PTHREADS_STREAM_FCLOSE_NONE;
+	return pthreads_stream_close(threaded_stream, PTHREADS_STREAM_FREE_CLOSE);
+}
+#elif defined(HAVE_PTHREADS_FOPENCOOKIE)
+static ssize_t pthreads_stream_cookie_reader(void *cookie, char *buffer, size_t size)
+{
+	ssize_t ret;
+
+	ret = pthreads_stream_read(((pthreads_stream_t *)cookie), buffer, size);
+	return ret;
+}
+
+static ssize_t pthreads_stream_cookie_writer(void *cookie, const char *buffer, size_t size)
+{
+	return pthreads_stream_write(((pthreads_stream_t *)cookie), (char *)buffer, size);
+}
+
+# ifdef COOKIE_SEEKER_USES_OFF64_T
+static int pthreads_stream_cookie_seeker(void *cookie, __off64_t *position, int whence)
+{
+	*position = pthreads_stream_seek((pthreads_stream_t *)cookie, (zend_off_t)*position, whence);
+
+	if (*position == -1) {
+		return -1;
+	}
+	return 0;
+}
+# else
+static int pthreads_stream_cookie_seeker(void *cookie, zend_off_t position, int whence)
+{
+	return pthreads_stream_seek((pthreads_stream_t *)cookie, position, whence);
+}
+# endif
+
+static int pthreads_stream_cookie_closer(void *cookie)
+{
+	pthreads_stream_t *threaded_stream = (pthreads_stream_t *)cookie;
+	pthreads_stream *stream = PTHREADS_FETCH_STREAMS_STREAM(threaded_stream);
+
+	/* prevent recursion */
+	stream->fclose_stdiocast = PTHREADS_STREAM_FCLOSE_NONE;
+	return pthreads_stream_close_unsafe(threaded_stream, PTHREADS_STREAM_FREE_CLOSE);
+}
+#endif /* elif defined(HAVE_PTHREADS_FOPENCOOKIE) */
+
+#if HAVE_PTHREADS_FOPENCOOKIE
+static COOKIE_IO_FUNCTIONS_T stream_cookie_functions =
+{
+	pthreads_stream_cookie_reader, pthreads_stream_cookie_writer,
+	pthreads_stream_cookie_seeker, pthreads_stream_cookie_closer
+};
+#else
+/* TODO: use socketpair() to emulate fopencookie, as suggested by Hartmut ? */
+#endif
+/* }}} */
+
+/* {{{ pthreads_stream_mode_sanitize_fdopen_fopencookie
+ * Result should have at least size 5, e.g. to write wbx+\0 */
+void pthreads_stream_mode_sanitize_fdopen_fopencookie(pthreads_stream_t *threaded_stream, char *result) {
+	pthreads_stream *stream = PTHREADS_FETCH_STREAMS_STREAM(threaded_stream);
+
+	/* replace modes not supported by fdopen and fopencookie, but supported
+	 * by PHP's fread(), so that their calls won't fail */
+	const char *cur_mode = stream->mode;
+	int         has_plus = 0,
+		        has_bin  = 0,
+				i,
+				res_curs = 0;
+
+	if (cur_mode[0] == 'r' || cur_mode[0] == 'w' || cur_mode[0] == 'a') {
+		result[res_curs++] = cur_mode[0];
+	} else {
+		/* assume cur_mode[0] is 'c' or 'x'; substitute by 'w', which should not
+		 * truncate anything in fdopen/fopencookie */
+		result[res_curs++] = 'w';
+
+		/* x is allowed (at least by glibc & compat), but not as the 1st mode
+		 * as in PHP and in any case is (at best) ignored by fdopen and fopencookie */
+	}
+
+	/* assume current mode has at most length 4 (e.g. wbn+) */
+	for (i = 1; i < 4 && cur_mode[i] != '\0'; i++) {
+		if (cur_mode[i] == 'b') {
+			has_bin = 1;
+		} else if (cur_mode[i] == '+') {
+			has_plus = 1;
+		}
+		/* ignore 'n', 't' or other stuff */
+	}
+
+	if (has_bin) {
+		result[res_curs++] = 'b';
+	}
+	if (has_plus) {
+		result[res_curs++] = '+';
+	}
+
+	result[res_curs] = '\0';
+}
+/* }}} */
+
+/* {{{ pthreads_stream_cast */
+int _pthreads_stream_cast(pthreads_stream_t *threaded_stream, int castas, void **ret, int show_err) {
+	pthreads_stream *stream = PTHREADS_FETCH_STREAMS_STREAM(threaded_stream);
+
+	int flags = castas & PTHREADS_STREAM_CAST_MASK;
+	castas &= ~PTHREADS_STREAM_CAST_MASK;
+
+	if(stream_lock(threaded_stream)) {
+		/* synchronize our buffer (if possible) */
+		if (ret && castas != PTHREADS_STREAM_AS_FD_FOR_SELECT) {
+			pthreads_stream_flush(threaded_stream);
+			if (stream->ops->seek && (stream->flags & PTHREADS_STREAM_FLAG_NO_SEEK) == 0) {
+				zend_off_t dummy;
+
+				stream->ops->seek(threaded_stream, stream->position, SEEK_SET, &dummy);
+				stream->readpos = stream->writepos = 0;
+			}
+		}
+
+		/* filtered streams can only be cast as stdio, and only when fopencookie is present */
+
+		if (castas == PTHREADS_STREAM_AS_STDIO) {
+			if (stream->stdiocast) {
+				if (ret) {
+					*(FILE**)ret = stream->stdiocast;
+				}
+				goto exit_success;
+			}
+
+			/* if the stream is a stdio stream let's give it a chance to respond
+			 * first, to avoid doubling up the layers of stdio with an fopencookie */
+			if (pthreads_stream_is(threaded_stream, PTHREADS_STREAM_IS_STDIO) &&
+				stream->ops->cast &&
+				!pthreads_stream_is_filtered(threaded_stream) &&
+				stream->ops->cast(threaded_stream, castas, ret) == SUCCESS
+			) {
+				goto exit_success;
+			}
+
+#if HAVE_PTHREADS_FOPENCOOKIE
+			/* if just checking, say yes we can be a FILE*, but don't actually create it yet */
+			if (ret == NULL) {
+				goto exit_success;
+			}
+
+			{
+				char fixed_mode[5];
+				pthreads_stream_mode_sanitize_fdopen_fopencookie(threaded_stream, fixed_mode);
+				*(FILE**)ret = fopencookie(threaded_stream, fixed_mode, PHP_STREAM_COOKIE_FUNCTIONS);
+			}
+
+			if (*ret != NULL) {
+				zend_off_t pos;
+
+				stream->fclose_stdiocast = PTHREADS_STREAM_FCLOSE_FOPENCOOKIE;
+
+				/* If the stream position is not at the start, we need to force
+				 * the stdio layer to believe it's real location. */
+				pos = pthreads_stream_tell(threaded_stream);
+				if (pos > 0) {
+					zend_fseek(*ret, pos, SEEK_SET);
+				}
+
+				goto exit_success;
+			}
+			stream_unlock(threaded_stream);
+
+			/* must be either:
+				a) programmer error
+				b) no memory
+				-> lets bail
+			*/
+			php_error_docref(NULL, E_ERROR, "fopencookie failed");
+			return FAILURE;
+#endif
+
+			if (!pthreads_stream_is_filtered(threaded_stream) && stream->ops->cast && stream->ops->cast(threaded_stream, castas, NULL) == SUCCESS) {
+				if (FAILURE == stream->ops->cast(threaded_stream, castas, ret)) {
+					stream_unlock(threaded_stream);
+					return FAILURE;
+				}
+				goto exit_success;
+			} else if (flags & PTHREADS_STREAM_CAST_TRY_HARD) {
+				pthreads_stream_t *threaded_newstream;
+
+				threaded_newstream = pthreads_stream_fopen_tmpfile();
+				if (threaded_newstream) {
+					int retcopy = pthreads_stream_copy_to_stream_ex(threaded_stream, threaded_newstream, PTHREADS_STREAM_COPY_ALL, NULL);
+
+					if (retcopy != SUCCESS) {
+						pthreads_stream_close(threaded_newstream, PTHREADS_STREAM_FREE_CLOSE);
+					} else {
+						int retcast = pthreads_stream_cast(threaded_newstream, castas | flags, (void **)ret, show_err);
+
+						if (retcast == SUCCESS) {
+							rewind(*(FILE**)ret);
+						}
+
+						/* do some specialized cleanup */
+						if ((flags & PTHREADS_STREAM_CAST_RELEASE)) {
+							pthreads_stream_close(threaded_stream, PTHREADS_STREAM_FREE_CLOSE_CASTED);
+						}
+						stream_unlock(threaded_stream);
+
+						/* TODO: we probably should be setting .stdiocast and .fclose_stdiocast or
+						 * we may be leaking the FILE*. Needs investigation, though. */
+						return retcast;
+					}
+				}
+			}
+		}
+
+		if (pthreads_stream_is_filtered(threaded_stream)) {
+			stream_unlock(threaded_stream);
+			php_error_docref(NULL, E_WARNING, "cannot cast a filtered stream on this system");
+			return FAILURE;
+		} else if (stream->ops->cast && stream->ops->cast(threaded_stream, castas, ret) == SUCCESS) {
+			goto exit_success;
+		}
+		stream_unlock(threaded_stream);
+	}
+
+	if (show_err) {
+		/* these names depend on the values of the PTHREADS_STREAM_AS_XXX defines in streams.h */
+		static const char *cast_names[4] = {
+			"STDIO FILE*",
+			"File Descriptor",
+			"Socket Descriptor",
+			"select()able descriptor"
+		};
+
+		php_error_docref(NULL, E_WARNING, "cannot represent a stream of type %s as a %s", stream->ops->label, cast_names[castas]);
+	}
+
+	return FAILURE;
+
+exit_success:
+
+	if ((stream->writepos - stream->readpos) > 0 &&
+		stream->fclose_stdiocast != PTHREADS_STREAM_FCLOSE_FOPENCOOKIE &&
+		(flags & PTHREADS_STREAM_CAST_INTERNAL) == 0
+	) {
+		/* the data we have buffered will be lost to the third party library that
+		 * will be accessing the stream.  Emit a warning so that the end-user will
+		 * know that they should try something else */
+
+		php_error_docref(NULL, E_WARNING, ZEND_LONG_FMT " bytes of buffered data lost during stream conversion!", (zend_long)(stream->writepos - stream->readpos));
+	}
+
+	if (castas == PTHREADS_STREAM_AS_STDIO && ret) {
+		stream->stdiocast = *(FILE**)ret;
+	}
+
+	if (flags & PTHREADS_STREAM_CAST_RELEASE) {
+		pthreads_stream_close(threaded_stream, PTHREADS_STREAM_FREE_CLOSE_CASTED);
+	}
+	stream_unlock(threaded_stream);
+
+	return SUCCESS;
+
+}
+/* }}} */
+
+/* {{{ pthreads_stream_open_wrapper_as_file */
+FILE * _pthreads_stream_open_wrapper_as_file(char *path, char *mode, int options, zend_string **opened_path)
+{
+	FILE *fp = NULL;
+	pthreads_stream_t *threaded_stream = NULL;
+
+	threaded_stream = pthreads_stream_open_wrapper(path, mode, options | PTHREADS_STREAM_WILL_CAST, opened_path);
+
+	if (threaded_stream == NULL) {
+		return NULL;
+	}
+
+	if (pthreads_stream_cast(threaded_stream, PTHREADS_STREAM_AS_STDIO|PTHREADS_STREAM_CAST_TRY_HARD|PTHREADS_STREAM_CAST_RELEASE, (void**)&fp, PTHREADS_REPORT_ERRORS) == FAILURE) {
+		pthreads_stream_close(threaded_stream, PTHREADS_STREAM_FREE_CLOSE);
+		if (opened_path && *opened_path) {
+			zend_string_release(*opened_path);
+		}
+		return NULL;
+	}
+	return fp;
+}
+/* }}} */
+
+/* {{{ pthreads_stream_make_seekable */
+int _pthreads_stream_make_seekable(pthreads_stream_t *threaded_origstream, pthreads_stream_t **threaded_newstream, int flags) {
+	pthreads_stream *origstream = PTHREADS_FETCH_STREAMS_STREAM(threaded_origstream),
+			*newstream = PTHREADS_FETCH_STREAMS_STREAM(*threaded_newstream);
+
+	if (threaded_newstream == NULL) {
+		return PTHREADS_STREAM_FAILED;
+	}
+	*threaded_newstream = NULL;
+
+	if (((flags & PTHREADS_STREAM_FORCE_CONVERSION) == 0) && origstream->ops->seek != NULL) {
+		*threaded_newstream = threaded_origstream;
+		return PTHREADS_STREAM_UNCHANGED;
+	}
+
+	/* Use a tmpfile and copy the old streams contents into it */
+
+	if (flags & PTHREADS_STREAM_PREFER_STDIO) {
+		*threaded_newstream = pthreads_stream_fopen_tmpfile();
+	} else {
+		*threaded_newstream = pthreads_stream_temp_new();
+	}
+
+	if (*threaded_newstream == NULL) {
+		return PTHREADS_STREAM_FAILED;
+	}
+
+	if (pthreads_stream_copy_to_stream_ex(threaded_origstream, *threaded_newstream, PTHREADS_STREAM_COPY_ALL, NULL) != SUCCESS) {
+		pthreads_stream_close(*threaded_newstream, PTHREADS_STREAM_FREE_CLOSE);
+		*threaded_newstream = NULL;
+		return PTHREADS_STREAM_CRITICAL;
+	}
+
+	pthreads_stream_close(threaded_origstream, PTHREADS_STREAM_FREE_CLOSE);
+	pthreads_stream_seek(*threaded_newstream, 0, SEEK_SET);
+
+	return PTHREADS_STREAM_RELEASED;
+}
+/* }}} */
+
+#endif

--- a/src/streams/context.h
+++ b/src/streams/context.h
@@ -1,0 +1,96 @@
+/*
+  +----------------------------------------------------------------------+
+  | pthreads                                                             |
+  +----------------------------------------------------------------------+
+  | Copyright (c) Joe Watkins 2018                                       |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | http://www.php.net/license/3_01.txt                                  |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors: Bastian Schneider <b.schneider@badnoob.com>                 |
+  | Borrowed code from php-src                                           |
+  +----------------------------------------------------------------------+
+ */
+#ifndef HAVE_PTHREADS_STREAMS_CONTEXT_H
+#define HAVE_PTHREADS_STREAMS_CONTEXT_H
+
+#ifndef HAVE_PTHREADS_STORE_H
+#	include "src/store.h"
+#endif
+
+/* Stream context and status notification related definitions */
+
+/* callback for status notifications */
+typedef void (*pthreads_stream_notification_func)(pthreads_stream_context *context,
+		int notifycode, int severity,
+		char *xmsg, int xcode,
+		size_t bytes_sofar, size_t bytes_max,
+		void * ptr);
+
+#define PTHREADS_STREAM_NOTIFIER_PROGRESS	1
+
+/* Attempt to fetch context from the zval passed,
+   If no context was passed, use the default context
+   The default context has not yet been created, do it now. */
+#define pthreads_stream_context_from_zval(zcontext, nocontext) ( \
+		(zcontext) && !Z_ISNULL_P(zcontext) ? PTHREADS_FETCH_FROM(Z_OBJ_P(zcontext)) : \
+		(nocontext) ? NULL : PTHREADS_GET_DEF_CONTEXT )
+
+#define pthreads_stream_context_to_zval(context, zval) { ZVAL_OBJ(zval, context); Z_ADDREF_P((zval)); }
+
+typedef struct _pthreads_stream_notifier pthreads_stream_notifier;
+
+struct _pthreads_stream_notifier {
+	pthreads_stream_notification_func func;
+	void (*dtor)(pthreads_stream_notifier *notifier);
+	pthreads_storage *ptr;
+	int mask;
+	size_t progress, progress_max; /* position for progress notification */
+};
+
+struct _pthreads_stream_context {
+	pthreads_stream_notifier *notifier;
+	pthreads_object_t *options;	/* hash keyed by wrapper family or specific wrapper */
+};
+
+pthreads_stream_context *pthreads_stream_context_alloc(void);
+void pthreads_stream_context_free(pthreads_stream_context *context);
+zval *pthreads_stream_context_get_option(pthreads_stream_context_t *threaded_context, const char *wrappername, const char *optionname);
+int pthreads_stream_context_set_option(pthreads_stream_context_t *threaded_context, const char *wrappername, const char *optionname, zval *optionvalue);
+pthreads_stream_notifier *pthreads_stream_notification_alloc(void);
+void pthreads_stream_notification_free(pthreads_stream_notifier *notifier);
+
+/* not all notification codes are implemented */
+#define PTHREADS_STREAM_NOTIFY_RESOLVE			1
+#define PTHREADS_STREAM_NOTIFY_CONNECT			2
+#define PTHREADS_STREAM_NOTIFY_AUTH_REQUIRED	3
+#define PTHREADS_STREAM_NOTIFY_MIME_TYPE_IS		4
+#define PTHREADS_STREAM_NOTIFY_FILE_SIZE_IS		5
+#define PTHREADS_STREAM_NOTIFY_REDIRECTED		6
+#define PTHREADS_STREAM_NOTIFY_PROGRESS			7
+#define PTHREADS_STREAM_NOTIFY_COMPLETED		8
+#define PTHREADS_STREAM_NOTIFY_FAILURE			9
+#define PTHREADS_STREAM_NOTIFY_AUTH_RESULT		10
+
+#define PTHREADS_STREAM_NOTIFY_SEVERITY_INFO	0
+#define PTHREADS_STREAM_NOTIFY_SEVERITY_WARN	1
+#define PTHREADS_STREAM_NOTIFY_SEVERITY_ERR		2
+
+void pthreads_stream_notification_notify(pthreads_stream_context_t *threaded_context, int notifycode, int severity,
+		char *xmsg, int xcode, size_t bytes_sofar, size_t bytes_max, void * ptr);
+
+pthreads_stream_context_t *pthreads_stream_context_set(pthreads_stream_t *threaded_stream, pthreads_stream_context_t *threaded_context);
+
+void pthreads_stream_notify_info(pthreads_stream_context_t *threaded_context, int code, char *xmsg, int xcode);
+void pthreads_stream_notify_progress(pthreads_stream_context_t *threaded_context, size_t bsofar, size_t bmax);
+void pthreads_stream_notify_progress_init(pthreads_stream_context_t *threaded_context, size_t sofar, size_t bmax);
+void pthreads_stream_notify_progress_increment(pthreads_stream_context_t *threaded_context, size_t sofar, size_t max);
+void pthreads_stream_notify_file_size(pthreads_stream_context_t *threaded_context, size_t file_size, char *xmsg, int xcode);
+void pthreads_stream_notify_error(pthreads_stream_context_t *threaded_context, int code, char *xmsg, int xcode);
+
+#endif

--- a/src/streams/context_api.c
+++ b/src/streams/context_api.c
@@ -1,0 +1,212 @@
+/*
+  +----------------------------------------------------------------------+
+  | pthreads                                                             |
+  +----------------------------------------------------------------------+
+  | Copyright (c) Joe Watkins 2018                                       |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | http://www.php.net/license/3_01.txt                                  |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors: Bastian Schneider <b.schneider@badnoob.com>                 |
+  | Borrowed code from php-src                                           |
+  +----------------------------------------------------------------------+
+ */
+#ifndef HAVE_PTHREADS_API_CONTEXT
+#define HAVE_PTHREADS_API_CONTEXT
+
+/* {{{ stream_context related functions */
+static void pthreads_user_space_stream_notifier(pthreads_stream_context *context, int notifycode, int severity,
+		char *xmsg, int xcode, size_t bytes_sofar, size_t bytes_max, void * ptr) {
+
+	zval callback;
+	zval retval;
+	zval zvs[6];
+	int i;
+
+	pthreads_store_convert(context->notifier->ptr, &callback);
+
+	if(Z_ISNULL(callback) || Z_ISUNDEF(callback)) {
+		return;
+	}
+
+	ZVAL_LONG(&zvs[0], notifycode);
+	ZVAL_LONG(&zvs[1], severity);
+	if (xmsg) {
+		ZVAL_STRING(&zvs[2], xmsg);
+	} else {
+		ZVAL_NULL(&zvs[2]);
+	}
+	ZVAL_LONG(&zvs[3], xcode);
+	ZVAL_LONG(&zvs[4], bytes_sofar);
+	ZVAL_LONG(&zvs[5], bytes_max);
+
+	if (FAILURE == call_user_function_ex(EG(function_table), NULL, &callback, &retval, 6, zvs, 0, NULL)) {
+		php_error_docref(NULL, E_WARNING, "failed to call user notifier");
+	}
+	for (i = 0; i < 6; i++) {
+		zval_ptr_dtor(&zvs[i]);
+	}
+	zval_ptr_dtor(&retval);
+}
+
+static void pthreads_user_space_stream_notifier_dtor(pthreads_stream_notifier *notifier) {
+	if (notifier && notifier->ptr) {
+		pthreads_store_storage_dtor(notifier->ptr);
+		notifier->ptr = NULL;
+	}
+}
+
+static int pthreads_parse_context_options(pthreads_stream_context_t *threaded_context, zval *options) {
+	zval *wval, *oval;
+	zend_string *wkey, *okey;
+	int ret = SUCCESS;
+
+	if(MONITOR_LOCK(threaded_context)) {
+		ZEND_HASH_FOREACH_STR_KEY_VAL(Z_ARRVAL_P(options), wkey, wval) {
+			ZVAL_DEREF(wval);
+			if (wkey && Z_TYPE_P(wval) == IS_ARRAY) {
+				ZEND_HASH_FOREACH_STR_KEY_VAL(Z_ARRVAL_P(wval), okey, oval) {
+					if (okey) {
+						pthreads_stream_context_set_option(threaded_context, ZSTR_VAL(wkey), ZSTR_VAL(okey), oval);
+					}
+				} ZEND_HASH_FOREACH_END();
+			} else {
+				php_error_docref(NULL, E_WARNING, "options should have the form [\"wrappername\"][\"optionname\"] = $value");
+			}
+		} ZEND_HASH_FOREACH_END();
+
+		MONITOR_UNLOCK(threaded_context);
+	}
+	return ret;
+}
+
+static int pthreads_parse_context_params(pthreads_stream_context_t *threaded_context, zval *params) {
+	pthreads_stream_context *context = PTHREADS_FETCH_STREAMS_CONTEXT(threaded_context);
+	int ret = SUCCESS;
+	zval *tmp;
+
+	if(MONITOR_LOCK(threaded_context)) {
+		if (NULL != (tmp = zend_hash_str_find(Z_ARRVAL_P(params), "notification", sizeof("notification")-1))) {
+			if (context->notifier) {
+				pthreads_stream_notification_free(context->notifier);
+				context->notifier = NULL;
+			}
+
+			context->notifier = pthreads_stream_notification_alloc();
+			context->notifier->func = pthreads_user_space_stream_notifier;
+			context->notifier->ptr = pthreads_store_create(tmp, 0);
+			context->notifier->dtor = pthreads_user_space_stream_notifier_dtor;
+		}
+
+		if (NULL != (tmp = zend_hash_str_find(Z_ARRVAL_P(params), "options", sizeof("options")-1))) {
+			if (Z_TYPE_P(tmp) == IS_ARRAY) {
+				pthreads_parse_context_options(threaded_context, tmp);
+			} else {
+				php_error_docref(NULL, E_WARNING, "Invalid stream/context parameter");
+			}
+		}
+		MONITOR_UNLOCK(threaded_context);
+	}
+	return ret;
+}
+
+/* {{{ */
+void pthreads_streams_api_context_get_options(zval *object, zval *return_value) {
+	pthreads_stream_context_t *threaded_context = PTHREADS_FETCH_FROM(Z_OBJ_P(object));
+	pthreads_stream_context *context = PTHREADS_FETCH_STREAMS_CONTEXT(threaded_context);
+
+	ZVAL_NULL(return_value);
+
+	if(MONITOR_LOCK(threaded_context)) {
+		_pthreads_volatile_map_to_array(context->options, return_value);
+		MONITOR_UNLOCK(threaded_context);
+	}
+}
+/* }}} */
+
+/* {{{ */
+void pthreads_streams_api_context_set_option(zval *object, zend_string *wrapper, zend_string *option, zval *zvalue, zval *return_value) {
+	pthreads_stream_context_t *threaded_context = PTHREADS_FETCH_FROM(Z_OBJ_P(object));
+
+	RETURN_BOOL(pthreads_stream_context_set_option(threaded_context, ZSTR_VAL(wrapper), ZSTR_VAL(option), zvalue) == SUCCESS);
+}
+/* }}} */
+
+/* {{{ */
+void pthreads_streams_api_context_set_options(zval *object, zval *options, zval *return_value) {
+	pthreads_stream_context_t *threaded_context = PTHREADS_FETCH_FROM(Z_OBJ_P(object));
+
+	RETURN_BOOL(pthreads_parse_context_options(threaded_context, options) == SUCCESS);
+}
+/* }}} */
+
+/* {{{ */
+void pthreads_streams_api_context_set_params(zval *object, zval *params, zval *return_value) {
+	pthreads_stream_context_t *threaded_context = PTHREADS_FETCH_FROM(Z_OBJ_P(object));
+
+	RETVAL_BOOL(pthreads_parse_context_params(threaded_context, params) == SUCCESS);
+}
+/* }}} */
+
+/* {{{ */
+void pthreads_streams_api_context_get_params(zval *object, zval *return_value) {
+	pthreads_stream_context_t *threaded_context = PTHREADS_FETCH_FROM(Z_OBJ_P(object));
+	pthreads_stream_context *context = PTHREADS_FETCH_STREAMS_CONTEXT(threaded_context);
+	zval pzval;
+
+	array_init(return_value);
+	if (context->notifier && context->notifier->ptr && context->notifier->func == pthreads_user_space_stream_notifier
+			&& pthreads_store_convert(context->notifier->ptr, &pzval) == SUCCESS) {
+		add_assoc_zval_ex(return_value, "notification", sizeof("notification")-1, &pzval);
+	}
+	zval options;
+
+	if(MONITOR_LOCK(threaded_context)) {
+		_pthreads_volatile_map_to_array(context->options, &options);
+		MONITOR_UNLOCK(threaded_context);
+	}
+	add_assoc_zval_ex(return_value, "options", sizeof("options")-1, &options);
+}
+/* }}} */
+
+/* {{{ */
+void pthreads_streams_api_context_get_default(zval *options, zval *return_value) {
+	pthreads_stream_context_t *threaded_context = PTHREADS_STREAMG(default_context);
+
+	if (options) {
+		pthreads_parse_context_options(threaded_context, options);
+	}
+	pthreads_stream_context_to_zval(PTHREADS_STD_P(threaded_context), return_value);
+}
+/* }}} */
+
+/* {{{ */
+void pthreads_streams_api_context_set_default(zval *options, zval *return_value) {
+	pthreads_stream_context_t *threaded_context = PTHREADS_STREAMG(default_context);
+
+	pthreads_parse_context_options(threaded_context, options);
+
+	pthreads_stream_context_to_zval(PTHREADS_STD_P(threaded_context), return_value);
+}
+/* }}} */
+
+/* {{{ */
+void pthreads_streams_api_context_create(zval *object, zval *options, zval *params, zval *return_value) {
+	pthreads_stream_context_t *threaded_context = PTHREADS_FETCH_FROM(Z_OBJ_P(object));
+
+	if (options) {
+		pthreads_parse_context_options(threaded_context, options);
+	}
+
+	if (params) {
+		pthreads_parse_context_params(threaded_context, params);
+	}
+}
+/* }}} */
+
+#endif

--- a/src/streams/filters.c
+++ b/src/streams/filters.c
@@ -1,0 +1,776 @@
+/*
+  +----------------------------------------------------------------------+
+  | pthreads                                                             |
+  +----------------------------------------------------------------------+
+  | Copyright (c) Joe Watkins 2018                                       |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | http://www.php.net/license/3_01.txt                                  |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors: Bastian Schneider <b.schneider@badnoob.com>                 |
+  | Borrowed code from php-src                                           |
+  +----------------------------------------------------------------------+
+ */
+#ifndef HAVE_PTHREADS_STREAMS_FILTERS
+#define HAVE_PTHREADS_STREAMS_FILTERS
+
+#ifndef HAVE_PTHREADS_H
+#	include <src/pthreads.h>
+#endif
+
+#ifndef HAVE_PTHREADS_STREAM_H
+#	include <src/streams.h>
+#endif
+
+#ifndef HAVE_PTHREADS_STREAMS_FILTERS_H
+#	include <src/streams/filters.h>
+#endif
+
+#ifndef HAVE_PTHREADS_OBJECT_H
+#	include <src/object.h>
+#endif
+
+#ifndef HAVE_PTHREADS_STREAMS_STANDARD_FILTERS_H
+#	include <src/streams/standard_filters.h>
+#endif
+
+int pthreads_init_stream_filters() {
+
+	zend_declare_class_constant_long(pthreads_stream_filter_entry,  ZEND_STRL("PSFS_PASS_ON")			, PTHREADS_SFS_PASS_ON);
+	zend_declare_class_constant_long(pthreads_stream_filter_entry,  ZEND_STRL("PSFS_FEED_ME")			, PTHREADS_SFS_FEED_ME);
+	zend_declare_class_constant_long(pthreads_stream_filter_entry,  ZEND_STRL("PSFS_ERR_FATAL")			, PTHREADS_SFS_ERR_FATAL);
+
+	zend_declare_class_constant_long(pthreads_stream_filter_entry,  ZEND_STRL("PSFS_FLAG_NORMAL")		, PTHREADS_SFS_FLAG_NORMAL);
+	zend_declare_class_constant_long(pthreads_stream_filter_entry,  ZEND_STRL("PSFS_FLAG_FLUSH_INC")	, PTHREADS_SFS_FLAG_FLUSH_INC);
+	zend_declare_class_constant_long(pthreads_stream_filter_entry,  ZEND_STRL("PSFS_FLAG_FLUSH_CLOSE")	, PTHREADS_SFS_FLAG_FLUSH_CLOSE);
+
+	standard_filters_init();
+
+	return SUCCESS;
+}
+
+int pthreads_shutdown_stream_filters() {
+
+	standard_filters_shutdown();
+
+	return SUCCESS;
+}
+
+static void pthreads_userfilter_dtor(pthreads_stream_filter_t *threaded_thisfilter) {
+	pthreads_stream_filter *thisfilter = PTHREADS_FETCH_STREAMS_FILTER(threaded_thisfilter);
+
+	zval *obj = &thisfilter->abstract;
+	zval func_name;
+	zval retval;
+
+	if (obj == NULL) {
+		/* If there's no object associated then there's nothing to dispose of */
+		return;
+	}
+
+	ZVAL_STRINGL(&func_name, PTHREADS_STREAM_FILTER_FUNC_ONCLOSE, sizeof(PTHREADS_STREAM_FILTER_FUNC_ONCLOSE)-1);
+
+	call_user_function(NULL,
+			obj,
+			&func_name,
+			&retval,
+			0, NULL);
+
+	zval_ptr_dtor(&retval);
+	zval_ptr_dtor(&func_name);
+
+	/* kill the object */
+	zval_ptr_dtor(obj);
+}
+
+pthreads_stream_filter_status_t pthreads_userfilter_filter(
+			pthreads_stream_t *threaded_stream,
+			pthreads_stream_filter_t *threaded_thisfilter,
+			pthreads_stream_bucket_brigade_t *threaded_buckets_in,
+			pthreads_stream_bucket_brigade_t *threaded_buckets_out,
+			size_t *bytes_consumed,
+			int flags
+			)
+{
+	pthreads_stream_bucket_brigade *buckets_in, *buckets_out;
+	pthreads_stream_filter_t *threaded_user_filter;
+	pthreads_stream_bucket_t *threaded_bucket;
+	int ret = PTHREADS_SFS_ERR_FATAL;
+	zval *obj = &PTHREADS_FETCH_STREAMS_FILTER(threaded_thisfilter)->abstract;
+	zval func_name, retval;
+	zval args[4];
+	zval zpropname;
+	int call_result;
+
+	/* the userfilter object probably doesn't exist anymore */
+	if (CG(unclean_shutdown)) {
+		return ret;
+	}
+
+	if(MONITOR_LOCK(threaded_thisfilter)) {
+		buckets_in = PTHREADS_FETCH_STREAMS_BRIGADE(threaded_buckets_in);
+		buckets_out = PTHREADS_FETCH_STREAMS_BRIGADE(threaded_buckets_out);
+		threaded_user_filter = PTHREADS_FETCH_FROM(Z_OBJ_P(obj));
+
+		if (MONITOR_LOCK(threaded_user_filter)) {
+			if (!zend_hash_str_exists_ind(threaded_user_filter->store.props, PTHREADS_STREAM_FILTER_PROP_STREAM, sizeof(PTHREADS_STREAM_FILTER_PROP_STREAM)-1)) {
+				zval tmp;
+
+				/* Give the userfilter class a hook back to the stream */
+				pthreads_stream_to_zval(threaded_stream, &tmp);
+				Z_ADDREF(tmp);
+				add_property_zval(obj, PTHREADS_STREAM_FILTER_PROP_STREAM, &tmp);
+				/* add_property_zval increments the refcount which is unwanted here */
+				zval_ptr_dtor(&tmp);
+			}
+			MONITOR_UNLOCK(threaded_user_filter);
+		}
+
+		ZVAL_STRINGL(&func_name, PTHREADS_STREAM_FILTER_FUNC_FILTER, sizeof(PTHREADS_STREAM_FILTER_FUNC_FILTER)-1);
+
+		/* Setup calling arguments */
+		ZVAL_OBJ(&args[0], PTHREADS_STD_P(threaded_buckets_in));
+		ZVAL_OBJ(&args[1], PTHREADS_STD_P(threaded_buckets_out));
+
+		if (bytes_consumed) {
+			ZVAL_LONG(&args[2], *bytes_consumed);
+		} else {
+			ZVAL_NULL(&args[2]);
+		}
+
+		ZVAL_BOOL(&args[3], flags & PTHREADS_SFS_FLAG_FLUSH_CLOSE);
+
+		call_result = call_user_function_ex(NULL,
+				obj,
+				&func_name,
+				&retval,
+				4, args,
+				0, NULL);
+
+		zval_ptr_dtor(&func_name);
+
+		if (call_result == SUCCESS && Z_TYPE(retval) != IS_UNDEF) {
+			convert_to_long(&retval);
+			ret = (int)Z_LVAL(retval);
+		} else if (call_result == FAILURE) {
+			php_error_docref(NULL, E_WARNING, "failed to call filter function");
+		}
+
+		if (bytes_consumed) {
+			*bytes_consumed = zval_get_long(&args[2]);
+		}
+
+		if (buckets_in->head) {
+			php_error_docref(NULL, E_WARNING, "Unprocessed filter buckets remaining on input brigade");
+
+			while ((threaded_bucket = buckets_in->head) != NULL) {
+				/* Remove unconsumed buckets from the brigade */
+				pthreads_stream_bucket_destroy(threaded_bucket);
+			}
+		}
+
+		if (ret != PTHREADS_SFS_PASS_ON) {
+			while ((threaded_bucket = buckets_out->head) != NULL) {
+				pthreads_stream_bucket_destroy(threaded_bucket);
+			}
+		}
+
+		/* filters are cleaned up by the stream destructor,
+		 * keeping a reference to the stream here would prevent it
+		 * from being destroyed properly */
+		ZVAL_STRINGL(&zpropname, PTHREADS_STREAM_FILTER_PROP_STREAM, sizeof(PTHREADS_STREAM_FILTER_PROP_STREAM)-1);
+		Z_OBJ_HANDLER_P(obj, unset_property)(obj, &zpropname, NULL);
+		zval_ptr_dtor(&zpropname);
+
+		MONITOR_UNLOCK(threaded_thisfilter);
+	}
+
+	zval_ptr_dtor(&args[3]);
+	zval_ptr_dtor(&args[2]);
+
+	return ret;
+}
+
+static const pthreads_stream_filter_ops pthreads_userfilter_ops = {
+	pthreads_userfilter_filter,
+	pthreads_userfilter_dtor,
+	"user-filter"
+};
+
+static pthreads_stream_filter_t *pthreads_user_filter_factory_create(const char *filtername, zval *filterparams) {
+	struct pthreads_user_filter_data *fdat = NULL;
+	pthreads_stream_filter_t *threaded_filter;
+	pthreads_stream_filter *filter;
+	zval obj, zfilter, func_name, retval;
+	zend_class_entry *filter_ce = NULL;
+	size_t len;
+
+	len = strlen(filtername);
+
+	pthreads_hashtable *user_filter_map = &PTHREADS_STREAMG(user_filter_map);
+
+	if(MONITOR_LOCK(user_filter_map)) {
+
+		/* determine the classname/class entry */
+		if (NULL == (fdat = zend_hash_str_find_ptr(&user_filter_map->ht, (char*)filtername, len))) {
+			char *period;
+
+			/* Userspace Filters using ambiguous wildcards could cause problems.
+			   i.e.: myfilter.foo.bar will always call into myfilter.foo.*
+					 never seeing myfilter.*
+			   TODO: Allow failed userfilter creations to continue
+					 scanning through the list */
+			if ((period = strrchr(filtername, '.'))) {
+				char *wildcard = safe_emalloc(len, 1, 3);
+
+				/* Search for wildcard matches instead */
+				memcpy(wildcard, filtername, len + 1); /* copy \0 */
+				period = wildcard + (period - filtername);
+				while (period) {
+					*period = '\0';
+					strncat(wildcard, ".*", 2);
+					if (NULL != (fdat = zend_hash_str_find_ptr(&user_filter_map->ht, wildcard, strlen(wildcard)))) {
+						period = NULL;
+					} else {
+						*period = '\0';
+						period = strrchr(wildcard, '.');
+					}
+				}
+				efree(wildcard);
+			}
+			if (fdat == NULL) {
+				MONITOR_UNLOCK(user_filter_map);
+				php_error_docref(NULL, E_WARNING,
+						"Err, filter \"%s\" is not in the user-filter map, but somehow the user-filter-factory was invoked for it!?", filtername);
+				return NULL;
+			}
+		}
+		MONITOR_UNLOCK(user_filter_map);
+	}
+
+	/* bind the classname to the actual class */
+	if (NULL == (filter_ce = zend_lookup_class(fdat->classname))) {
+		php_error_docref(NULL, E_WARNING,
+				"user-filter \"%s\" requires class \"%s\", but that class is not defined",
+				filtername, ZSTR_VAL(fdat->classname));
+		return NULL;
+	}
+
+	if(!instanceof_function(filter_ce, pthreads_threaded_entry)) {
+		php_error_docref(NULL, E_WARNING,
+							"user-filter \"%s\" must be an instance of Threaded",
+							filtername);
+		return NULL;
+	}
+
+	threaded_filter = pthreads_stream_filter_new(&pthreads_userfilter_ops, NULL);
+	if (threaded_filter == NULL) {
+		return NULL;
+	}
+	filter = PTHREADS_FETCH_STREAMS_FILTER(threaded_filter);
+
+	/* create the user_filter object */
+	object_init_ex(&obj, filter_ce);
+
+	/* filtername */
+	add_property_string(&obj, "filtername", (char*)filtername);
+
+	/* and the parameters, if any */
+	if (filterparams) {
+		add_property_zval(&obj, "params", filterparams);
+	} else {
+		add_property_null(&obj, "params");
+	}
+
+	/* invoke the constructor */
+	ZVAL_STRINGL(&func_name, PTHREADS_STREAM_FILTER_FUNC_ONCREATE, sizeof(PTHREADS_STREAM_FILTER_FUNC_ONCREATE)-1);
+
+	call_user_function(NULL,
+			&obj,
+			&func_name,
+			&retval,
+			0, NULL);
+
+	if (Z_TYPE(retval) != IS_UNDEF) {
+		if (Z_TYPE(retval) == IS_FALSE) {
+			/* User reported filter creation error "return false;" */
+			zval_ptr_dtor(&retval);
+
+			/* Kill the filter (safely) */
+			ZVAL_UNDEF(&filter->abstract);
+
+			/* Kill the object */
+			zval_ptr_dtor(&obj);
+
+			pthreads_ptr_dtor(threaded_filter);
+
+			/* Report failure to filter_alloc */
+			return NULL;
+		}
+		zval_ptr_dtor(&retval);
+	}
+	zval_ptr_dtor(&func_name);
+
+	ZVAL_COPY_VALUE(&filter->abstract, &obj);
+
+	/* set the filter property, this will be used during cleanup */
+	ZVAL_OBJ(&zfilter, PTHREADS_STD_P(threaded_filter));
+	add_property_zval(&obj, PTHREADS_STREAM_FILTER_PROP_FILTER, &zfilter);
+	/* add_property_zval increments the refcount which is unwanted here */
+	zval_ptr_dtor(&zfilter);
+
+	return threaded_filter;
+}
+
+const pthreads_stream_filter_factory pthreads_user_filter_factory = {
+	pthreads_user_filter_factory_create
+};
+
+pthreads_hashtable *_pthreads_get_stream_filters_hash(void) {
+	return &PTHREADS_STREAMG(stream_filters_hash);
+}
+
+int pthreads_stream_filter_register_factory(const char *filterpattern, const pthreads_stream_filter_factory *factory) {
+	pthreads_hashtable *stream_filters_hash = &PTHREADS_STREAMG(stream_filters_hash);
+	zend_string *str = zend_string_init_interned(filterpattern, strlen(filterpattern), 1);
+	int result;
+
+	if(MONITOR_LOCK(stream_filters_hash)) {
+		result = zend_hash_add_ptr(&stream_filters_hash->ht, str, (void*)factory) ? SUCCESS : FAILURE;
+		MONITOR_UNLOCK(stream_filters_hash);
+	}
+	return result;
+}
+
+int pthreads_stream_filter_unregister_factory(const char *filterpattern) {
+	pthreads_hashtable *stream_filters_hash = &PTHREADS_STREAMG(stream_filters_hash);
+	int result = FAILURE;
+
+	if(MONITOR_LOCK(stream_filters_hash)) {
+		result = zend_hash_str_del(&stream_filters_hash->ht, filterpattern, strlen(filterpattern));
+		MONITOR_UNLOCK(stream_filters_hash);
+	}
+	return result;
+}
+
+int pthreads_streams_add_user_filter_map_entry(zend_string *filtername, zend_string *classname) {
+	struct pthreads_user_filter_data *fdat;
+
+	fdat = calloc(1, sizeof(struct pthreads_user_filter_data));
+	fdat->classname = classname;
+
+	pthreads_hashtable *user_filter_map = &PTHREADS_STREAMG(user_filter_map);
+
+	if(MONITOR_LOCK(user_filter_map)) {
+		void *result = zend_hash_add_ptr(&user_filter_map->ht, filtername, fdat);
+
+		MONITOR_UNLOCK(user_filter_map);
+
+		if(result != NULL) {
+			return SUCCESS;
+		}
+	}
+	free(fdat);
+
+	return FAILURE;
+}
+
+void pthreads_streams_drop_user_filter_map_entry(zend_string *filtername) {
+	pthreads_hashtable *user_filter_map = &PTHREADS_STREAMG(user_filter_map);
+
+	if(MONITOR_LOCK(user_filter_map)) {
+		zend_hash_del(&user_filter_map->ht, filtername);
+		MONITOR_UNLOCK(user_filter_map);
+	}
+}
+
+/* We allow very simple pattern matching for filter factories:
+ * if "convert.charset.utf-8/sjis" is requested, we search first for an exact
+ * match. If that fails, we try "convert.charset.*", then "convert.*"
+ * This means that we don't need to clog up the hashtable with a zillion
+ * charsets (for example) but still be able to provide them all as filters */
+pthreads_stream_filter_t *pthreads_stream_filter_create(const char *filtername, zval *filterparams) {
+	pthreads_hashtable *filter_hash = pthreads_get_stream_filters_hash();
+	const pthreads_stream_filter_factory *factory = NULL;
+	pthreads_stream_filter_t *threaded_filter = NULL;
+	size_t n;
+	char *period;
+
+	n = strlen(filtername);
+
+	if(pthreads_monitor_lock(filter_hash->monitor)) {
+		factory = zend_hash_str_find_ptr(&filter_hash->ht, filtername, n);
+		pthreads_monitor_unlock(filter_hash->monitor);
+	}
+
+	if (NULL != factory) {
+		threaded_filter = factory->create_filter(filtername, filterparams);
+	} else if ((period = strrchr(filtername, '.'))) {
+		/* try a wildcard */
+		char *wildname;
+
+		wildname = safe_emalloc(1, n, 3);
+		memcpy(wildname, filtername, n+1);
+		period = wildname + (period - filtername);
+		while (period && !threaded_filter) {
+			*period = '\0';
+			strncat(wildname, ".*", 2);
+
+			if(pthreads_monitor_lock(filter_hash->monitor)) {
+				factory = zend_hash_str_find_ptr(&filter_hash->ht, wildname, strlen(wildname));
+				pthreads_monitor_unlock(filter_hash->monitor);
+			}
+
+			if (NULL != factory) {
+				threaded_filter = factory->create_filter(filtername, filterparams);
+			}
+
+			*period = '\0';
+			period = strrchr(wildname, '.');
+		}
+		efree(wildname);
+	}
+
+	if (threaded_filter == NULL) {
+		/* TODO: these need correct docrefs */
+		if (factory == NULL)
+			php_error_docref(NULL, E_WARNING, "unable to locate filter \"%s\"", filtername);
+		else
+			php_error_docref(NULL, E_WARNING, "unable to create or locate filter \"%s\"", filtername);
+	}
+
+	return threaded_filter;
+}
+
+pthreads_stream_filter *_pthreads_stream_filter_alloc(const pthreads_stream_filter_ops *fops, void *abstract) {
+	pthreads_stream_filter *filter;
+
+	filter = (pthreads_stream_filter*) malloc(sizeof(pthreads_stream_filter));
+	memset(filter, 0, sizeof(pthreads_stream_filter));
+
+	filter->fops = fops;
+	Z_PTR(filter->abstract) = abstract;
+
+	return filter;
+}
+
+void pthreads_stream_filter_free(pthreads_stream_filter *filter, pthreads_stream_filter_t *threaded_filter) {
+	if (filter->fops->dtor)
+		filter->fops->dtor(threaded_filter);
+	free(filter);
+}
+
+int pthreads_stream_filter_prepend_ex(pthreads_stream_filter_chain_t *threaded_chain, pthreads_stream_filter_t *threaded_filter) {
+	pthreads_stream_filter *filter = PTHREADS_FETCH_STREAMS_FILTER(threaded_filter);
+
+	if(pthreads_streams_aquire_double_lock(threaded_filter, threaded_chain)) {
+		//filter->next = chain->head;
+		pthreads_filter_set_next(threaded_filter, pthreads_chain_get_head(threaded_chain));
+
+		//filter->prev = NULL;
+		pthreads_filter_set_prev(threaded_filter, NULL);
+
+		if (pthreads_chain_has_head(threaded_chain)) {
+			//PTHREADS_FETCH_STREAMS_FILTER(chain->head)->prev = threaded_filter;
+			pthreads_filter_set_prev(pthreads_chain_get_head(threaded_chain), threaded_filter);
+		} else {
+			//chain->tail = threaded_filter;
+			pthreads_chain_set_tail(threaded_chain, threaded_filter);
+		}
+		//chain->head = threaded_filter;
+		pthreads_chain_set_head(threaded_chain, threaded_filter);
+		//filter->chain = chain;
+		pthreads_filter_set_chain(threaded_filter, threaded_chain);
+
+		pthreads_add_ref(threaded_filter);
+
+		pthreads_streams_release_double_lock(threaded_filter, threaded_chain);
+	}
+	return SUCCESS;
+}
+
+void _pthreads_stream_filter_prepend(pthreads_stream_filter_chain_t *threaded_chain, pthreads_stream_filter_t *threaded_filter) {
+	pthreads_stream_filter_prepend_ex(threaded_chain, threaded_filter);
+}
+
+int pthreads_stream_filter_append_ex(pthreads_stream_filter_chain_t *threaded_chain, pthreads_stream_filter_t *threaded_filter) {
+	pthreads_stream_t *threaded_stream = pthreads_chain_get_stream(threaded_chain);
+
+	pthreads_stream *stream = PTHREADS_FETCH_STREAMS_STREAM(threaded_stream);
+	pthreads_stream_filter *filter = PTHREADS_FETCH_STREAMS_FILTER(threaded_filter);
+
+	// reentrant lock
+	if(pthreads_streams_aquire_double_lock(threaded_filter, threaded_chain)) {
+		//filter->prev = chain->tail;
+		pthreads_filter_set_prev(threaded_filter, pthreads_chain_get_tail(threaded_chain));
+
+		//filter->next = NULL;
+		pthreads_filter_set_next(threaded_filter, NULL);
+
+		if (pthreads_chain_has_tail(threaded_chain)) {
+			//PTHREADS_FETCH_STREAMS_FILTER(chain->tail)->next = threaded_filter;
+			pthreads_filter_set_next(pthreads_chain_get_tail(threaded_chain), threaded_filter);
+		} else {
+			//chain->head = threaded_filter;
+			pthreads_chain_set_head(threaded_chain, threaded_filter);
+		}
+
+		//chain->tail = threaded_filter;
+		pthreads_chain_set_tail(threaded_chain, threaded_filter);
+
+		//filter->chain = chain;
+		pthreads_filter_set_chain(threaded_filter, threaded_chain);
+
+		pthreads_add_ref(threaded_filter);
+
+		pthreads_streams_release_double_lock(threaded_filter, threaded_chain);
+	}
+
+	if(stream_lock(threaded_stream)) {
+		if (!pthreads_object_compare(pthreads_stream_get_readfilters(threaded_stream), threaded_chain) && (stream->writepos - stream->readpos) > 0) {
+			/* Let's going ahead and wind anything in the buffer through this filter */
+			pthreads_stream_bucket_brigade_t *brig_inp = pthreads_stream_bucket_brigade_new(), *brig_outp = pthreads_stream_bucket_brigade_new();
+			pthreads_stream_filter_status_t status;
+			pthreads_stream_bucket_t *threaded_bucket;
+			pthreads_stream_bucket *bucket;
+			size_t consumed = 0;
+
+			threaded_bucket = pthreads_stream_bucket_new((char*) stream->readbuf + stream->readpos, stream->writepos - stream->readpos);
+			pthreads_stream_bucket_append(brig_inp, threaded_bucket, 0);
+			status = filter->fops->filter(threaded_stream, threaded_filter, brig_inp, brig_outp, &consumed, PTHREADS_SFS_FLAG_NORMAL);
+
+			if (stream->readpos + consumed > (uint32_t)stream->writepos) {
+				/* No behaving filter should cause this. */
+				status = PTHREADS_SFS_ERR_FATAL;
+			}
+			pthreads_ptr_dtor(threaded_bucket);
+
+			switch (status) {
+				case PTHREADS_SFS_ERR_FATAL:
+					while ((threaded_bucket = PTHREADS_FETCH_STREAMS_BRIGADE(brig_inp)->head) != NULL) {
+						pthreads_stream_bucket_destroy(threaded_bucket);
+					}
+
+					while ((threaded_bucket = PTHREADS_FETCH_STREAMS_BRIGADE(brig_outp)->head) != NULL) {
+						pthreads_stream_bucket_destroy(threaded_bucket);
+					}
+					php_error_docref(NULL, E_WARNING, "Filter failed to process pre-buffered data");
+
+					pthreads_ptr_dtor(brig_inp);
+					pthreads_ptr_dtor(brig_outp);
+
+					return FAILURE;
+				case PTHREADS_SFS_FEED_ME:
+					/* We don't actually need data yet,
+					   leave this filter in a feed me state until data is needed.
+					   Reset stream's internal read buffer since the filter is "holding" it. */
+					stream->readpos = 0;
+					stream->writepos = 0;
+					break;
+				case PTHREADS_SFS_PASS_ON:
+					/* If any data is consumed, we cannot rely upon the existing read buffer,
+					   as the filtered data must replace the existing data, so invalidate the cache */
+					/* note that changes here should be reflected in
+					   src/streams/streams.c::pthreads_stream_fill_read_buffer */
+					stream->writepos = 0;
+					stream->readpos = 0;
+
+					while ((threaded_bucket = PTHREADS_FETCH_STREAMS_BRIGADE(brig_outp)->head) != NULL) {
+						pthreads_stream_bucket_sync_properties(threaded_bucket);
+						bucket = PTHREADS_FETCH_STREAMS_BUCKET(threaded_bucket);
+
+						/* Grow buffer to hold this bucket if need be.
+						   TODO: See warning in src/streams/streams.c::pthreads_stream_fill_read_buffer */
+						if (stream->readbuflen - stream->writepos < bucket->buflen) {
+							stream->readbuflen += bucket->buflen;
+							stream->readbuf = realloc(stream->readbuf, stream->readbuflen);
+						}
+						memcpy(stream->readbuf + stream->writepos, bucket->buf, bucket->buflen);
+						stream->writepos += bucket->buflen;
+
+						pthreads_stream_bucket_destroy(threaded_bucket);
+					}
+					break;
+			}
+			pthreads_ptr_dtor(brig_inp);
+			pthreads_ptr_dtor(brig_outp);
+		}
+		pthreads_monitor_unlock(threaded_stream->monitor);
+	}
+
+	return SUCCESS;
+}
+
+void _pthreads_stream_filter_append(pthreads_stream_filter_chain_t *threaded_chain, pthreads_stream_filter_t *threaded_filter) {
+	pthreads_stream_filter *filter;
+
+	if(pthreads_streams_aquire_double_lock(threaded_filter, threaded_chain)) {
+		filter = PTHREADS_FETCH_STREAMS_FILTER(threaded_filter);
+		if (pthreads_stream_filter_append_ex(threaded_chain, threaded_filter) != SUCCESS) {
+			if (!pthreads_object_compare(pthreads_chain_get_head(threaded_chain), threaded_filter)) {
+				//chain->head = NULL;
+				pthreads_chain_set_head(threaded_chain, NULL);
+				//chain->tail = NULL;
+				pthreads_chain_set_tail(threaded_chain, NULL);
+			} else {
+				//PTHREADS_FETCH_STREAMS_FILTER(filter->prev)->next = NULL;
+				pthreads_filter_set_next(pthreads_filter_get_prev(threaded_filter), NULL);
+				//chain->tail = filter->prev;
+				pthreads_chain_set_tail(threaded_chain, pthreads_filter_get_prev(threaded_filter));
+			}
+		}
+		pthreads_streams_release_double_lock(threaded_filter, threaded_chain);
+	}
+}
+
+int _pthreads_stream_filter_flush(pthreads_stream_filter_t *threaded_filter, int finish) {
+	pthreads_stream_bucket_brigade_t *inp = pthreads_stream_bucket_brigade_new(), *outp = pthreads_stream_bucket_brigade_new(), *brig_temp;
+	pthreads_stream_bucket_t *threaded_bucket;
+	pthreads_stream_bucket *bucket;
+	pthreads_stream_filter_chain_t *threaded_chain;
+	pthreads_stream_t *threaded_stream;
+	pthreads_stream *stream;
+	pthreads_stream_filter_t *current;
+	pthreads_stream_filter *filter = PTHREADS_FETCH_STREAMS_FILTER(threaded_filter);
+	size_t flushed_size = 0;
+	long flags = (finish ? PTHREADS_SFS_FLAG_FLUSH_CLOSE : PTHREADS_SFS_FLAG_FLUSH_INC);
+
+	threaded_chain = pthreads_filter_get_chain(threaded_filter);
+
+	if (!threaded_chain) {
+		/* Filter is not attached to a chain */
+		return FAILURE;
+	}
+	threaded_stream = pthreads_chain_get_stream(threaded_chain);
+
+	if (!threaded_stream) {
+		/* Chain is somehow not part of a stream */
+		return FAILURE;
+	}
+	if(stream_lock(threaded_stream)) {
+		stream = PTHREADS_FETCH_STREAMS_STREAM(threaded_stream);
+
+		for(current = threaded_filter; current; current = pthreads_filter_get_next(current)) {
+			pthreads_stream_filter_status_t status;
+
+			status = filter->fops->filter(threaded_stream, current, inp, outp, NULL, flags);
+			if (status == PTHREADS_SFS_FEED_ME) {
+				stream_unlock(threaded_stream);
+				/* We've flushed the data far enough */
+				return SUCCESS;
+			}
+			if (status == PTHREADS_SFS_ERR_FATAL) {
+				stream_unlock(threaded_stream);
+				return FAILURE;
+			}
+			/* Otherwise we have data available to PASS_ON
+				Swap the brigades and continue */
+			brig_temp = inp;
+			inp = outp;
+			outp = brig_temp;
+			PTHREADS_FETCH_STREAMS_BRIGADE(outp)->head = NULL;
+			PTHREADS_FETCH_STREAMS_BRIGADE(outp)->tail = NULL;
+
+			flags = PTHREADS_SFS_FLAG_NORMAL;
+		}
+
+		/* Last filter returned data via PTHREADS_SFS_PASS_ON
+			Do something with it */
+
+		for(threaded_bucket = PTHREADS_FETCH_STREAMS_BRIGADE(inp)->head; threaded_bucket; threaded_bucket = PTHREADS_FETCH_STREAMS_BUCKET(threaded_bucket)->next) {
+			pthreads_stream_bucket_sync_properties(threaded_bucket);
+			flushed_size += PTHREADS_FETCH_STREAMS_BUCKET(threaded_bucket)->buflen;
+		}
+
+		if (flushed_size == 0) {
+			stream_unlock(threaded_stream);
+			/* Unlikely, but possible */
+			return SUCCESS;
+		}
+
+		if (!pthreads_object_compare(threaded_chain, pthreads_stream_get_readfilters(threaded_stream))) {
+			/* Dump any newly flushed data to the read buffer */
+			if (stream->readpos > 0) {
+				/* Back the buffer up */
+				memcpy(stream->readbuf, stream->readbuf + stream->readpos, stream->writepos - stream->readpos);
+				stream->readpos = 0;
+				stream->writepos -= stream->readpos;
+			}
+
+			if (flushed_size > (stream->readbuflen - stream->writepos)) {
+				/* Grow the buffer */
+				stream->readbuf = realloc(stream->readbuf, stream->writepos + flushed_size + stream->chunk_size);
+			}
+
+			while ((threaded_bucket = PTHREADS_FETCH_STREAMS_BRIGADE(inp)->head)) {
+				bucket = PTHREADS_FETCH_STREAMS_BUCKET(threaded_bucket);
+				memcpy(stream->readbuf + stream->writepos, bucket->buf, bucket->buflen);
+				stream->writepos += bucket->buflen;
+				pthreads_stream_bucket_destroy(threaded_bucket);
+			}
+		} else if (!pthreads_object_compare(threaded_chain, pthreads_stream_get_writefilters(threaded_stream))) {
+			/* Send flushed data to the stream */
+			while ((threaded_bucket = PTHREADS_FETCH_STREAMS_BRIGADE(inp)->head)) {
+				bucket = PTHREADS_FETCH_STREAMS_BUCKET(threaded_bucket);
+				stream->ops->write(threaded_stream, bucket->buf, bucket->buflen);
+				pthreads_stream_bucket_destroy(threaded_bucket);
+			}
+		}
+		pthreads_ptr_dtor(inp);
+		pthreads_ptr_dtor(outp);
+
+		stream_unlock(threaded_stream);
+	}
+
+	return SUCCESS;
+}
+
+int _pthreads_stream_filter_is_integrated(pthreads_stream_filter_t *threaded_filter) {
+	return pthreads_filter_has_chain(threaded_filter);
+}
+
+pthreads_stream_filter_t *_pthreads_stream_filter_remove(pthreads_stream_filter_t *threaded_filter, int call_dtor) {
+	pthreads_stream_filter *filter = PTHREADS_FETCH_STREAMS_FILTER(threaded_filter);
+	pthreads_stream_filter_t *next, *prev;
+
+	if(MONITOR_LOCK(threaded_filter)) {
+		prev = pthreads_filter_get_prev(threaded_filter);
+		next = pthreads_filter_get_next(threaded_filter);
+
+		if (prev) {
+			//PTHREADS_FETCH_STREAMS_FILTER(prev)->next = next;
+			pthreads_filter_set_next(prev, next);
+		} else {
+			//filter->chain->head = next;
+			pthreads_chain_set_head(pthreads_filter_get_chain(threaded_filter), next);
+		}
+
+		if (next) {
+			//PTHREADS_FETCH_STREAMS_FILTER(next)->prev = prev;
+			pthreads_filter_set_prev(next, prev);
+		} else {
+			//filter->chain->tail = prev;
+			pthreads_chain_set_tail(pthreads_filter_get_chain(threaded_filter), prev);
+		}
+		//pthreads_filter_set_chain(threaded_filter, NULL);
+
+		MONITOR_UNLOCK(threaded_filter);
+	}
+
+	if (call_dtor) {
+		pthreads_ptr_dtor(threaded_filter);
+		return NULL;
+	}
+	return threaded_filter;
+}
+
+#ifndef HAVE_PTHREADS_API_FILTERS
+#	include "src/streams/filters_api.c"
+#endif
+
+#endif

--- a/src/streams/filters.h
+++ b/src/streams/filters.h
@@ -1,0 +1,126 @@
+/*
+  +----------------------------------------------------------------------+
+  | pthreads                                                             |
+  +----------------------------------------------------------------------+
+  | Copyright (c) Joe Watkins 2018                                       |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | http://www.php.net/license/3_01.txt                                  |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors: Bastian Schneider <b.schneider@badnoob.com>                 |
+  | Borrowed code from php-src                                           |
+  +----------------------------------------------------------------------+
+ */
+#ifndef HAVE_PTHREADS_STREAMS_FILTERS_H
+#define HAVE_PTHREADS_STREAMS_FILTERS_H
+
+#ifndef HAVE_PTHREADS_STREAMS_H
+#	include <src/streams.h>
+#endif
+
+#ifndef HAVE_PTHREADS_STREAMS_BUCKETS_H
+#	include <src/streams/buckets.h>
+#endif
+
+#define PTHREADS_STREAM_BUCKET_PROP_DATA	"data"
+#define PTHREADS_STREAM_BUCKET_PROP_DATALEN "datalen"
+
+#define PTHREADS_STREAM_FILTER_PROP_STREAM	"stream"
+#define PTHREADS_STREAM_FILTER_PROP_FILTER	"filter"
+
+#define PTHREADS_STREAM_FILTER_FUNC_FILTER		"filter"
+#define PTHREADS_STREAM_FILTER_FUNC_ONCREATE	"oncreate"
+#define PTHREADS_STREAM_FILTER_FUNC_ONCLOSE		"onclose"
+
+#define PTHREADS_STREAM_FILTER_READ		0x0001
+#define PTHREADS_STREAM_FILTER_WRITE	0x0002
+#define PTHREADS_STREAM_FILTER_ALL		(PTHREADS_STREAM_FILTER_READ | PTHREADS_STREAM_FILTER_WRITE)
+
+
+typedef enum {
+	PTHREADS_SFS_ERR_FATAL,	/* error in data stream */
+	PTHREADS_SFS_FEED_ME,	/* filter needs more data; stop processing chain until more is available */
+	PTHREADS_SFS_PASS_ON	/* filter generated output buckets; pass them on to next in chain */
+} pthreads_stream_filter_status_t;
+
+#define PTHREADS_SFS_FLAG_NORMAL		0	/* regular read/write */
+#define PTHREADS_SFS_FLAG_FLUSH_INC		1	/* an incremental flush */
+#define PTHREADS_SFS_FLAG_FLUSH_CLOSE	2	/* final flush prior to closing */
+
+struct pthreads_user_filter_data {
+	/* variable length; this *must* be last in the structure */
+	zend_string *classname;
+};
+
+typedef struct _pthreads_stream_filter_ops {
+
+	pthreads_stream_filter_status_t (*filter)(
+			pthreads_stream_t *threaded_stream,
+			pthreads_stream_filter_t *threaded_thisfilter,
+			pthreads_stream_bucket_brigade_t *threaded_buckets_in,
+			pthreads_stream_bucket_brigade_t *threaded_buckets_out,
+			size_t *bytes_consumed,
+			int flags
+			);
+
+	void (*dtor)(pthreads_stream_filter_t *thisfilter);
+
+	const char *label;
+
+} pthreads_stream_filter_ops;
+
+struct _pthreads_stream_filter {
+	const pthreads_stream_filter_ops *fops;
+	zval abstract; /* for use by filter implementation */
+};
+
+int pthreads_init_stream_filters();
+int pthreads_shutdown_stream_filters();
+
+/* stack filter onto a stream */
+void _pthreads_stream_filter_prepend(pthreads_stream_filter_chain_t *threaded_chain, pthreads_stream_filter_t *threaded_filter);
+int pthreads_stream_filter_prepend_ex(pthreads_stream_filter_chain_t *threaded_chain, pthreads_stream_filter_t *threaded_filter);
+void _pthreads_stream_filter_append(pthreads_stream_filter_chain_t *threaded_chain, pthreads_stream_filter_t *threaded_filter);
+int pthreads_stream_filter_append_ex(pthreads_stream_filter_chain_t *threaded_chain, pthreads_stream_filter_t *threaded_filter);
+int _pthreads_stream_filter_flush(pthreads_stream_filter_t *threaded_filter, int finish);
+pthreads_stream_filter_t *_pthreads_stream_filter_remove(pthreads_stream_filter_t *threaded_filter, int call_dtor);
+#define pthreads_stream_filter_remove(threaded_filter) _pthreads_stream_filter_remove((threaded_filter), 1)
+int _pthreads_stream_filter_is_integrated(pthreads_stream_filter_t *threaded_filter);
+#define pthreads_stream_filter_is_integrated(threaded_filter) _pthreads_stream_filter_is_integrated((threaded_filter))
+
+void pthreads_stream_filter_free(pthreads_stream_filter *filter, pthreads_stream_filter_t *threaded_filter);
+pthreads_stream_filter *_pthreads_stream_filter_alloc(const pthreads_stream_filter_ops *fops, void *abstract);
+
+#define pthreads_stream_filter_alloc(fops, thisptr) _pthreads_stream_filter_alloc((fops), (thisptr))
+#define pthreads_stream_filter_prepend(chain, filter) _pthreads_stream_filter_prepend((chain), (filter))
+#define pthreads_stream_filter_append(chain, filter) _pthreads_stream_filter_append((chain), (filter))
+#define pthreads_stream_filter_flush(filter, finish) _pthreads_stream_filter_flush((filter), (finish))
+
+#define pthreads_stream_is_filtered(threaded_stream)	(pthreads_chain_has_head(pthreads_stream_get_readfilters((threaded_stream))) \
+		|| pthreads_chain_has_tail(pthreads_stream_get_writefilters((threaded_stream))))
+
+typedef struct _pthreads_stream_filter_factory {
+	pthreads_stream_filter_t *(*create_filter)(const char *filtername, zval *filterparams);
+} pthreads_stream_filter_factory;
+
+extern const pthreads_stream_filter_factory pthreads_user_filter_factory;
+
+int pthreads_stream_filter_register_factory(const char *filterpattern, const pthreads_stream_filter_factory *factory);
+int pthreads_stream_filter_unregister_factory(const char *filterpattern);
+int pthreads_streams_add_user_filter_map_entry(zend_string *filtername, zend_string *classname);
+void pthreads_streams_drop_user_filter_map_entry(zend_string *filtername);
+pthreads_stream_filter_t *pthreads_stream_filter_create(const char *filtername, zval *filterparams);
+
+pthreads_hashtable *_pthreads_get_stream_filters_hash(void);
+#define pthreads_get_stream_filters_hash()	_pthreads_get_stream_filters_hash()
+
+/* API */
+
+void pthreads_streams_api_buffer_construct(zval *object, zend_string *buffer);
+
+#endif

--- a/src/streams/filters_api.c
+++ b/src/streams/filters_api.c
@@ -1,0 +1,98 @@
+/*
+  +----------------------------------------------------------------------+
+  | pthreads                                                             |
+  +----------------------------------------------------------------------+
+  | Copyright (c) Joe Watkins 2018                                       |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | http://www.php.net/license/3_01.txt                                  |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors: Bastian Schneider <b.schneider@badnoob.com>                 |
+  | Borrowed code from php-src                                           |
+  +----------------------------------------------------------------------+
+ */
+#ifndef HAVE_PTHREADS_API_FILTERS
+#define HAVE_PTHREADS_API_FILTERS
+
+/* {{{ pthreads_streams_api_buffer_construct */
+void pthreads_streams_api_bucket_construct(zval *object, zend_string *buffer, zval *return_value) {
+	pthreads_object_t *threaded =
+		PTHREADS_FETCH_FROM(Z_OBJ_P(object));
+	pthreads_stream_bucket *bucket;
+
+	bucket = pthreads_stream_bucket_alloc(ZSTR_VAL(buffer), ZSTR_LEN(buffer));
+
+	if (bucket == NULL) {
+		php_error_docref(NULL, E_WARNING, "Could not create StreamBucket");
+		RETURN_FALSE;
+	}
+	PTHREADS_FETCH_STREAMS_BUCKET(threaded) = bucket;
+
+	add_property_stringl(object, PTHREADS_STREAM_BUCKET_PROP_DATA, bucket->buf, bucket->buflen);
+	add_property_long(object, PTHREADS_STREAM_BUCKET_PROP_DATALEN, bucket->buflen);
+
+	Z_ADDREF_P(object);
+}
+/* }}} */
+
+/* {{{ pthreads_streams_api_bucket_attach */
+void pthreads_streams_api_bucket_attach(zval *object, zval *bucket_object, int append, int separate) {
+	pthreads_stream_bucket_brigade_t *threaded_brigade = PTHREADS_FETCH_FROM(Z_OBJ_P(object));
+	pthreads_stream_bucket_t *threaded_bucket = PTHREADS_FETCH_FROM(Z_OBJ_P(bucket_object));
+
+	pthreads_stream_bucket_sync_properties(threaded_bucket);
+
+	if (append) {
+		pthreads_stream_bucket_append(threaded_brigade, threaded_bucket, separate);
+	} else {
+		pthreads_stream_bucket_prepend(threaded_brigade, threaded_bucket, separate);
+	}
+}
+/* }}} */
+
+/* {{{ pthreads_streams_api_bucket_fetch */
+void pthreads_streams_api_bucket_fetch(zval *object, zval *return_value) {
+	pthreads_stream_bucket_brigade_t *threaded_brigade = PTHREADS_FETCH_FROM(Z_OBJ_P(object));
+	pthreads_stream_bucket_brigade *brigade = PTHREADS_FETCH_STREAMS_BRIGADE(threaded_brigade);
+	pthreads_stream_bucket_t *threaded_bucket = NULL;
+	pthreads_stream_bucket *bucket;
+
+	ZVAL_NULL(return_value);
+
+	if(MONITOR_LOCK(threaded_brigade)) {
+		if (brigade->head) {
+			threaded_bucket = brigade->head;
+
+			ZVAL_OBJ(return_value, PTHREADS_STD_P(threaded_bucket));
+			Z_ADDREF_P(return_value);
+
+			pthreads_stream_bucket_unlink(threaded_bucket);
+
+			bucket = PTHREADS_FETCH_STREAMS_BUCKET(threaded_bucket);
+
+			add_property_stringl(return_value, PTHREADS_STREAM_BUCKET_PROP_DATA, bucket->buf, bucket->buflen);
+			add_property_long(return_value, PTHREADS_STREAM_BUCKET_PROP_DATALEN, bucket->buflen);
+		}
+		MONITOR_UNLOCK(threaded_brigade);
+	}
+}
+/* }}} */
+
+/* {{{ pthreads_streams_api_filter_remove */
+void pthreads_streams_api_filter_remove(zval *object, zval *return_value) {
+	pthreads_stream_filter_t *threaded_filter = PTHREADS_FETCH_FROM(Z_OBJ_P(object));
+
+	// pthreads_stream_filter_remove() returns NULL in case of success!
+	if(threaded_filter && !pthreads_stream_filter_remove(threaded_filter)) {
+		RETURN_TRUE;
+	}
+	RETURN_FALSE;
+}
+/* }}} */
+
+#endif

--- a/src/streams/internal.h
+++ b/src/streams/internal.h
@@ -1,0 +1,51 @@
+/*
+  +----------------------------------------------------------------------+
+  | pthreads                                                             |
+  +----------------------------------------------------------------------+
+  | Copyright (c) Joe Watkins 2018                                       |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | http://www.php.net/license/3_01.txt                                  |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors: Bastian Schneider <b.schneider@badnoob.com>                 |
+  | Borrowed code from php-src                                           |
+  +----------------------------------------------------------------------+
+ */
+#ifndef HAVE_PTHREADS_STREAMS_INTERNAL_H
+#define HAVE_PTHREADS_STREAMS_INTERNAL_H
+
+#define PTHREADS_STREAM_DEBUG 0
+
+#ifndef MAP_FAILED
+#define MAP_FAILED ((void *) -1)
+#endif
+
+#define CHUNK_SIZE	8192
+
+#ifdef PHP_WIN32
+# ifdef EWOULDBLOCK
+#  undef EWOULDBLOCK
+# endif
+# define EWOULDBLOCK WSAEWOULDBLOCK
+# ifdef EMSGSIZE
+#  undef EMSGSIZE
+# endif
+# define EMSGSIZE WSAEMSGSIZE
+#endif
+
+/* This functions transforms the first char to 'w' if it's not 'r', 'a' or 'w'
+ * and strips any subsequent chars except '+' and 'b'.
+ * Use this to sanitize stream->mode if you call e.g. fdopen, fopencookie or
+ * any other function that expects standard modes and you allow non-standard
+ * ones. result should be a char[5]. */
+void pthreads_stream_mode_sanitize_fdopen_fopencookie(pthreads_stream_t *threaded_stream, char *result);
+
+void pthreads_stream_tidy_wrapper_error_log(pthreads_stream_wrapper_t *threaded_wrapper);
+void pthreads_stream_display_wrapper_errors(pthreads_stream_wrapper_t *threaded_wrapper, const char *path, const char *caption);
+
+#endif

--- a/src/streams/memory.c
+++ b/src/streams/memory.c
@@ -1,0 +1,949 @@
+/*
+  +----------------------------------------------------------------------+
+  | pthreads                                                             |
+  +----------------------------------------------------------------------+
+  | Copyright (c) Joe Watkins 2018                                       |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | http://www.php.net/license/3_01.txt                                  |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors: Bastian Schneider <b.schneider@badnoob.com>                 |
+  | Borrowed code from php-src                                           |
+  +----------------------------------------------------------------------+
+ */
+#ifndef HAVE_PTHREADS_STREAMS_MEMORY
+#define HAVE_PTHREADS_STREAMS_MEMORY
+
+#include "php.h"
+#include "ext/standard/base64.h"
+
+#ifndef HAVE_PTHREADS_H
+#	include <src/pthreads.h>
+#endif
+
+#ifndef HAVE_PTHREADS_STREAM_H
+#	include <src/streams.h>
+#endif
+
+#ifndef HAVE_PTHREADS_STREAMS_MEMORY_H
+#	include <src/streams/memory.h>
+#endif
+
+#ifndef HAVE_PTHREADS_OBJECT_H
+#	include <src/object.h>
+#endif
+
+size_t pthreads_url_decode(char *str, size_t len);
+
+/* Memory streams use a dynamic memory buffer to emulate a stream.
+ * You can use pthreads_stream_memory_open to create a readonly stream
+ * from an existing memory buffer.
+ */
+
+/* Temp streams are streams that uses memory streams as long their
+ * size is less than a given memory amount. When a write operation
+ * exceeds that limit the content is written to a temporary file.
+ */
+
+/* {{{ ------- MEMORY stream implementation -------*/
+
+typedef struct {
+	char        *data;
+	size_t      fpos;
+	size_t      fsize;
+	size_t      smax;
+	int			mode;
+} pthreads_stream_memory_data;
+
+
+/* {{{ */
+static size_t pthreads_stream_memory_write(pthreads_stream_t *threaded_stream, const char *buf, size_t count) {
+	pthreads_stream *stream = PTHREADS_FETCH_STREAMS_STREAM(threaded_stream);
+
+	if(stream_lock(threaded_stream)) {
+		pthreads_stream_memory_data *ms = (pthreads_stream_memory_data*)stream->abstract;
+		assert(ms != NULL);
+
+		if (ms->mode & PTHREADS_TEMP_STREAM_READONLY) {
+			return 0;
+		} else if (ms->mode & PTHREADS_TEMP_STREAM_APPEND) {
+			ms->fpos = ms->fsize;
+		}
+		if (ms->fpos + count > ms->fsize) {
+			char *tmp;
+			if (!ms->data) {
+				tmp = malloc(ms->fpos + count);
+			} else {
+				tmp = realloc(ms->data, ms->fpos + count);
+			}
+			ms->data = tmp;
+			ms->fsize = ms->fpos + count;
+		}
+		if (!ms->data)
+			count = 0;
+		if (count) {
+			assert(buf!= NULL);
+			memcpy(ms->data + ms->fpos, (char*)buf, count);
+			ms->fpos += count;
+		}
+		stream_unlock(threaded_stream);
+	}
+	return count;
+}
+/* }}} */
+
+/* {{{ */
+static size_t pthreads_stream_memory_read(pthreads_stream_t *threaded_stream, char *buf, size_t count) {
+	pthreads_stream *stream = PTHREADS_FETCH_STREAMS_STREAM(threaded_stream);
+
+	if(stream_lock(threaded_stream)) {
+		pthreads_stream_memory_data *ms = (pthreads_stream_memory_data*)stream->abstract;
+		assert(ms != NULL);
+
+		if (ms->fpos == ms->fsize) {
+			stream->eof = 1;
+			count = 0;
+		} else {
+			if (ms->fpos + count >= ms->fsize) {
+				count = ms->fsize - ms->fpos;
+			}
+			if (count) {
+				assert(ms->data!= NULL);
+				assert(buf!= NULL);
+				memcpy(buf, ms->data+ms->fpos, count);
+				ms->fpos += count;
+			}
+		}
+		stream_unlock(threaded_stream);
+	}
+	return count;
+}
+/* }}} */
+
+/* {{{ */
+static int pthreads_stream_memory_close(pthreads_stream_t *threaded_stream, int close_handle) {
+	return 0;
+}
+/* }}} */
+
+/* {{{ */
+static void pthreads_stream_memory_free(pthreads_stream_t *threaded_stream, int close_handle) {
+	pthreads_stream *stream = PTHREADS_FETCH_STREAMS_STREAM(threaded_stream);
+
+	pthreads_stream_memory_data *ms = (pthreads_stream_memory_data*)stream->abstract;
+	assert(ms != NULL);
+
+	if (ms->data && close_handle && ms->mode != PTHREADS_TEMP_STREAM_READONLY) {
+		free(ms->data);
+	}
+	free(ms);
+}
+/* }}} */
+
+/* {{{ */
+static int pthreads_stream_memory_flush(pthreads_stream_t *threaded_stream)
+{
+	/* nothing to do here */
+	return 0;
+}
+/* }}} */
+
+/* {{{ */
+static int pthreads_stream_memory_seek(pthreads_stream_t *threaded_stream, zend_off_t offset, int whence, zend_off_t *newoffs) {
+	pthreads_stream *stream = PTHREADS_FETCH_STREAMS_STREAM(threaded_stream);
+
+	if(stream_lock(threaded_stream)) {
+		pthreads_stream_memory_data *ms = (pthreads_stream_memory_data*)stream->abstract;
+		assert(ms != NULL);
+
+		switch(whence) {
+			case SEEK_CUR:
+				if (offset < 0) {
+					if (ms->fpos < (size_t)(-offset)) {
+						ms->fpos = 0;
+						*newoffs = -1;
+						return -1;
+					} else {
+						ms->fpos = ms->fpos + offset;
+						*newoffs = ms->fpos;
+						stream->eof = 0;
+						return 0;
+					}
+				} else {
+					if (ms->fpos + (size_t)(offset) > ms->fsize) {
+						ms->fpos = ms->fsize;
+						*newoffs = -1;
+						return -1;
+					} else {
+						ms->fpos = ms->fpos + offset;
+						*newoffs = ms->fpos;
+						stream->eof = 0;
+						return 0;
+					}
+				}
+			case SEEK_SET:
+				if (ms->fsize < (size_t)(offset)) {
+					ms->fpos = ms->fsize;
+					*newoffs = -1;
+					return -1;
+				} else {
+					ms->fpos = offset;
+					*newoffs = ms->fpos;
+					stream->eof = 0;
+					return 0;
+				}
+			case SEEK_END:
+				if (offset > 0) {
+					ms->fpos = ms->fsize;
+					*newoffs = -1;
+					return -1;
+				} else if (ms->fsize < (size_t)(-offset)) {
+					ms->fpos = 0;
+					*newoffs = -1;
+					return -1;
+				} else {
+					ms->fpos = ms->fsize + offset;
+					*newoffs = ms->fpos;
+					stream->eof = 0;
+					return 0;
+				}
+			default:
+				*newoffs = ms->fpos;
+				return -1;
+		}
+		stream_unlock(threaded_stream);
+	}
+}
+/* }}} */
+
+/* {{{ */
+static int pthreads_stream_memory_cast(pthreads_stream_t *threaded_stream, int castas, void **ret) {
+	return FAILURE;
+}
+/* }}} */
+
+/* {{{ */
+static int pthreads_stream_memory_stat(pthreads_stream_t *threaded_stream, pthreads_stream_statbuf *ssb)  {
+	pthreads_stream *stream = PTHREADS_FETCH_STREAMS_STREAM(threaded_stream);
+
+	if(stream_lock(threaded_stream)) {
+		time_t timestamp = 0;
+		pthreads_stream_memory_data *ms = (pthreads_stream_memory_data*)stream->abstract;
+		assert(ms != NULL);
+
+		memset(ssb, 0, sizeof(pthreads_stream_statbuf));
+		/* read-only across the board */
+
+		ssb->sb.st_mode = ms->mode & PTHREADS_TEMP_STREAM_READONLY ? 0444 : 0666;
+
+		ssb->sb.st_size = ms->fsize;
+		ssb->sb.st_mode |= S_IFREG; /* regular file */
+		ssb->sb.st_mtime = timestamp;
+		ssb->sb.st_atime = timestamp;
+		ssb->sb.st_ctime = timestamp;
+		ssb->sb.st_nlink = 1;
+		ssb->sb.st_rdev = -1;
+		/* this is only for APC, so use /dev/null device - no chance of conflict there! */
+		ssb->sb.st_dev = 0xC;
+		/* generate unique inode number for alias/filename, so no phars will conflict */
+		ssb->sb.st_ino = 0;
+
+#ifndef PHP_WIN32
+		ssb->sb.st_blksize = -1;
+		ssb->sb.st_blocks = -1;
+#endif
+		stream_unlock(threaded_stream);
+	}
+	return 0;
+}
+/* }}} */
+
+/* {{{ */
+static int pthreads_stream_memory_set_option(pthreads_stream_t *threaded_stream, int option, int value, void *ptrparam) {
+	pthreads_stream *stream = PTHREADS_FETCH_STREAMS_STREAM(threaded_stream);
+
+	if(stream_lock(threaded_stream)) {
+		pthreads_stream_memory_data *ms = (pthreads_stream_memory_data*)stream->abstract;
+		size_t newsize;
+
+		switch(option) {
+			case PTHREADS_STREAM_OPTION_TRUNCATE_API:
+				switch (value) {
+					case PTHREADS_STREAM_TRUNCATE_SUPPORTED:
+						stream_unlock(threaded_stream);
+						return PTHREADS_STREAM_OPTION_RETURN_OK;
+
+					case PTHREADS_STREAM_TRUNCATE_SET_SIZE:
+						if (ms->mode & PTHREADS_TEMP_STREAM_READONLY) {
+							stream_unlock(threaded_stream);
+							return PTHREADS_STREAM_OPTION_RETURN_ERR;
+						}
+						newsize = *(size_t*)ptrparam;
+						if (newsize <= ms->fsize) {
+							if (newsize < ms->fpos) {
+								ms->fpos = newsize;
+							}
+						} else {
+							ms->data = realloc(ms->data, newsize);
+							memset(ms->data+ms->fsize, 0, newsize - ms->fsize);
+							ms->fsize = newsize;
+						}
+						ms->fsize = newsize;
+						stream_unlock(threaded_stream);
+						return PTHREADS_STREAM_OPTION_RETURN_OK;
+				}
+			default:
+				stream_unlock(threaded_stream);
+				return PTHREADS_STREAM_OPTION_RETURN_NOTIMPL;
+		}
+		stream_unlock(threaded_stream); // never used
+	}
+}
+/* }}} */
+
+const pthreads_stream_ops pthreads_stream_memory_ops = {
+	pthreads_stream_memory_write, pthreads_stream_memory_read,
+	pthreads_stream_memory_close, pthreads_stream_memory_free,
+	pthreads_stream_memory_flush,
+	"MEMORY",
+	pthreads_stream_memory_seek,
+	pthreads_stream_memory_cast,
+	pthreads_stream_memory_stat,
+	pthreads_stream_memory_set_option
+};
+
+/* {{{ */
+int pthreads_stream_mode_from_str(const char *mode)
+{
+	if (strpbrk(mode, "a")) {
+		return PTHREADS_TEMP_STREAM_APPEND;
+	} else if (strpbrk(mode, "w+")) {
+		return PTHREADS_TEMP_STREAM_DEFAULT;
+	}
+	return PTHREADS_TEMP_STREAM_READONLY;
+}
+/* }}} */
+
+/* {{{ */
+const char *_pthreads_stream_mode_to_str(int mode)
+{
+	if (mode == PTHREADS_TEMP_STREAM_READONLY) {
+		return "rb";
+	} else if (mode == PTHREADS_TEMP_STREAM_APPEND) {
+		return "a+b";
+	}
+	return "w+b";
+}
+/* }}} */
+
+/* {{{ */
+pthreads_stream_t *_pthreads_stream_memory_create(int mode, zend_class_entry *ce) {
+	pthreads_stream_memory_data *self;
+	pthreads_stream_t *threaded_stream;
+
+	self = malloc(sizeof(*self));
+	self->data = NULL;
+	self->fpos = 0;
+	self->fsize = 0;
+	self->smax = ~0u;
+	self->mode = mode;
+
+	if(ce == NULL) {
+		ce = pthreads_file_stream_entry;
+	}
+	threaded_stream = PTHREADS_STREAM_CLASS_NEW(&pthreads_stream_memory_ops, self, _pthreads_stream_mode_to_str(mode), ce);
+	PTHREADS_FETCH_STREAMS_STREAM(threaded_stream)->flags |= PTHREADS_STREAM_FLAG_NO_BUFFER;
+
+	return threaded_stream;
+}
+/* }}} */
+
+/* {{{ */
+pthreads_stream_t *_pthreads_stream_memory_open(int mode, char *buf, size_t length, zend_class_entry *ce) {
+	pthreads_stream *stream;
+	pthreads_stream_t *threaded_stream;
+	pthreads_stream_memory_data *ms;
+
+	if ((threaded_stream = pthreads_stream_memory_create(mode, ce)) != NULL) {
+		stream = PTHREADS_FETCH_STREAMS_STREAM(threaded_stream);
+		ms = (pthreads_stream_memory_data*)stream->abstract;
+
+		if (mode == PTHREADS_TEMP_STREAM_READONLY || mode == PTHREADS_TEMP_STREAM_TAKE_BUFFER) {
+			/* use the buffer directly */
+			ms->data = buf;
+			ms->fsize = length;
+		} else {
+			if (length) {
+				assert(buf != NULL);
+				pthreads_stream_write(threaded_stream, buf, length);
+			}
+		}
+	}
+	return threaded_stream;
+}
+/* }}} */
+
+/* {{{ */
+char *_pthreads_stream_memory_get_buffer(pthreads_stream_t *threaded_stream, size_t *length) {
+	pthreads_stream *stream = PTHREADS_FETCH_STREAMS_STREAM(threaded_stream);
+
+	if(stream_lock(threaded_stream)) {
+		pthreads_stream_memory_data *ms = (pthreads_stream_memory_data*)stream->abstract;
+
+		assert(ms != NULL);
+		assert(length != 0);
+
+		*length = ms->fsize;
+
+		stream_unlock(threaded_stream);
+		return ms->data;
+	}
+	return NULL;
+}
+/* }}} */
+
+/* }}} */
+
+/* {{{ ------- TEMP stream implementation -------*/
+
+typedef struct {
+	pthreads_stream_t  *innerstream;
+	size_t             smax;
+	int			       mode;
+	zval               meta;
+	char*		       tmpdir;
+	pthreads_object_t  *storage;
+} pthreads_stream_temp_data;
+
+
+/* {{{ */
+static size_t pthreads_stream_temp_write(pthreads_stream_t *threaded_stream, const char *buf, size_t count) {
+	pthreads_stream *stream = PTHREADS_FETCH_STREAMS_STREAM(threaded_stream);
+	pthreads_stream_t *innerstream;
+	size_t ret = -1;
+
+	if(stream_lock(threaded_stream)) {
+		pthreads_stream_temp_data *ts = (pthreads_stream_temp_data*)stream->abstract;
+		assert(ts != NULL);
+		innerstream = pthreads_get_inner_stream(threaded_stream);
+
+		if (!innerstream) {
+			stream_unlock(threaded_stream);
+			return -1;
+		}
+
+		if (pthreads_stream_is(innerstream, PTHREADS_STREAM_IS_MEMORY)) {
+			size_t memsize;
+			char *membuf = pthreads_stream_memory_get_buffer(innerstream, &memsize);
+
+			if (memsize + count >= ts->smax) {
+				pthreads_stream_t *threaded_file = pthreads_stream_fopen_temporary_file(ts->tmpdir, "php", NULL);
+				if (threaded_file == NULL) {
+					stream_unlock(threaded_stream);
+					php_error_docref(NULL, E_WARNING, "Unable to create temporary file, Check permissions in temporary files directory.");
+					return 0;
+				}
+				pthreads_stream_write(threaded_file, membuf, memsize);
+				pthreads_stream_close_ignore_parent(innerstream, PTHREADS_STREAM_FREE_CLOSE);
+
+				pthreads_set_inner_stream(threaded_stream, threaded_file);
+				pthreads_stream_set_parent(innerstream, threaded_stream);
+
+				pthreads_del_ref(innerstream);
+				pthreads_del_ref(threaded_stream);
+			}
+		}
+		ret = pthreads_stream_write(innerstream, buf, count);
+
+		stream_unlock(threaded_stream);
+	}
+	return ret;
+}
+/* }}} */
+
+/* {{{ */
+static size_t pthreads_stream_temp_read(pthreads_stream_t *threaded_stream, char *buf, size_t count) {
+	pthreads_stream *stream = PTHREADS_FETCH_STREAMS_STREAM(threaded_stream);
+	pthreads_stream_t *innerstream;
+
+	if(stream_lock(threaded_stream)) {
+		pthreads_stream_temp_data *ts = (pthreads_stream_temp_data*)stream->abstract;
+		size_t got;
+
+		assert(ts != NULL);
+		innerstream = pthreads_get_inner_stream(threaded_stream);
+
+		if (!innerstream) {
+			stream_unlock(threaded_stream);
+			return -1;
+		}
+		got = pthreads_stream_read(innerstream, buf, count);
+
+		stream->eof = PTHREADS_FETCH_STREAMS_STREAM(innerstream)->eof;
+		stream_unlock(threaded_stream);
+
+		return got;
+	}
+	return -1;
+}
+/* }}} */
+
+/* {{{ */
+static int pthreads_stream_temp_close(pthreads_stream_t *threaded_stream, int close_handle) {
+	pthreads_stream *stream = PTHREADS_FETCH_STREAMS_STREAM(threaded_stream);
+	pthreads_stream_t *innerstream;
+
+	pthreads_stream_temp_data *ts = (pthreads_stream_temp_data*)stream->abstract;
+	int ret;
+
+	assert(ts != NULL);
+
+	innerstream = pthreads_get_inner_stream(threaded_stream);
+
+	if (innerstream) {
+		ret = pthreads_stream_close_ignore_parent(innerstream, PTHREADS_STREAM_FREE_CLOSE | (close_handle ? 0 : PTHREADS_STREAM_FREE_PRESERVE_HANDLE));
+	} else {
+		ret = 0;
+	}
+	zval_ptr_dtor(&ts->meta);
+
+	return ret;
+}
+/* }}} */
+
+/* {{{ */
+static void pthreads_stream_temp_free(pthreads_stream_t *threaded_stream, int close_handle) {
+	pthreads_stream *stream = PTHREADS_FETCH_STREAMS_STREAM(threaded_stream);
+
+	pthreads_stream_temp_data *ts = (pthreads_stream_temp_data*)stream->abstract;
+
+	assert(ts != NULL);
+
+	if (ts->tmpdir) {
+		free(ts->tmpdir);
+	}
+	free(ts);
+}
+/* }}} */
+
+/* {{{ */
+static int pthreads_stream_temp_flush(pthreads_stream_t *threaded_stream) {
+	pthreads_stream *stream = PTHREADS_FETCH_STREAMS_STREAM(threaded_stream);
+	pthreads_stream_t *innerstream;
+	int result = -1;
+
+	if(stream_lock(threaded_stream)) {
+		pthreads_stream_temp_data *ts = (pthreads_stream_temp_data*)stream->abstract;
+		assert(ts != NULL);
+		innerstream = pthreads_get_inner_stream(threaded_stream);
+		result = innerstream ? pthreads_stream_flush(innerstream) : -1;
+
+		stream_unlock(threaded_stream);
+	}
+	return result;
+}
+/* }}} */
+
+/* {{{ */
+static int pthreads_stream_temp_seek(pthreads_stream_t *threaded_stream, zend_off_t offset, int whence, zend_off_t *newoffs) {
+	pthreads_stream *stream = PTHREADS_FETCH_STREAMS_STREAM(threaded_stream);
+	pthreads_stream_t *innerstream;
+	int ret = -1;
+
+	if(stream_lock(threaded_stream)) {
+		pthreads_stream_temp_data *ts = (pthreads_stream_temp_data*)stream->abstract;
+		assert(ts != NULL);
+		innerstream = pthreads_get_inner_stream(threaded_stream);
+
+		if (!innerstream) {
+			*newoffs = -1;
+			stream_unlock(threaded_stream);
+			return ret;
+		}
+		ret = pthreads_stream_seek(innerstream, offset, whence);
+		*newoffs = pthreads_stream_tell(innerstream);
+		stream->eof = PTHREADS_FETCH_STREAMS_STREAM(innerstream)->eof;
+
+		stream_unlock(threaded_stream);
+	}
+	return ret;
+}
+/* }}} */
+
+/* {{{ */
+static int pthreads_stream_temp_cast(pthreads_stream_t *threaded_stream, int castas, void **ret) {
+	pthreads_stream *stream = PTHREADS_FETCH_STREAMS_STREAM(threaded_stream);
+	pthreads_stream_t *innerstream;
+
+	if(stream_lock(threaded_stream)) {
+		pthreads_stream_temp_data *ts = (pthreads_stream_temp_data*)stream->abstract;
+		pthreads_stream_t *threaded_file;
+		size_t memsize;
+		char *membuf;
+		zend_off_t pos;
+
+		assert(ts != NULL);
+		innerstream = pthreads_get_inner_stream(threaded_stream);
+
+		if (!innerstream) {
+			stream_unlock(threaded_stream);
+			return FAILURE;
+		}
+
+		if (pthreads_stream_is(innerstream, PTHREADS_STREAM_IS_STDIO)) {
+			int result = pthreads_stream_cast(innerstream, castas, ret, 0);
+			stream_unlock(threaded_stream);
+			return result;
+		}
+
+		/* we are still using a memory based backing. If they are if we can be
+		 * a FILE*, say yes because we can perform the conversion.
+		 * If they actually want to perform the conversion, we need to switch
+		 * the memory stream to a tmpfile stream */
+
+		if (ret == NULL && castas == PTHREADS_STREAM_AS_STDIO) {
+			return SUCCESS;
+		}
+
+		/* say "no" to other stream forms */
+		if (ret == NULL) {
+			return FAILURE;
+		}
+
+		threaded_file = pthreads_stream_fopen_tmpfile();
+		if (threaded_file == NULL) {
+			stream_unlock(threaded_stream);
+			php_error_docref(NULL, E_WARNING, "Unable to create temporary file.");
+			return FAILURE;
+		}
+
+		/* perform the conversion and then pass the request on to the innerstream */
+		membuf = pthreads_stream_memory_get_buffer(innerstream, &memsize);
+		pthreads_stream_write(threaded_file, membuf, memsize);
+		pos = pthreads_stream_tell(innerstream);
+
+		pthreads_stream_close_ignore_parent(innerstream, PTHREADS_STREAM_FREE_CLOSE);
+		pthreads_set_inner_stream(threaded_stream, threaded_file);
+
+		/* switch to new innerstream*/
+		innerstream = threaded_file;
+
+		pthreads_stream_set_parent(innerstream, threaded_stream);
+
+		pthreads_del_ref(innerstream);
+		pthreads_del_ref(threaded_stream);
+
+		pthreads_stream_seek(innerstream, pos, SEEK_SET);
+
+		int result = pthreads_stream_cast(innerstream, castas, ret, 1);
+
+		stream_unlock(threaded_stream);
+
+		return result;
+	}
+	return FAILURE;
+}
+/* }}} */
+
+/* {{{ */
+static int pthreads_stream_temp_stat(pthreads_stream_t *threaded_stream, pthreads_stream_statbuf *ssb) {
+	pthreads_stream *stream = PTHREADS_FETCH_STREAMS_STREAM(threaded_stream);
+	pthreads_stream_t *innerstream;
+	int ret = -1;
+
+	if(stream_lock(threaded_stream)) {
+		pthreads_stream_temp_data *ts = (pthreads_stream_temp_data*)stream->abstract;
+		assert(ts != NULL);
+		innerstream = pthreads_get_inner_stream(threaded_stream);
+
+		if (!ts || !innerstream) {
+			stream_unlock(threaded_stream);
+			return ret;
+		}
+		ret = pthreads_stream_stat(innerstream, ssb);
+		stream_unlock(threaded_stream);
+	}
+	return ret;
+}
+/* }}} */
+
+/* {{{ */
+static int pthreads_stream_temp_set_option(pthreads_stream_t *threaded_stream, int option, int value, void *ptrparam) {
+	pthreads_stream *stream = PTHREADS_FETCH_STREAMS_STREAM(threaded_stream);
+	pthreads_stream_t *innerstream;
+	int ret = -1;
+
+	if(stream_lock(threaded_stream)) {
+		pthreads_stream_temp_data *ts = (pthreads_stream_temp_data*)stream->abstract;
+
+		assert(ts != NULL);
+		innerstream = pthreads_get_inner_stream(threaded_stream);
+
+		switch(option) {
+			case PTHREADS_STREAM_OPTION_META_DATA_API:
+				if (Z_TYPE(ts->meta) != IS_UNDEF) {
+					zend_hash_copy(Z_ARRVAL_P((zval*)ptrparam), Z_ARRVAL(ts->meta), zval_add_ref);
+				}
+				stream_unlock(threaded_stream);
+
+				return PTHREADS_STREAM_OPTION_RETURN_OK;
+			default:
+				if (innerstream) {
+					ret = pthreads_stream_set_option(innerstream, option, value, ptrparam);
+					stream_unlock(threaded_stream);
+
+					return ret;
+				}
+				stream_unlock(threaded_stream);
+
+				return PTHREADS_STREAM_OPTION_RETURN_NOTIMPL;
+		}
+		stream_unlock(threaded_stream);
+	}
+}
+/* }}} */
+
+const pthreads_stream_ops pthreads_stream_temp_ops = {
+	pthreads_stream_temp_write, pthreads_stream_temp_read,
+	pthreads_stream_temp_close, pthreads_stream_temp_free,
+	pthreads_stream_temp_flush,
+	"TEMP",
+	pthreads_stream_temp_seek,
+	pthreads_stream_temp_cast,
+	pthreads_stream_temp_stat,
+	pthreads_stream_temp_set_option
+};
+
+/* }}} */
+
+/* {{{ _pthreads_stream_temp_create_ex */
+pthreads_stream_t *_pthreads_stream_temp_create_ex(int mode, size_t max_memory_usage, const char *tmpdir, zend_class_entry *ce) {
+	pthreads_stream_temp_data *self;
+	pthreads_stream_t *threaded_stream, *innerstream;
+
+	self = calloc(1, sizeof(*self));
+	self->smax = max_memory_usage;
+	self->mode = mode;
+	ZVAL_UNDEF(&self->meta);
+	if (tmpdir) {
+		self->tmpdir = strdup(tmpdir);
+	}
+	threaded_stream = PTHREADS_STREAM_CLASS_NEW(&pthreads_stream_temp_ops, self, _pthreads_stream_mode_to_str(mode), ce);
+	PTHREADS_FETCH_STREAMS_STREAM(threaded_stream)->flags |= PTHREADS_STREAM_FLAG_NO_BUFFER;
+
+	innerstream = pthreads_stream_memory_create(mode, ce);
+
+	pthreads_set_inner_stream(threaded_stream, innerstream);
+
+	pthreads_stream_set_parent(innerstream, threaded_stream);
+
+	pthreads_del_ref(innerstream);
+	pthreads_del_ref(threaded_stream);
+
+	return threaded_stream;
+}
+/* }}} */
+
+/* {{{ _pthreads_stream_temp_create */
+pthreads_stream_t *_pthreads_stream_temp_create(int mode, size_t max_memory_usage, zend_class_entry *ce) {
+	if(ce == NULL) {
+		ce = pthreads_file_stream_entry;
+	}
+	return pthreads_stream_temp_create_ex(mode, max_memory_usage, NULL, ce);
+}
+/* }}} */
+
+/* {{{ _pthreads_stream_temp_open */
+pthreads_stream_t *_pthreads_stream_temp_open(int mode, size_t max_memory_usage, char *buf, size_t length, zend_class_entry *ce) {
+	pthreads_stream_t *threaded_stream;
+	pthreads_stream_temp_data *ts;
+	zend_off_t newoffs;
+
+	if ((threaded_stream = pthreads_stream_temp_create(mode, max_memory_usage, ce)) != NULL) {
+		if (length) {
+			assert(buf != NULL);
+			pthreads_stream_temp_write(threaded_stream, buf, length);
+			pthreads_stream_temp_seek(threaded_stream, 0, SEEK_SET, &newoffs);
+		}
+		ts = (pthreads_stream_temp_data*)PTHREADS_FETCH_STREAMS_STREAM(threaded_stream)->abstract;
+		assert(ts != NULL);
+		ts->mode = mode;
+	}
+	return threaded_stream;
+}
+/* }}} */
+
+const pthreads_stream_ops pthreads_stream_rfc2397_ops = {
+	pthreads_stream_temp_write, pthreads_stream_temp_read,
+	pthreads_stream_temp_close, pthreads_stream_temp_free,
+	pthreads_stream_temp_flush,
+	"RFC2397",
+	pthreads_stream_temp_seek,
+	pthreads_stream_temp_cast,
+	pthreads_stream_temp_stat,
+	pthreads_stream_temp_set_option
+};
+
+/* {{{ */
+pthreads_stream_t * pthreads_stream_url_wrap_rfc2397(pthreads_stream_wrapper_t *threaded_wrapper, const char *path,
+												const char *mode, int options, zend_string **opened_path,
+												pthreads_stream_context_t *threaded_context, zend_class_entry *ce) {
+	pthreads_stream *stream;
+	pthreads_stream_t *threaded_stream;
+	pthreads_stream_temp_data *ts;
+	char *comma, *semi, *sep;
+	size_t mlen, dlen, plen, vlen, ilen;
+	zend_off_t newoffs;
+	zval meta;
+	int base64 = 0;
+	zend_string *base64_comma = NULL, *base64_tmp = NULL;
+
+	ZVAL_NULL(&meta);
+	if (memcmp(path, "data:", 5)) {
+		return NULL;
+	}
+
+	path += 5;
+	dlen = strlen(path);
+
+	if (dlen >= 2 && path[0] == '/' && path[1] == '/') {
+		dlen -= 2;
+		path += 2;
+	}
+
+	if ((comma = memchr(path, ',', dlen)) == NULL) {
+		pthreads_stream_wrapper_log_error(threaded_wrapper, options, "rfc2397: no comma in URL");
+		return NULL;
+	}
+
+	if (comma != path) {
+		/* meta info */
+		mlen = comma - path;
+		dlen -= mlen;
+		semi = memchr(path, ';', mlen);
+		sep = memchr(path, '/', mlen);
+
+		if (!semi && !sep) {
+			pthreads_stream_wrapper_log_error(threaded_wrapper, options, "rfc2397: illegal media type");
+			return NULL;
+		}
+
+		array_init(&meta);
+		if (!semi) { /* there is only a mime type */
+			add_assoc_stringl(&meta, "mediatype", (char *) path, mlen);
+			mlen = 0;
+		} else if (sep && sep < semi) { /* there is a mime type */
+			plen = semi - path;
+			add_assoc_stringl(&meta, "mediatype", (char *) path, plen);
+			mlen -= plen;
+			path += plen;
+		} else if (semi != path || mlen != sizeof(";base64")-1 || memcmp(path, ";base64", sizeof(";base64")-1)) { /* must be error since parameters are only allowed after mediatype */
+			zval_ptr_dtor(&meta);
+			pthreads_stream_wrapper_log_error(threaded_wrapper, options, "rfc2397: illegal media type");
+			return NULL;
+		}
+		/* get parameters and potentially ';base64' */
+		while(semi && (semi == path)) {
+			path++;
+			mlen--;
+			sep = memchr(path, '=', mlen);
+			semi = memchr(path, ';', mlen);
+			if (!sep || (semi && semi < sep)) { /* must be ';base64' or failure */
+				if (mlen != sizeof("base64")-1 || memcmp(path, "base64", sizeof("base64")-1)) {
+					/* must be error since parameters are only allowed after mediatype and we have no '=' sign */
+					zval_ptr_dtor(&meta);
+					pthreads_stream_wrapper_log_error(threaded_wrapper, options, "rfc2397: illegal parameter");
+					return NULL;
+				}
+				base64 = 1;
+				mlen -= sizeof("base64") - 1;
+				path += sizeof("base64") - 1;
+				break;
+			}
+			/* found parameter ... the heart of cs ppl lies in +1/-1 or was it +2 this time? */
+			plen = sep - path;
+			vlen = (semi ? (size_t)(semi - sep) : (mlen - plen)) - 1 /* '=' */;
+			if (plen != sizeof("mediatype")-1 || memcmp(path, "mediatype", sizeof("mediatype")-1)) {
+				add_assoc_stringl_ex(&meta, path, plen, sep + 1, vlen);
+			}
+			plen += vlen + 1;
+			mlen -= plen;
+			path += plen;
+		}
+		if (mlen) {
+			zval_ptr_dtor(&meta);
+			pthreads_stream_wrapper_log_error(threaded_wrapper, options, "rfc2397: illegal URL");
+			return NULL;
+		}
+	} else {
+		array_init(&meta);
+	}
+	add_assoc_bool(&meta, "base64", base64);
+
+	/* skip ',' */
+	comma++;
+	dlen--;
+
+	if (base64) {
+		base64_comma = php_base64_decode_ex((const unsigned char *)comma, dlen, 1);
+		if (!base64_comma) {
+			zval_ptr_dtor(&meta);
+			pthreads_stream_wrapper_log_error(threaded_wrapper, options, "rfc2397: unable to decode");
+			return NULL;
+		}
+		base64_tmp = zend_string_dup(base64_comma, 1);
+		zend_string_free(base64_comma);
+		base64_comma = base64_tmp;
+
+		comma = ZSTR_VAL(base64_comma);
+		ilen = ZSTR_LEN(base64_comma);
+	} else {
+		comma = strndup(comma, dlen);
+		dlen = php_url_decode(comma, dlen);
+		ilen = dlen;
+	}
+
+	if ((threaded_stream = pthreads_stream_temp_create(0, ~0u, ce)) != NULL) {
+		stream = PTHREADS_FETCH_STREAMS_STREAM(threaded_stream);
+		/* store data */
+		//pthreads_stream_temp_write(threaded_stream, comma, ilen);
+		//pthreads_stream_temp_seek(threaded_stream, 0, SEEK_SET, &newoffs);
+		/* set special stream stuff (enforce exact mode) */
+		vlen = strlen(mode);
+		if (vlen >= sizeof(stream->mode)) {
+			vlen = sizeof(stream->mode) - 1;
+		}
+		memcpy(stream->mode, mode, vlen);
+		stream->mode[vlen] = '\0';
+		stream->ops = &pthreads_stream_rfc2397_ops;
+		ts = (pthreads_stream_temp_data*)stream->abstract;
+		assert(ts != NULL);
+		ts->mode = mode && mode[0] == 'r' && mode[1] != '+' ? PTHREADS_TEMP_STREAM_READONLY : 0;
+		ZVAL_COPY_VALUE(&ts->meta, &meta);
+	}
+
+	if (base64_comma) {
+		zend_string_free(base64_comma);
+	} else {
+		free(comma);
+	}
+
+	return threaded_stream;
+}
+
+const pthreads_stream_wrapper_ops pthreads_stream_rfc2397_wops = {
+	pthreads_stream_url_wrap_rfc2397,
+	NULL, /* close */ NULL, /* fstat */
+	NULL, /* stat */ NULL, /* opendir */
+	"RFC2397",
+	NULL, /* unlink */ NULL, /* rename */
+	NULL, /* mkdir */ NULL, /* rmdir */
+	NULL, /* stream_metadata */
+};
+
+#endif

--- a/src/streams/memory.h
+++ b/src/streams/memory.h
@@ -1,0 +1,61 @@
+/*
+  +----------------------------------------------------------------------+
+  | pthreads                                                             |
+  +----------------------------------------------------------------------+
+  | Copyright (c) Joe Watkins 2018                                       |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | http://www.php.net/license/3_01.txt                                  |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors: Bastian Schneider <b.schneider@badnoob.com>                 |
+  | Borrowed code from php-src                                           |
+  +----------------------------------------------------------------------+
+ */
+#ifndef HAVE_PTHREADS_STREAMS_MEMORY_H
+#define HAVE_PTHREADS_STREAMS_MEMORY_H
+
+#define PTHREADS_STREAM_MAX_MEM	2 * 1024 * 1024
+
+#define PTHREADS_TEMP_STREAM_DEFAULT     0x0
+#define PTHREADS_TEMP_STREAM_READONLY    0x1
+#define PTHREADS_TEMP_STREAM_TAKE_BUFFER 0x2
+#define PTHREADS_TEMP_STREAM_APPEND      0x4
+
+#define pthreads_stream_memory_create(mode, ce) _pthreads_stream_memory_create((mode), (ce))
+#define pthreads_stream_memory_open(mode, buf, length, ce) _pthreads_stream_memory_open((mode), (buf), (length), (ce))
+#define pthreads_stream_memory_get_buffer(stream, length) _pthreads_stream_memory_get_buffer((stream), (length))
+
+#define pthreads_stream_temp_new() pthreads_stream_temp_create(PTHREADS_TEMP_STREAM_DEFAULT, PTHREADS_STREAM_MAX_MEM, NULL)
+#define pthreads_stream_temp_create(mode, max_memory_usage, ce) _pthreads_stream_temp_create((mode), (max_memory_usage), (ce))
+#define pthreads_stream_temp_create_ex(mode, max_memory_usage, tmpdir, ce) _pthreads_stream_temp_create_ex((mode), (max_memory_usage), (tmpdir), (ce))
+#define pthreads_stream_temp_open(mode, max_memory_usage, buf, length, ce) _pthreads_stream_temp_open((mode), (max_memory_usage), (buf), (length), (ce))
+
+pthreads_stream_t *_pthreads_stream_memory_create(int mode, zend_class_entry *ce);
+pthreads_stream_t *_pthreads_stream_memory_open(int mode, char *buf, size_t length, zend_class_entry *ce);
+char *_pthreads_stream_memory_get_buffer(pthreads_stream_t *threaded_stream, size_t *length);
+
+pthreads_stream_t *_pthreads_stream_temp_create(int mode, size_t max_memory_usage, zend_class_entry *ce);
+pthreads_stream_t *_pthreads_stream_temp_create_ex(int mode, size_t max_memory_usage, const char *tmpdir, zend_class_entry *ce);
+pthreads_stream_t *_pthreads_stream_temp_open(int mode, size_t max_memory_usage, char *buf, size_t length, zend_class_entry *ce);
+
+pthreads_stream_t * pthreads_stream_url_wrap_rfc2397(pthreads_stream_wrapper_t *threaded_wrapper, const char *path,
+												const char *mode, int options, zend_string **opened_path,
+												pthreads_stream_context_t *threaded_context, zend_class_entry *ce);
+
+int pthreads_stream_mode_from_str(const char *mode);
+const char *_pthreads_stream_mode_to_str(int mode);
+
+extern const pthreads_stream_ops pthreads_stream_memory_ops;
+extern const pthreads_stream_ops pthreads_stream_temp_ops;
+extern const pthreads_stream_ops pthreads_stream_rfc2397_ops;
+extern const pthreads_stream_wrapper_ops pthreads_stream_rfc2397_wops;
+
+#define PTHREADS_STREAM_IS_MEMORY &pthreads_stream_memory_ops
+#define PTHREADS_STREAM_IS_TEMP   &pthreads_stream_temp_ops
+
+#endif

--- a/src/streams/mmap.c
+++ b/src/streams/mmap.c
@@ -1,0 +1,79 @@
+/*
+  +----------------------------------------------------------------------+
+  | pthreads                                                             |
+  +----------------------------------------------------------------------+
+  | Copyright (c) Joe Watkins 2018                                       |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | http://www.php.net/license/3_01.txt                                  |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors: Bastian Schneider <b.schneider@badnoob.com>                 |
+  | Borrowed code from php-src                                           |
+  +----------------------------------------------------------------------+
+ */
+#ifndef HAVE_PTHREADS_STREAMS_MMAP
+#define HAVE_PTHREADS_STREAMS_MMAP
+
+#ifndef HAVE_PTHREADS_H
+#	include <src/pthreads.h>
+#endif
+
+#ifndef HAVE_PTHREADS_STREAM_H
+#	include <src/streams.h>
+#endif
+
+/* Memory Mapping interface for streams */
+//#include "php.h"
+#ifndef HAVE_PTHREADS_STREAMS_INTERNAL_H
+#	include <src/streams/internal.h>
+#endif
+
+char *_pthreads_stream_mmap_range(pthreads_stream_t *threaded_stream, size_t offset, size_t length, pthreads_stream_mmap_access_t mode, size_t *mapped_len) {
+	pthreads_stream_mmap_range range;
+
+	range.offset = offset;
+	range.length = length;
+	range.mode = mode;
+	range.mapped = NULL;
+
+	/* For now, we impose an arbitrary limit to avoid
+	 * runaway swapping when large files are passed through. */
+	if (length > 4 * 1024 * 1024) {
+		return NULL;
+	}
+
+	if (PTHREADS_STREAM_OPTION_RETURN_OK == pthreads_stream_set_option(threaded_stream, PTHREADS_STREAM_OPTION_MMAP_API, PTHREADS_STREAM_MMAP_MAP_RANGE, &range)) {
+		if (mapped_len) {
+			*mapped_len = range.length;
+		}
+		return range.mapped;
+	}
+	return NULL;
+}
+
+int _pthreads_stream_mmap_unmap(pthreads_stream_t *threaded_stream) {
+	return pthreads_stream_set_option(threaded_stream, PTHREADS_STREAM_OPTION_MMAP_API, PTHREADS_STREAM_MMAP_UNMAP, NULL) == PTHREADS_STREAM_OPTION_RETURN_OK ? 1 : 0;
+}
+
+int _pthreads_stream_mmap_unmap_ex(pthreads_stream_t *threaded_stream, zend_off_t readden) {
+	int ret = 1;
+
+	if(stream_lock(threaded_stream)) {
+		if (pthreads_stream_seek(threaded_stream, readden, SEEK_CUR) != 0) {
+			ret = 0;
+		}
+		if (pthreads_stream_mmap_unmap(threaded_stream) == 0) {
+			ret = 0;
+		}
+		stream_unlock(threaded_stream);
+	}
+
+	return ret;
+}
+
+#endif

--- a/src/streams/mmap.h
+++ b/src/streams/mmap.h
@@ -1,0 +1,79 @@
+/*
+  +----------------------------------------------------------------------+
+  | pthreads                                                             |
+  +----------------------------------------------------------------------+
+  | Copyright (c) Joe Watkins 2018                                       |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | http://www.php.net/license/3_01.txt                                  |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors: Bastian Schneider <b.schneider@badnoob.com>                 |
+  | Borrowed code from php-src                                           |
+  +----------------------------------------------------------------------+
+ */
+#ifndef HAVE_PTHREADS_STREAMS_MMAP_H
+#define HAVE_PTHREADS_STREAMS_MMAP_H
+
+/* Memory Mapping interface for streams.
+ * The intention is to provide a uniform interface over the most common
+ * operations that are used within PHP itself, rather than a complete
+ * API for all memory mapping needs.
+ *
+ * ATM, we support only mmap(), but win32 memory mapping support will
+ * follow soon.
+ * */
+
+typedef enum {
+	/* Does the stream support mmap ? */
+	PTHREADS_STREAM_MMAP_SUPPORTED,
+	/* Request a range and offset to be mapped;
+	 * while mapped, you MUST NOT use any read/write functions
+	 * on the stream (win9x compatibility) */
+	PTHREADS_STREAM_MMAP_MAP_RANGE,
+	/* Unmap the last range that was mapped for the stream */
+	PTHREADS_STREAM_MMAP_UNMAP
+} pthreads_stream_mmap_operation_t;
+
+typedef enum {
+	PTHREADS_STREAM_MAP_MODE_READONLY,
+	PTHREADS_STREAM_MAP_MODE_READWRITE,
+	PTHREADS_STREAM_MAP_MODE_SHARED_READONLY,
+	PTHREADS_STREAM_MAP_MODE_SHARED_READWRITE
+} pthreads_stream_mmap_access_t;
+
+typedef struct {
+	/* requested offset and length.
+	 * If length is 0, the whole file is mapped */
+	size_t offset;
+	size_t length;
+
+	pthreads_stream_mmap_access_t mode;
+
+	/* returned mapped address */
+	char *mapped;
+
+} pthreads_stream_mmap_range;
+
+#define PTHREADS_STREAM_MMAP_ALL 0
+
+#define pthreads_stream_mmap_supported(threaded_stream)	(_pthreads_stream_set_option((threaded_stream), PTHREADS_STREAM_OPTION_MMAP_API, PTHREADS_STREAM_MMAP_SUPPORTED, NULL) == 0 ? 1 : 0)
+
+/* Returns 1 if the stream in its current state can be memory mapped, 0 otherwise */
+#define pthreads_stream_mmap_possible(threaded_stream)	(!pthreads_stream_is_filtered((threaded_stream)) && pthreads_stream_mmap_supported(threaded_stream))
+
+char *_pthreads_stream_mmap_range(pthreads_stream_t *threaded_stream, size_t offset, size_t length, pthreads_stream_mmap_access_t mode, size_t *mapped_len);
+#define pthreads_stream_mmap_range(threaded_stream, offset, length, mode, mapped_len)	_pthreads_stream_mmap_range((threaded_stream), (offset), (length), (mode), (mapped_len))
+
+/* un-maps the last mapped range */
+int _pthreads_stream_mmap_unmap(pthreads_stream_t *threaded_stream);
+#define pthreads_stream_mmap_unmap(threaded_stream)	_pthreads_stream_mmap_unmap((threaded_stream))
+
+int _pthreads_stream_mmap_unmap_ex(pthreads_stream_t *threaded_stream, zend_off_t readden);
+#define pthreads_stream_mmap_unmap_ex(threaded_stream, readden)	_pthreads_stream_mmap_unmap_ex((threaded_stream), (readden))
+
+#endif

--- a/src/streams/standard_filters.c
+++ b/src/streams/standard_filters.c
@@ -1,0 +1,74 @@
+/*
+  +----------------------------------------------------------------------+
+  | pthreads                                                             |
+  +----------------------------------------------------------------------+
+  | Copyright (c) Joe Watkins 2018                                       |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | http://www.php.net/license/3_01.txt                                  |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors: Bastian Schneider <b.schneider@badnoob.com>                 |
+  | Borrowed code from php-src                                           |
+  +----------------------------------------------------------------------+
+ */
+#ifndef HAVE_PTHREADS_STREAMS_STANDARD_FILTERS
+#define HAVE_PTHREADS_STREAMS_STANDARD_FILTERS
+
+#ifndef HAVE_PTHREADS_H
+#	include <src/pthreads.h>
+#endif
+
+#ifndef HAVE_PTHREADS_STREAM_H
+#	include <src/streams.h>
+#endif
+
+#ifndef HAVE_PTHREADS_STREAMS_STANDARD_FILTERS_H
+#	include <src/streams/standard_filters.h>
+#endif
+
+#ifndef HAVE_PTHREADS_STREAMS_STRING_FILTERS
+#	include <src/streams/string_filters.c>
+#endif
+
+static const struct {
+	const pthreads_stream_filter_ops *ops;
+	const pthreads_stream_filter_factory *factory;
+} pthreads_standard_filters[] = {
+	{ &pthreads_strfilter_rot13_ops, &pthreads_strfilter_rot13_factory },
+	{ &pthreads_strfilter_toupper_ops, &pthreads_strfilter_toupper_factory },
+	{ &pthreads_strfilter_tolower_ops, &pthreads_strfilter_tolower_factory },
+	/* additional filters to go here */
+	{ NULL, NULL }
+};
+
+/* {{{ filter init and shutdown */
+int standard_filters_init() {
+	int i;
+
+	for (i = 0; pthreads_standard_filters[i].ops; i++) {
+		if (FAILURE == pthreads_stream_filter_register_factory(
+				pthreads_standard_filters[i].ops->label,
+				pthreads_standard_filters[i].factory
+				)) {
+			return FAILURE;
+		}
+	}
+	return SUCCESS;
+}
+
+int standard_filters_shutdown() {
+	int i;
+
+	for (i = 0; pthreads_standard_filters[i].ops; i++) {
+		pthreads_stream_filter_unregister_factory(pthreads_standard_filters[i].ops->label);
+	}
+	return SUCCESS;
+}
+/* }}} */
+
+#endif

--- a/src/streams/standard_filters.h
+++ b/src/streams/standard_filters.h
@@ -1,0 +1,25 @@
+/*
+  +----------------------------------------------------------------------+
+  | pthreads                                                             |
+  +----------------------------------------------------------------------+
+  | Copyright (c) Joe Watkins 2018                                       |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | http://www.php.net/license/3_01.txt                                  |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors: Bastian Schneider <b.schneider@badnoob.com>                 |
+  | Borrowed code from php-src                                           |
+  +----------------------------------------------------------------------+
+ */
+#ifndef HAVE_PTHREADS_STREAMS_STANDARD_FILTERS_H
+#define HAVE_PTHREADS_STREAMS_STANDARD_FILTERS_H
+
+int standard_filters_init();
+int standard_filters_shutdown();
+
+#endif

--- a/src/streams/streamglobals.c
+++ b/src/streams/streamglobals.c
@@ -1,0 +1,176 @@
+/*
+  +----------------------------------------------------------------------+
+  | pthreads                                                             |
+  +----------------------------------------------------------------------+
+  | Copyright (c) Joe Watkins 2018                                       |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | http://www.php.net/license/3_01.txt                                  |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors: Bastian Schneider <b.schneider@badnoob.com>                 |
+  | Borrowed code from php-src                                           |
+  +----------------------------------------------------------------------+
+ */
+#ifndef HAVE_PTHREADS_STREAM_GLOBALS
+#define HAVE_PTHREADS_STREAM_GLOBALS
+
+#ifndef HAVE_PTHREADS_H
+#	include <src/pthreads.h>
+#endif
+
+#ifndef HAVE_PTHREADS_STREAM_H
+#	include <src/streams.h>
+#endif
+
+#ifndef HAVE_PTHREADS_STREAM_GLOBALS_H
+#	include <src/streams/streamglobals.h>
+#endif
+
+#ifndef HAVE_PTHREADS_OBJECT_H
+#	include <src/object.h>
+#endif
+
+struct _pthreads_stream_globals pthreads_stream_globals;
+
+#ifndef PTHREADS_STREAMG
+#	define PTHREADS_STREAMG () ?  : (void***) &pthreads_stream_globals
+#endif
+
+static void pthreads_filter_item_dtor(zval *zv) {
+	struct pthreads_user_filter_data *fdat = Z_PTR_P(zv);
+	free(fdat);
+}
+
+static void pthreads_wrapper_list_dtor(zval *item) {
+	zend_llist *list = (zend_llist*)Z_PTR_P(item);
+	zend_llist_destroy(list);
+	pefree(list, 1);
+}
+
+static void pthreads_stream_wrapper_dtor(zval *item) {
+	pthreads_stream_wrapper_t *threaded_wrapper = (pthreads_stream_wrapper_t*)Z_PTR_P(item);
+	pthreads_stream_wrapper *wrapper = PTHREADS_FETCH_STREAMS_WRAPPER(threaded_wrapper);
+	struct pthreads_user_stream_wrapper * uwrap = wrapper->abstract;
+
+	if(uwrap) {
+		free(uwrap->protoname);
+		zend_string_release(uwrap->classname);
+
+		if(uwrap->threaded_wrapper) {
+			pthreads_ptr_dtor(uwrap->threaded_wrapper);
+		}
+		free(uwrap);
+	}
+}
+
+/* {{{ */
+int pthreads_stream_globals_is_main_context() {
+	return (!PTHREADS_STREAMG(creatorId) || PTHREADS_STREAMG(creatorId) == pthreads_self()) ? 1 : 0;
+} /* }}} */
+
+/* {{{ */
+void pthreads_stream_globals_init() {
+	PTHREADS_STREAMG(monitor) = pthreads_monitor_alloc();
+	pthreads_hashtable_init(&PTHREADS_STREAMG(xport_hash), 8, NULL);
+	pthreads_hashtable_init(&PTHREADS_STREAMG(url_stream_wrappers_hash), 8, pthreads_stream_wrapper_dtor);
+	pthreads_hashtable_init(&PTHREADS_STREAMG(stream_filters_hash), 8, NULL);
+	pthreads_hashtable_init(&PTHREADS_STREAMG(wrapper_errors), 8, pthreads_wrapper_list_dtor);
+	pthreads_hashtable_init(&PTHREADS_STREAMG(user_filter_map), 8, pthreads_filter_item_dtor);
+
+	PTHREADS_STREAMG(CurrentStatFile)  	= NULL;
+	PTHREADS_STREAMG(CurrentLStatFile) 	= NULL;
+	PTHREADS_STREAMG(default_context)	= NULL;
+
+	PTHREADS_STREAMG(creatorId) = 0;
+} /* }}} */
+
+
+/* {{{ */
+int pthreads_stream_globals_object_init() {
+	if(PTHREADS_STREAMG(creatorId) == 0) {
+		PTHREADS_STREAMG(creatorId)				 = pthreads_self();
+		PTHREADS_STREAMG(default_context)        = pthreads_object_init(pthreads_stream_context_entry);
+
+		PTHREADS_STREAMG(plain_files_wrapper)    = pthreads_object_init(pthreads_stream_wrapper_entry);
+		PTHREADS_STREAMG(stream_php_wrapper)     = pthreads_object_init(pthreads_stream_wrapper_entry);
+		PTHREADS_STREAMG(stream_rfc2397_wrapper) = pthreads_object_init(pthreads_stream_wrapper_entry);
+		PTHREADS_STREAMG(stream_http_wrapper)    = pthreads_object_init(pthreads_stream_wrapper_entry);
+		PTHREADS_STREAMG(stream_ftp_wrapper)     = pthreads_object_init(pthreads_stream_wrapper_entry);
+		PTHREADS_STREAMG(glob_stream_wrapper)    = pthreads_object_init(pthreads_stream_wrapper_entry);
+
+		return SUCCESS;
+	}
+	return FAILURE;
+} /* }}} */
+
+/* {{{ */
+int pthreads_stream_globals_object_shutdown() {
+	if(pthreads_stream_globals_is_main_context()) {
+		pthreads_ptr_dtor(PTHREADS_STREAMG(glob_stream_wrapper));
+		pthreads_ptr_dtor(PTHREADS_STREAMG(stream_ftp_wrapper));
+		pthreads_ptr_dtor(PTHREADS_STREAMG(stream_http_wrapper));
+		pthreads_ptr_dtor(PTHREADS_STREAMG(stream_rfc2397_wrapper));
+		pthreads_ptr_dtor(PTHREADS_STREAMG(stream_php_wrapper));
+		pthreads_ptr_dtor(PTHREADS_STREAMG(plain_files_wrapper));
+		pthreads_ptr_dtor(PTHREADS_STREAMG(default_context));
+
+		pthreads_clear_hashtable(&PTHREADS_STREAMG(xport_hash));
+		pthreads_clear_hashtable(&PTHREADS_STREAMG(url_stream_wrappers_hash));
+		pthreads_clear_hashtable(&PTHREADS_STREAMG(stream_filters_hash));
+		pthreads_clear_hashtable(&PTHREADS_STREAMG(wrapper_errors));
+		pthreads_clear_hashtable(&PTHREADS_STREAMG(user_filter_map));
+
+		PTHREADS_STREAMG(default_context)        = NULL;
+		PTHREADS_STREAMG(plain_files_wrapper)    = NULL;
+		PTHREADS_STREAMG(stream_php_wrapper)     = NULL;
+		PTHREADS_STREAMG(stream_rfc2397_wrapper) = NULL;
+		PTHREADS_STREAMG(stream_http_wrapper)    = NULL;
+		PTHREADS_STREAMG(stream_ftp_wrapper)     = NULL;
+		PTHREADS_STREAMG(glob_stream_wrapper)    = NULL;
+
+		return SUCCESS;
+	}
+	return FAILURE;
+} /* }}} */
+
+int pthreads_is_default_context(pthreads_stream_context_t *threaded_context) {
+	return pthreads_object_compare(threaded_context, PTHREADS_STREAMG(default_context)) == 0 ? 1 : 0;
+}
+
+/* {{{ */
+void pthreads_stream_globals_shutdown() {
+	pthreads_free_hashtable(&PTHREADS_STREAMG(url_stream_wrappers_hash));
+	pthreads_free_hashtable(&PTHREADS_STREAMG(stream_filters_hash));
+	pthreads_free_hashtable(&PTHREADS_STREAMG(wrapper_errors));
+	pthreads_free_hashtable(&PTHREADS_STREAMG(user_filter_map));
+	pthreads_free_hashtable(&PTHREADS_STREAMG(xport_hash));
+
+	if (PTHREADS_STREAMG(CurrentStatFile)) {
+		free(PTHREADS_STREAMG(CurrentStatFile));
+	}
+
+	if (PTHREADS_STREAMG(CurrentLStatFile)) {
+		free(PTHREADS_STREAMG(CurrentLStatFile));
+	}
+	PTHREADS_STREAMG(CurrentStatFile) = NULL;
+	PTHREADS_STREAMG(CurrentLStatFile) = NULL;
+
+	pthreads_monitor_free(PTHREADS_STREAMG(monitor));
+} /* }}} */
+
+/* {{{ */
+zend_bool pthreads_stream_globals_lock() {
+	return pthreads_monitor_lock(PTHREADS_STREAMG(monitor));
+} /* }}} */
+
+/* {{{ */
+void pthreads_stream_globals_unlock() {
+	pthreads_monitor_unlock(PTHREADS_STREAMG(monitor));
+} /* }}} */
+
+#endif

--- a/src/streams/streamglobals.h
+++ b/src/streams/streamglobals.h
@@ -1,0 +1,85 @@
+/*
+  +----------------------------------------------------------------------+
+  | pthreads                                                             |
+  +----------------------------------------------------------------------+
+  | Copyright (c) Joe Watkins 2018                                       |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | http://www.php.net/license/3_01.txt                                  |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors: Bastian Schneider <b.schneider@badnoob.com>                 |
+  | Borrowed code from php-src                                           |
+  +----------------------------------------------------------------------+
+ */
+#ifndef HAVE_PTHREADS_STREAM_GLOBALS_H
+#define HAVE_PTHREADS_STREAM_GLOBALS_H
+
+/* {{{ pthreads_stream_globals */
+struct _pthreads_stream_globals {
+	pthreads_monitor_t *monitor;
+	pthreads_stream_context_t *default_context;
+	pthreads_hashtable xport_hash;
+	pthreads_hashtable url_stream_wrappers_hash;
+	pthreads_hashtable stream_filters_hash;
+	pthreads_hashtable wrapper_errors;
+	pthreads_hashtable user_filter_map;
+
+	pthreads_stream_wrapper_t *plain_files_wrapper;
+	pthreads_stream_wrapper_t *stream_php_wrapper;
+	pthreads_stream_wrapper_t *stream_rfc2397_wrapper;
+	pthreads_stream_wrapper_t *stream_http_wrapper;
+	pthreads_stream_wrapper_t *stream_ftp_wrapper;
+	pthreads_stream_wrapper_t *glob_stream_wrapper;
+
+	/* filestat.c && main/streams/streams.c */
+	char *CurrentStatFile, *CurrentLStatFile;
+	pthreads_stream_statbuf ssb, lssb;
+
+	ulong creatorId;
+}; /* }}} */
+
+extern struct _pthreads_stream_globals pthreads_stream_globals;
+
+ZEND_EXTERN_MODULE_GLOBALS(pthreads_stream)
+
+#define PTHREADS_GET_DEF_CONTEXT PTHREADS_STREAMG(default_context)
+
+/* {{{ PTHREADS_STREAMG */
+#define PTHREADS_STREAMG(v) pthreads_stream_globals.v
+/* }}} */
+
+/* {{{  */
+int pthreads_stream_globals_is_main_context(); /* }}} */
+
+/* {{{ initialize (true) file globals */
+void pthreads_stream_globals_init(); /* }}} */
+
+/* {{{  */
+int pthreads_stream_globals_object_init(); /* }}} */
+
+/* {{{  */
+int pthreads_stream_globals_object_shutdown(); /* }}} */
+
+int pthreads_is_default_context(pthreads_stream_context_t *threaded_context);
+
+/* {{{  */
+void pthreads_stream_globals_shutdown(); /* }}} */
+
+/* {{{  */
+zend_bool pthreads_stream_globals_lock(); /* }}} */
+
+/* {{{  */
+void pthreads_stream_globals_unlock(); /* }}} */
+
+#define INIT_GLOBAL_WRAPPER(wrapper, ops, abst, isurl) do { \
+	PTHREADS_FETCH_STREAMS_WRAPPER(PTHREADS_STREAMG(wrapper))->wops = &(ops); \
+	PTHREADS_FETCH_STREAMS_WRAPPER(PTHREADS_STREAMG(wrapper))->abstract = (abst); \
+	PTHREADS_FETCH_STREAMS_WRAPPER(PTHREADS_STREAMG(wrapper))->is_url = (isurl); \
+} while(0)
+
+#endif

--- a/src/streams/streams_api.c
+++ b/src/streams/streams_api.c
@@ -1,0 +1,1180 @@
+/*
+  +----------------------------------------------------------------------+
+  | pthreads                                                             |
+  +----------------------------------------------------------------------+
+  | Copyright (c) Joe Watkins 2018                                       |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | http://www.php.net/license/3_01.txt                                  |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors: Bastian Schneider <b.schneider@badnoob.com>                 |
+  | Borrowed code from php-src                                           |
+  +----------------------------------------------------------------------+
+ */
+#ifndef HAVE_PTHREADS_STREAMS_STREAMS_API
+#define HAVE_PTHREADS_STREAMS_STREAMS_API
+
+#ifndef PHP_WIN32
+#define php_select(m, r, w, e, t)	select(m, r, w, e, t)
+typedef unsigned long long pthreads_timeout_ull;
+#else
+#include "win32/select.h"
+#include "win32/sockets.h"
+#include "win32/console.h"
+typedef unsigned __int64 pthreads_timeout_ull;
+#endif
+
+/**
+ * Streams
+ */
+
+/* {{{ pthreads_streams_api_get_filters */
+void pthreads_streams_api_get_filters(zval *return_value) {
+	zend_string *filter_name;
+	pthreads_hashtable *filter_hash;
+
+	array_init(return_value);
+
+	filter_hash = pthreads_get_stream_filters_hash();
+
+	if(MONITOR_LOCK(filter_hash)) {
+		ZEND_HASH_FOREACH_STR_KEY(&filter_hash->ht, filter_name) {
+			if (filter_name) {
+				add_next_index_str(return_value, zend_string_dup(filter_name, 1));
+			}
+		} ZEND_HASH_FOREACH_END();
+
+		MONITOR_UNLOCK(filter_hash);
+	}
+	/* It's okay to return an empty array if no filters are registered */
+}
+/* }}} */
+
+
+/* {{{ pthreads_streams_api_get_transports */
+void pthreads_streams_api_get_transports(zval *return_value) {
+	pthreads_hashtable *xport_hash;
+	zend_string *stream_xport;
+
+	array_init(return_value);
+
+	xport_hash = pthreads_stream_xport_get_hash();
+
+	if(MONITOR_LOCK(xport_hash)) {
+		ZEND_HASH_FOREACH_STR_KEY(&xport_hash->ht, stream_xport) {
+			if(stream_xport) {
+				add_next_index_str(return_value, zend_string_copy(stream_xport));
+			}
+		} ZEND_HASH_FOREACH_END();
+
+		MONITOR_UNLOCK(xport_hash);
+	}
+	/* It's okay to return an empty array if no transports are registered */
+}
+/* }}} */
+
+/* {{{ pthreads_streams_api_get_wrappers */
+void pthreads_streams_api_get_wrappers(zval *return_value) {
+	pthreads_hashtable *url_stream_wrappers_hash;
+	zend_string *stream_protocol;
+
+	array_init(return_value);
+
+	url_stream_wrappers_hash = pthreads_stream_get_url_stream_wrappers_hash();
+
+	if(MONITOR_LOCK(url_stream_wrappers_hash)) {
+		ZEND_HASH_FOREACH_STR_KEY(&url_stream_wrappers_hash->ht, stream_protocol) {
+			if (stream_protocol) {
+				add_next_index_str(return_value, zend_string_copy(stream_protocol));
+			}
+		} ZEND_HASH_FOREACH_END();
+
+		MONITOR_UNLOCK(url_stream_wrappers_hash);
+	}
+	/* It's okay to return an empty array if no wrappers are registered */
+}
+/* }}} */
+
+/* {{{ pthreads_streams_api_register_wrapper */
+void pthreads_streams_api_register_wrapper(zend_string *protocol, zend_string *classname, zend_long flags, zval *return_value) {
+	struct pthreads_user_stream_wrapper * uwrap;
+	pthreads_stream_wrapper *wrapper;
+	zend_class_entry *ce;
+
+	if ((ce = zend_lookup_class(classname)) != NULL) {
+		if(!instanceof_function(ce, pthreads_threaded_entry)) {
+			php_error_docref(NULL, E_WARNING,
+								"user-wrapper \"%s\" must be an instance of Threaded",
+								ZSTR_VAL(classname));
+
+			RETURN_FALSE;
+		}
+
+		uwrap = (struct pthreads_user_stream_wrapper *)calloc(1, sizeof(*uwrap));
+		uwrap->protoname = strndup(ZSTR_VAL(protocol), ZSTR_LEN(protocol));
+		uwrap->classname = zend_string_init(ZSTR_VAL(classname), ZSTR_LEN(classname), 1);
+		uwrap->threaded_wrapper = pthreads_stream_wrapper_new();
+
+		wrapper = PTHREADS_FETCH_STREAMS_WRAPPER(uwrap->threaded_wrapper);
+		wrapper->wops = &pthreads_user_stream_wops;
+		wrapper->abstract = uwrap;
+		wrapper->is_url = ((flags & PTHREADS_STREAM_IS_URL) != 0);
+
+		if (pthreads_register_url_stream_wrapper(ZSTR_VAL(protocol), uwrap->threaded_wrapper) == SUCCESS) {
+			RETURN_TRUE;
+		} else {
+			pthreads_hashtable *url_stream_wrappers_hash = &PTHREADS_STREAMG(url_stream_wrappers_hash);
+			int protocol_exist = 0;
+
+			if(MONITOR_LOCK(url_stream_wrappers_hash)) {
+				protocol_exist = zend_hash_exists(&url_stream_wrappers_hash->ht, protocol);
+				MONITOR_UNLOCK(url_stream_wrappers_hash);
+			}
+
+			/* We failed.  But why? */
+			if (protocol_exist) {
+				php_error_docref(NULL, E_WARNING, "Protocol %s:// is already defined.", ZSTR_VAL(protocol));
+			} else {
+				/* Hash doesn't exist so it must have been an invalid protocol scheme */
+				php_error_docref(NULL, E_WARNING, "Invalid protocol scheme specified. Unable to register wrapper class %s to %s://", ZSTR_VAL(classname), ZSTR_VAL(protocol));
+			}
+		}
+		pthreads_ptr_dtor(uwrap->threaded_wrapper);
+		free(uwrap);
+	} else {
+		php_error_docref(NULL, E_WARNING, "class '%s' is undefined", ZSTR_VAL(classname));
+	}
+
+	RETURN_FALSE;
+}
+/* }}} */
+
+/* {{{ pthreads_streams_api_unregister_wrapper */
+void pthreads_streams_api_unregister_wrapper(zend_string *protocol, zval *return_value) {
+	if (pthreads_unregister_url_stream_wrapper(ZSTR_VAL(protocol)) == FAILURE) {
+		/* We failed */
+		php_error_docref(NULL, E_WARNING, "Unable to unregister protocol %s://", ZSTR_VAL(protocol));
+		RETURN_FALSE;
+	}
+
+	RETURN_TRUE;
+}
+/* }}} */
+
+/* {{{ pthreads_streams_api_register_filter */
+void pthreads_streams_api_register_filter(zend_string *filtername, zend_string *classname, zval *return_value) {
+	pthreads_hashtable *stream_filters_hash;
+
+	filtername = zend_string_init_interned(ZSTR_VAL(filtername), ZSTR_LEN(filtername), 1);
+	classname = zend_string_init_interned(ZSTR_VAL(classname), ZSTR_LEN(classname), 1);
+
+	int added = pthreads_streams_add_user_filter_map_entry(filtername, classname);
+
+	RETVAL_FALSE;
+
+	stream_filters_hash = &PTHREADS_STREAMG(stream_filters_hash);
+
+	if(added == SUCCESS && MONITOR_LOCK(stream_filters_hash)) {
+		if (pthreads_stream_filter_register_factory(ZSTR_VAL(filtername), &pthreads_user_filter_factory) == SUCCESS) {
+			RETVAL_TRUE;
+		} else {
+			pthreads_streams_drop_user_filter_map_entry(filtername);
+		}
+		MONITOR_UNLOCK(stream_filters_hash);
+	}
+}
+/* }}} */
+
+/**
+ * Stream
+ */
+
+/* {{{ pthreads_streams_api_stream_copy_to_stream */
+void pthreads_streams_api_stream_copy_to_stream(zval *object, zval *dest, zend_long maxlen, zend_long offset, zval *return_value) {
+	pthreads_stream_t *threaded_src = PTHREADS_FETCH_FROM(Z_OBJ_P(object));
+	pthreads_stream_t *threaded_dest = PTHREADS_FETCH_FROM(Z_OBJ_P(dest));
+	size_t len;
+	int ret;
+
+	if (offset > 0 && pthreads_stream_seek(threaded_src, offset, SEEK_SET) < 0) {
+		php_error_docref(NULL, E_WARNING, "Failed to seek to position " ZEND_LONG_FMT " in the stream", offset);
+		RETURN_LONG(-1);
+	}
+	ret = pthreads_stream_copy_to_stream_ex(threaded_src, threaded_dest, maxlen, &len);
+
+	if (ret != SUCCESS) {
+		RETURN_LONG(-1);
+	}
+	RETURN_LONG(len);
+}
+/* }}} */
+
+/* {{{ pthreads_streams_api_stream_apply_filter_to_stream */
+void pthreads_streams_api_stream_apply_filter_to_stream(int append, zval *object, zend_string *filtername, zend_long read_write, zval *params, zval *return_value) {
+	pthreads_stream_t *threaded_stream = PTHREADS_FETCH_FROM(Z_OBJ_P(object));
+	pthreads_stream *stream = PTHREADS_FETCH_STREAMS_STREAM(threaded_stream);
+	pthreads_stream_filter_t *threaded_filter = NULL;
+	int ret;
+	if ((read_write & PTHREADS_STREAM_FILTER_ALL) == 0) {
+		/* Chain not specified.
+		 * Examine stream->mode to determine which filters are needed
+		 * There's no harm in attaching a filter to an unused chain,
+		 * but why waste the memory and clock cycles?
+		 */
+		if (strchr(stream->mode, 'r') || strchr(stream->mode, '+')) {
+			read_write |= PTHREADS_STREAM_FILTER_READ;
+		}
+		if (strchr(stream->mode, 'w') || strchr(stream->mode, '+') || strchr(stream->mode, 'a')) {
+			read_write |= PTHREADS_STREAM_FILTER_WRITE;
+		}
+	}
+
+	if (read_write & PTHREADS_STREAM_FILTER_READ) {
+		threaded_filter = pthreads_stream_filter_create(ZSTR_VAL(filtername), params);
+		if (threaded_filter == NULL) {
+			RETURN_NULL();
+		}
+
+		if (append) {
+			ret = pthreads_stream_filter_append_ex(pthreads_stream_get_readfilters(threaded_stream), threaded_filter);
+		} else {
+			ret = pthreads_stream_filter_prepend_ex(pthreads_stream_get_readfilters(threaded_stream), threaded_filter);
+		}
+		if (ret != SUCCESS) {
+			pthreads_stream_filter_remove(threaded_filter);
+			RETURN_NULL();
+		}
+	}
+
+	if (read_write & PTHREADS_STREAM_FILTER_WRITE) {
+		threaded_filter = pthreads_stream_filter_create(ZSTR_VAL(filtername), params);
+		if (threaded_filter == NULL) {
+			RETURN_NULL();
+		}
+
+		if (append) {
+			ret = pthreads_stream_filter_append_ex(pthreads_stream_get_writefilters(threaded_stream), threaded_filter);
+		} else {
+			ret = pthreads_stream_filter_prepend_ex(pthreads_stream_get_writefilters(threaded_stream), threaded_filter);
+		}
+		if (ret != SUCCESS) {
+			pthreads_stream_filter_remove(threaded_filter);
+			RETURN_NULL();
+		}
+	}
+
+	if (threaded_filter) {
+		RETURN_OBJ(PTHREADS_STD_P(threaded_filter));
+	} else {
+		RETURN_NULL();
+	}
+}
+/* }}} */
+
+/* {{{ proto int stream_socket_enable_crypto(resource stream, bool enable [, int cryptokind [, resource sessionstream]])
+   Enable or disable a specific kind of crypto on the stream */
+void pthreads_streams_api_stream_enable_crypto(zval *object, zend_bool enable, zend_long cryptokind, zval *zsessstream, zval *return_value) {
+	pthreads_stream_t *threaded_stream = PTHREADS_FETCH_FROM(Z_OBJ_P(object));
+	pthreads_stream_t *threaded_session_stream = NULL;
+	int ret;
+
+	if (enable) {
+		if (zsessstream) {
+			threaded_session_stream = PTHREADS_FETCH_FROM(Z_OBJ_P(zsessstream));
+		}
+
+		if (pthreads_stream_xport_crypto_setup(threaded_stream, cryptokind, threaded_session_stream) < 0) {
+			RETURN_FALSE;
+		}
+	}
+
+	ret = pthreads_stream_xport_crypto_enable(threaded_stream, enable);
+	switch (ret) {
+		case -1:
+			RETURN_FALSE;
+
+		case 0:
+			RETURN_LONG(0);
+
+		default:
+			RETURN_TRUE;
+	}
+}
+/* }}} */
+
+/* {{{ pthreads_streams_api_stream_get_contents */
+void pthreads_streams_api_stream_get_contents(zval *object, zend_long maxlen, zend_long desiredpos, zval *return_value) {
+	pthreads_stream_t *threaded_stream = PTHREADS_FETCH_FROM(Z_OBJ_P(object));
+	zend_string *contents;
+
+	if (desiredpos >= 0) {
+		int		seek_res = 0;
+		zend_off_t	position;
+
+		position = pthreads_stream_tell(threaded_stream);
+		if (position >= 0 && desiredpos > position) {
+			/* use SEEK_CUR to allow emulation in streams that don't support seeking */
+			seek_res = pthreads_stream_seek(threaded_stream, desiredpos - position, SEEK_CUR);
+		} else if (desiredpos < position)  {
+			/* desired position before position or error on tell */
+			seek_res = pthreads_stream_seek(threaded_stream, desiredpos, SEEK_SET);
+		}
+
+		if (seek_res != 0) {
+			php_error_docref(NULL, E_WARNING,
+				"Failed to seek to position " ZEND_LONG_FMT " in the stream", desiredpos);
+			RETURN_NULL();
+		}
+	}
+
+	if (maxlen > INT_MAX) {
+		php_error_docref(NULL, E_WARNING, "maxlen truncated from " ZEND_LONG_FMT " to %d bytes", maxlen, INT_MAX);
+		maxlen = INT_MAX;
+	}
+	if ((contents = pthreads_stream_copy_to_mem(threaded_stream, maxlen, 0))) {
+		RETURN_STR(contents);
+	} else {
+		RETURN_NULL();
+	}
+}
+/* }}} */
+
+/* {{{ pthreads_streams_api_stream_get_line */
+void pthreads_streams_api_stream_get_line(zval *object, zend_long max_length, zend_string *ending, zval *return_value) {
+	pthreads_stream_t *threaded_stream = PTHREADS_FETCH_FROM(Z_OBJ_P(object));
+	zend_string *buf;
+	char *str = NULL;
+	size_t str_len = 0;
+
+	if (!max_length) {
+		max_length = PHP_SOCK_CHUNK_SIZE;
+	}
+
+	if(ending) {
+		str = ZSTR_VAL(ending);
+		str_len = ZSTR_LEN(ending);
+	}
+
+	if ((buf = pthreads_stream_get_record(threaded_stream, max_length, str, str_len))) {
+		RETURN_STR(buf);
+	} else {
+		RETURN_NULL();
+	}
+}
+/* }}} */
+
+/* {{{ pthreads_streams_api_stream_get_meta_data */
+void pthreads_streams_api_stream_get_meta_data(zval *object, zval *return_value) {
+	pthreads_stream_t *threaded_stream = PTHREADS_FETCH_FROM(Z_OBJ_P(object));
+	pthreads_stream *stream = PTHREADS_FETCH_STREAMS_STREAM(threaded_stream);
+
+	if (PTHREADS_IS_INVALID_STREAM(stream)) {
+		php_error_docref(NULL, E_WARNING, "%s was already closed", ZSTR_VAL(Z_OBJCE_P(object)->name));
+		RETURN_NULL();
+	}
+	array_init(return_value);
+
+	if (!pthreads_stream_populate_meta_data(threaded_stream, return_value)) {
+		add_assoc_bool(return_value, "timed_out", 0);
+		add_assoc_bool(return_value, "blocked", 1);
+		add_assoc_bool(return_value, "eof", pthreads_stream_eof(threaded_stream));
+	}
+
+	if(stream_lock(threaded_stream)) {
+
+		pthreads_object_t *threaded_val = pthreads_stream_get_wrapperdata(threaded_stream);
+
+		if (threaded_val != NULL) {
+			zval wval, obj;
+
+			ZVAL_OBJ(&obj, PTHREADS_STD_P(threaded_val));
+
+			if(instanceof_function(Z_OBJCE(obj), pthreads_volatile_map_entry)) {
+				_pthreads_volatile_map_to_array(threaded_val, &wval);
+			} else {
+				ZVAL_OBJ(&wval, PTHREADS_STD_P(threaded_val));
+			}
+
+			add_assoc_zval(return_value, "wrapper_data", &wval);
+		}
+		if (stream->wrapper) {
+			add_assoc_string(return_value, "wrapper_type", (char *)PTHREADS_FETCH_STREAMS_WRAPPER(stream->wrapper)->wops->label);
+		}
+		add_assoc_string(return_value, "stream_type", (char *)stream->ops->label);
+
+		add_assoc_string(return_value, "mode", stream->mode);
+
+		if (pthreads_stream_is_filtered(threaded_stream)) {
+			pthreads_stream_filter_t *threaded_filter;
+
+			zval newval;
+			array_init(&newval);
+
+			for (threaded_filter = pthreads_chain_get_head(pthreads_stream_get_readfilters(threaded_stream)); threaded_filter; threaded_filter = pthreads_filter_get_next(threaded_filter)) {
+				add_next_index_string(&newval, (char *)PTHREADS_FETCH_STREAMS_FILTER(threaded_filter)->fops->label);
+			}
+
+			for (threaded_filter = pthreads_chain_get_head(pthreads_stream_get_writefilters(threaded_stream)); threaded_filter; threaded_filter = pthreads_filter_get_next(threaded_filter)) {
+				add_next_index_string(&newval, (char *)PTHREADS_FETCH_STREAMS_FILTER(threaded_filter)->fops->label);
+			}
+
+			add_assoc_zval(return_value, "filters", &newval);
+		}
+
+		add_assoc_long(return_value, "unread_bytes", stream->writepos - stream->readpos);
+
+		add_assoc_bool(return_value, "seekable", (stream->ops->seek) && (stream->flags & PTHREADS_STREAM_FLAG_NO_SEEK) == 0);
+		if (stream->orig_path) {
+			add_assoc_string(return_value, "uri", stream->orig_path);
+		}
+		stream_unlock(threaded_stream);
+	}
+}
+/* }}} */
+
+
+/* {{{ pthreads_streams_api_stream_is_local */
+void pthreads_streams_api_stream_is_local(zval *object, zval *stream_or_url, zval *return_value) {
+	pthreads_stream_t *threaded_stream;
+	pthreads_stream *stream;
+
+	pthreads_stream_wrapper_t *threaded_wrapper = NULL;
+
+	if (Z_TYPE_P(stream_or_url) == IS_OBJECT) {
+		threaded_stream = PTHREADS_FETCH_FROM(Z_OBJ_P(stream_or_url));
+		if (threaded_stream == NULL) {
+			RETURN_FALSE;
+		}
+		stream = PTHREADS_FETCH_STREAMS_STREAM(threaded_stream);
+		threaded_wrapper = stream->wrapper;
+	} else {
+		convert_to_string_ex(stream_or_url);
+
+		threaded_wrapper = pthreads_stream_locate_url_wrapper(Z_STRVAL_P(stream_or_url), NULL, 0);
+	}
+
+	if (!threaded_wrapper) {
+		RETURN_FALSE;
+	}
+
+	RETURN_BOOL(PTHREADS_FETCH_STREAMS_WRAPPER(threaded_wrapper)->is_url == 0);
+}
+/* }}} */
+
+/* {{{ pthreads_streams_api_stream_isatty */
+void pthreads_streams_api_stream_isatty(zval *object, zval *return_value) {
+	pthreads_stream_t *threaded_stream = PTHREADS_FETCH_FROM(Z_OBJ_P(object));
+	php_socket_t fileno;
+
+	if (pthreads_stream_can_cast(threaded_stream, PTHREADS_STREAM_AS_FD_FOR_SELECT) == SUCCESS) {
+		pthreads_stream_cast(threaded_stream, PTHREADS_STREAM_AS_FD_FOR_SELECT, (void*)&fileno, 0);
+	} else if (pthreads_stream_can_cast(threaded_stream, PTHREADS_STREAM_AS_FD) == SUCCESS) {
+		pthreads_stream_cast(threaded_stream, PTHREADS_STREAM_AS_FD, (void*)&fileno, 0);
+	} else {
+		RETURN_FALSE;
+	}
+
+#ifdef PHP_WIN32
+	/* Check if the Windows standard handle is redirected to file */
+	RETVAL_BOOL(php_win32_console_fileno_is_console(fileno));
+#elif HAVE_UNISTD_H
+	/* Check if the file descriptor identifier is a terminal */
+	RETVAL_BOOL(isatty(fileno));
+#else
+	{
+		zend_stat_t stat = {0};
+		RETVAL_BOOL(zend_fstat(fileno, &stat) == 0 && (stat.st_mode & /*S_IFMT*/0170000) == /*S_IFCHR*/0020000);
+	}
+#endif
+}
+/* }}} */
+
+
+#ifdef PHP_WIN32
+/* {{{ pthreads_streams_api_stream_windows_vt100_support
+   Get or set VT100 support for the specified stream associated to an
+   output buffer of a Windows console.
+*/
+void pthreads_streams_api_stream_windows_vt100_support(int argc, zval *object, zend_bool enable, zval *return_value) {
+	pthreads_stream_t *threaded_stream = PTHREADS_FETCH_FROM(Z_OBJ_P(object));
+	zend_long fileno;
+
+	if (pthreads_stream_can_cast(threaded_stream, PTHREADS_STREAM_AS_FD_FOR_SELECT) == SUCCESS) {
+		pthreads_stream_cast(threaded_stream, PTHREADS_STREAM_AS_FD_FOR_SELECT, (void*)&fileno, 0);
+	} else if (pthreads_stream_can_cast(threaded_stream, PTHREADS_STREAM_AS_FD) == SUCCESS) {
+		pthreads_stream_cast(threaded_stream, PTHREADS_STREAM_AS_FD, (void*)&fileno, 0);
+	}
+	else {
+		zend_internal_type_error(
+			ZEND_ARG_USES_STRICT_TYPES(),
+			"%s() was not able to analyze the specified stream",
+			get_active_function_name()
+		);
+		RETURN_FALSE;
+	}
+
+	/* Check if the file descriptor is a console */
+	if (!php_win32_console_fileno_is_console(fileno)) {
+		RETURN_FALSE;
+	}
+
+	if (argc == 1) {
+		/* Check if the Windows standard handle has VT100 control codes enabled */
+		if (php_win32_console_fileno_has_vt100(fileno)) {
+			RETURN_TRUE;
+		}
+		else {
+			RETURN_FALSE;
+		}
+	}
+	else {
+		/* Enable/disable VT100 control codes support for the specified Windows standard handle */
+		if (php_win32_console_fileno_set_vt100(fileno, enable ? TRUE : FALSE)) {
+			RETURN_TRUE;
+		}
+		else {
+			RETURN_FALSE;
+		}
+	}
+}
+#endif
+
+
+/* {{{ stream_select related functions */
+static int pthreads_stream_array_to_fd_set(zval *stream_array, fd_set *fds, php_socket_t *max_fd) {
+	zval *elem;
+	pthreads_stream_t *threaded_stream;
+	int cnt = 0;
+
+	if (Z_TYPE_P(stream_array) != IS_ARRAY) {
+		return 0;
+	}
+
+	ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(stream_array), elem) {
+		/* Temporary int fd is needed for the STREAM data type on windows, passing this_fd directly to pthreads_stream_cast()
+			would eventually bring a wrong result on x64. pthreads_stream_cast() casts to int internally, and this will leave
+			the higher bits of a SOCKET variable uninitialized on systems with little endian. */
+		php_socket_t this_fd;
+
+		ZVAL_DEREF(elem);
+		threaded_stream = PTHREADS_FETCH_FROM(Z_OBJ_P(elem));
+		if (threaded_stream == NULL) {
+			continue;
+		}
+		/* get the fd.
+		 * NB: Most other code will NOT use the PTHREADS_STREAM_CAST_INTERNAL flag
+		 * when casting.  It is only used here so that the buffered data warning
+		 * is not displayed.
+		 * */
+		if (SUCCESS == pthreads_stream_cast(threaded_stream, PTHREADS_STREAM_AS_FD_FOR_SELECT | PTHREADS_STREAM_CAST_INTERNAL, (void*)&this_fd, 1) && this_fd != -1) {
+
+			PHP_SAFE_FD_SET(this_fd, fds);
+
+			if (this_fd > *max_fd) {
+				*max_fd = this_fd;
+			}
+			cnt++;
+		}
+	} ZEND_HASH_FOREACH_END();
+
+	return cnt ? 1 : 0;
+}
+
+static int pthreads_stream_array_from_fd_set(zval *stream_array, fd_set *fds) {
+	zval *elem, *dest_elem;
+	HashTable *ht;
+	pthreads_stream_t *threaded_stream;
+	int ret = 0;
+	zend_string *key;
+	zend_ulong num_ind;
+
+	if (Z_TYPE_P(stream_array) != IS_ARRAY) {
+		return 0;
+	}
+	ht = pthreads_new_array(zend_hash_num_elements(Z_ARRVAL_P(stream_array)));
+
+	ZEND_HASH_FOREACH_KEY_VAL(Z_ARRVAL_P(stream_array), num_ind, key, elem) {
+		php_socket_t this_fd;
+
+		ZVAL_DEREF(elem);
+		threaded_stream = PTHREADS_FETCH_FROM(Z_OBJ_P(elem));
+		if (threaded_stream == NULL) {
+			continue;
+		}
+		/* get the fd
+		 * NB: Most other code will NOT use the PTHREADS_STREAM_CAST_INTERNAL flag
+		 * when casting.  It is only used here so that the buffered data warning
+		 * is not displayed.
+		 */
+		if (SUCCESS == pthreads_stream_cast(threaded_stream, PTHREADS_STREAM_AS_FD_FOR_SELECT | PTHREADS_STREAM_CAST_INTERNAL, (void*)&this_fd, 1) && this_fd != SOCK_ERR) {
+			if (PHP_SAFE_FD_ISSET(this_fd, fds)) {
+				if (!key) {
+					dest_elem = zend_hash_index_update(ht, num_ind, elem);
+				} else {
+					dest_elem = zend_hash_update(ht, key, elem);
+				}
+
+				zval_add_ref(dest_elem);
+				ret++;
+				continue;
+			}
+		}
+	} ZEND_HASH_FOREACH_END();
+
+	/* destroy old array and add new one */
+	zval_ptr_dtor(stream_array);
+	ZVAL_ARR(stream_array, ht);
+
+	return ret;
+}
+
+static int pthreads_stream_array_emulate_read_fd_set(zval *stream_array) {
+	zval *elem, *dest_elem;
+	HashTable *ht;
+	pthreads_stream_t *threaded_stream;
+	pthreads_stream *stream;
+	int ret = 0;
+
+	if (Z_TYPE_P(stream_array) != IS_ARRAY) {
+		return 0;
+	}
+	ht = pthreads_new_array(zend_hash_num_elements(Z_ARRVAL_P(stream_array)));
+
+	ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(stream_array), elem) {
+		ZVAL_DEREF(elem);
+		threaded_stream = PTHREADS_FETCH_FROM(Z_OBJ_P(elem));
+		if (threaded_stream == NULL) {
+			continue;
+		}
+		stream = PTHREADS_FETCH_STREAMS_STREAM(threaded_stream);
+
+		if ((stream->writepos - stream->readpos) > 0) {
+			/* allow readable non-descriptor based streams to participate in stream_select.
+			 * Non-descriptor streams will only "work" if they have previously buffered the
+			 * data.  Not ideal, but better than nothing.
+			 * This branch of code also allows blocking streams with buffered data to
+			 * operate correctly in stream_select.
+			 * */
+			dest_elem = zend_hash_next_index_insert(ht, elem);
+			if (dest_elem) {
+				zval_add_ref(dest_elem);
+			}
+			ret++;
+			continue;
+		}
+	} ZEND_HASH_FOREACH_END();
+
+	if (ret > 0) {
+		/* destroy old array and add new one */
+		zval_ptr_dtor(stream_array);
+		ZVAL_ARR(stream_array, ht);
+	} else {
+		zend_array_destroy(ht);
+	}
+
+	return ret;
+}
+/* }}} */
+
+/* {{{ proto int stream_select(array &read_streams, array &write_streams, array &except_streams, int tv_sec[, int tv_usec])
+   Runs the select() system call on the sets of streams with a timeout specified by tv_sec and tv_usec */
+void pthreads_streams_api_stream_select(zval *r_array, zval *w_array, zval *e_array, zval *sec, zend_long usec, zval *return_value) {
+	struct timeval tv, *tv_p = NULL;
+	fd_set rfds, wfds, efds;
+	php_socket_t max_fd = 0;
+	int retval, sets = 0;
+	int set_count, max_set_count = 0;
+
+	FD_ZERO(&rfds);
+	FD_ZERO(&wfds);
+	FD_ZERO(&efds);
+
+	if (r_array != NULL) {
+		set_count = pthreads_stream_array_to_fd_set(r_array, &rfds, &max_fd);
+		if (set_count > max_set_count)
+			max_set_count = set_count;
+		sets += set_count;
+	}
+
+	if (w_array != NULL) {
+		set_count = pthreads_stream_array_to_fd_set(w_array, &wfds, &max_fd);
+		if (set_count > max_set_count)
+			max_set_count = set_count;
+		sets += set_count;
+	}
+
+	if (e_array != NULL) {
+		set_count = pthreads_stream_array_to_fd_set(e_array, &efds, &max_fd);
+		if (set_count > max_set_count)
+			max_set_count = set_count;
+		sets += set_count;
+	}
+
+	if (!sets) {
+		php_error_docref(NULL, E_WARNING, "No stream arrays were passed");
+		RETURN_FALSE;
+	}
+
+	PHP_SAFE_MAX_FD(max_fd, max_set_count);
+
+	/* If seconds is not set to null, build the timeval, else we wait indefinitely */
+	if (sec != NULL) {
+		zval tmp;
+
+		if (Z_TYPE_P(sec) != IS_LONG) {
+			tmp = *sec;
+			zval_copy_ctor(&tmp);
+			convert_to_long(&tmp);
+			sec = &tmp;
+		}
+
+		if (Z_LVAL_P(sec) < 0) {
+			php_error_docref(NULL, E_WARNING, "The seconds parameter must be greater than 0");
+			RETURN_FALSE;
+		} else if (usec < 0) {
+			php_error_docref(NULL, E_WARNING, "The microseconds parameter must be greater than 0");
+			RETURN_FALSE;
+		}
+
+		/* Windows, Solaris and BSD do not like microsecond values which are >= 1 sec */
+		tv.tv_sec = (long)(Z_LVAL_P(sec) + (usec / 1000000));
+		tv.tv_usec = (long)(usec % 1000000);
+		tv_p = &tv;
+	}
+
+	/* slight hack to support buffered data; if there is data sitting in the
+	 * read buffer of any of the streams in the read array, let's pretend
+	 * that we selected, but return only the readable sockets */
+	if (r_array != NULL) {
+		retval = pthreads_stream_array_emulate_read_fd_set(r_array);
+		if (retval > 0) {
+			if (w_array != NULL) {
+				zval_ptr_dtor(w_array);
+				ZVAL_EMPTY_ARRAY(w_array);
+			}
+			if (e_array != NULL) {
+				zval_ptr_dtor(e_array);
+				ZVAL_EMPTY_ARRAY(e_array);
+			}
+			RETURN_LONG(retval);
+		}
+	}
+
+	retval = php_select(max_fd+1, &rfds, &wfds, &efds, tv_p);
+
+	if (retval == -1) {
+		php_error_docref(NULL, E_WARNING, "unable to select [%d]: %s (max_fd=%d)",
+				errno, strerror(errno), max_fd);
+		RETURN_FALSE;
+	}
+
+	if (r_array != NULL) pthreads_stream_array_from_fd_set(r_array, &rfds);
+	if (w_array != NULL) pthreads_stream_array_from_fd_set(w_array, &wfds);
+	if (e_array != NULL) pthreads_stream_array_from_fd_set(e_array, &efds);
+
+	RETURN_LONG(retval);
+}
+/* }}} */
+
+
+/* {{{ pthreads_streams_api_stream_set_blocking */
+void pthreads_streams_api_stream_set_blocking(zval *object, zend_bool blocking, zval *return_value) {
+	pthreads_stream_t *threaded_stream = PTHREADS_FETCH_FROM(Z_OBJ_P(object));
+
+	if (pthreads_stream_set_option(threaded_stream, PTHREADS_STREAM_OPTION_BLOCKING, blocking, NULL) == -1) {
+		RETURN_FALSE;
+	}
+	RETURN_TRUE;
+}
+/* }}} */
+
+/* {{{ pthreads_streams_api_stream_set_chunk_size */
+void pthreads_streams_api_stream_set_chunk_size(zval *object, zend_long csize, zval *return_value) {
+	pthreads_stream_t *threaded_stream = PTHREADS_FETCH_FROM(Z_OBJ_P(object));
+	int ret;
+
+	ret = pthreads_stream_set_option(threaded_stream, PTHREADS_STREAM_OPTION_SET_CHUNK_SIZE, (int)csize, NULL);
+
+	RETURN_LONG(ret > 0 ? (zend_long)ret : (zend_long)EOF);
+}
+/* }}} */
+
+/* {{{ pthreads_streams_api_stream_set_read_buffer */
+void pthreads_streams_api_stream_set_read_buffer(zval *object, size_t buff, zval *return_value) {
+	pthreads_stream_t *threaded_stream = PTHREADS_FETCH_FROM(Z_OBJ_P(object));
+	int ret;
+
+	/* if buff is 0 then set to non-buffered */
+	if (buff == 0) {
+		ret = pthreads_stream_set_option(threaded_stream, PTHREADS_STREAM_OPTION_READ_BUFFER, PTHREADS_STREAM_BUFFER_NONE, NULL);
+	} else {
+		ret = pthreads_stream_set_option(threaded_stream, PTHREADS_STREAM_OPTION_READ_BUFFER, PTHREADS_STREAM_BUFFER_FULL, &buff);
+	}
+
+	RETURN_LONG(ret == 0 ? 0 : EOF);
+}
+/* }}} */
+
+/* {{{ pthreads_streams_api_stream_set_timeout */
+#if HAVE_SYS_TIME_H || defined(PHP_WIN32)
+void pthreads_streams_api_stream_set_timeout(int argc, zval *object, zend_long seconds, zend_long microseconds, zval *return_value) {
+	pthreads_stream_t *threaded_stream = PTHREADS_FETCH_FROM(Z_OBJ_P(object));
+	struct timeval t;
+
+#ifdef PHP_WIN32
+	t.tv_sec = (long)seconds;
+
+	if (argc == 3) {
+		t.tv_usec = (long)(microseconds % 1000000);
+		t.tv_sec +=(long)(microseconds / 1000000);
+	} else {
+		t.tv_usec = 0;
+	}
+#else
+	t.tv_sec = seconds;
+
+	if (argc == 3) {
+		t.tv_usec = microseconds % 1000000;
+		t.tv_sec += microseconds / 1000000;
+	} else {
+		t.tv_usec = 0;
+	}
+#endif
+
+	if (PTHREADS_STREAM_OPTION_RETURN_OK == pthreads_stream_set_option(threaded_stream, PTHREADS_STREAM_OPTION_READ_TIMEOUT, 0, &t)) {
+		RETURN_TRUE;
+	}
+
+	RETURN_FALSE;
+}
+#endif /* HAVE_SYS_TIME_H || defined(PHP_WIN32) */
+/* }}} */
+
+
+/* {{{ pthreads_streams_api_stream_set_write_buffer */
+void pthreads_streams_api_stream_set_write_buffer(zval *object, size_t buff, zval *return_value) {
+	pthreads_stream_t *threaded_stream = PTHREADS_FETCH_FROM(Z_OBJ_P(object));
+	int ret;
+
+	/* if buff is 0 then set to non-buffered */
+	if (buff == 0) {
+		ret = pthreads_stream_set_option(threaded_stream, PTHREADS_STREAM_OPTION_WRITE_BUFFER, PTHREADS_STREAM_BUFFER_NONE, NULL);
+	} else {
+		ret = pthreads_stream_set_option(threaded_stream, PTHREADS_STREAM_OPTION_WRITE_BUFFER, PTHREADS_STREAM_BUFFER_FULL, &buff);
+	}
+
+	RETURN_LONG(ret == 0 ? 0 : EOF);
+}
+/* }}} */
+
+/* {{{ pthreads_streams_api_stream_supports_lock */
+void pthreads_streams_api_stream_supports_lock(zval *object, zval *return_value) {
+	pthreads_stream_t *threaded_stream = PTHREADS_FETCH_FROM(Z_OBJ_P(object));
+
+	if (!pthreads_stream_supports_lock(threaded_stream)) {
+		RETURN_FALSE;
+	}
+
+	RETURN_TRUE;
+}
+/* }}} */
+
+/* {{{ pthreads_streams_api_stream_from_resource */
+void pthreads_streams_api_stream_from_resource(php_stream *stream, zval *return_value) {
+
+
+
+	RETURN_NULL();
+}
+/* }}} */
+
+/**
+ * SocketStream
+ */
+
+/* {{{ pthreads_streams_api_socket_stream_create_client */
+void pthreads_streams_api_socket_stream_create_client(zend_string *host, zval *zerrno, zval *zerrstr, double timeout, zend_long flags, zval *zcontext, zval *return_value) {
+	pthreads_timeout_ull conv;
+	struct timeval tv;
+	int err;
+	zend_string *errstr = NULL;
+	pthreads_stream_t *threaded_stream;
+	pthreads_stream_context_t *threaded_context = NULL;
+
+	RETVAL_NULL();
+
+	threaded_context = pthreads_stream_context_from_zval(zcontext, flags & PTHREADS_FILE_NO_DEFAULT_CONTEXT);
+
+	/* prepare the timeout value for use */
+	conv = (pthreads_timeout_ull) (timeout * 1000000.0);
+#ifdef PHP_WIN32
+	tv.tv_sec = (long)(conv / 1000000);
+	tv.tv_usec =(long)(conv % 1000000);
+#else
+	tv.tv_sec = conv / 1000000;
+	tv.tv_usec = conv % 1000000;
+#endif
+	if (zerrno)	{
+		zval_ptr_dtor(zerrno);
+		ZVAL_LONG(zerrno, 0);
+	}
+	if (zerrstr) {
+		zval_ptr_dtor(zerrstr);
+		ZVAL_EMPTY_STRING(zerrstr);
+	}
+
+	threaded_stream = pthreads_stream_xport_create(ZSTR_VAL(host), ZSTR_LEN(host), PTHREADS_REPORT_ERRORS,
+			PTHREADS_STREAM_XPORT_CLIENT | (flags & PTHREADS_STREAM_CLIENT_CONNECT ? PTHREADS_STREAM_XPORT_CONNECT : 0) |
+			(flags & PTHREADS_STREAM_CLIENT_ASYNC_CONNECT ? PTHREADS_STREAM_XPORT_CONNECT_ASYNC : 0),
+			&tv, threaded_context, &errstr, &err);
+
+	if (threaded_stream == NULL) {
+		/* host might contain binary characters */
+		zend_string *quoted_host = pthreads_addslashes(host);
+
+		php_error_docref(NULL, E_WARNING, "unable to connect to %s (%s)", ZSTR_VAL(quoted_host), errstr == NULL ? "Unknown error" : ZSTR_VAL(errstr));
+		zend_string_release(quoted_host);
+
+		if (zerrno) {
+			zval_ptr_dtor(zerrno);
+			ZVAL_LONG(zerrno, err);
+		}
+		if (zerrstr && errstr) {
+			zval_ptr_dtor(zerrstr);
+			ZVAL_STR(zerrstr, errstr);
+		} else if (errstr) {
+			zend_string_release(errstr);
+		}
+		RETURN_NULL();
+	}
+
+	if (errstr) {
+		zend_string_release(errstr);
+	}
+
+	pthreads_stream_to_zval(threaded_stream, return_value);
+
+}
+/* }}} */
+
+/* {{{ pthreads_streams_api_socket_stream_create_server */
+void pthreads_streams_api_socket_stream_create_server(zend_string *host, zval *zerrno, zval *zerrstr, zend_long flags, zval *zcontext, zval *return_value) {
+	int err = 0;
+	zend_string *errstr = NULL;
+	pthreads_stream_t *threaded_stream;
+	pthreads_stream_context_t *threaded_context = NULL;
+
+	RETVAL_NULL();
+
+	threaded_context = pthreads_stream_context_from_zval(zcontext, flags & PTHREADS_FILE_NO_DEFAULT_CONTEXT);
+
+	if (zerrno)	{
+		zval_ptr_dtor(zerrno);
+		ZVAL_LONG(zerrno, 0);
+	}
+	if (zerrstr) {
+		zval_ptr_dtor(zerrstr);
+		ZVAL_EMPTY_STRING(zerrstr);
+	}
+
+	threaded_stream = pthreads_stream_xport_create(ZSTR_VAL(host), ZSTR_LEN(host), PTHREADS_REPORT_ERRORS,
+			PTHREADS_STREAM_XPORT_SERVER | (int)flags, NULL, threaded_context, &errstr, &err);
+
+	if (threaded_stream == NULL) {
+		php_error_docref(NULL, E_WARNING, "unable to connect to %s (%s)", host, errstr == NULL ? "Unknown error" : ZSTR_VAL(errstr));
+	}
+
+	if (threaded_stream == NULL)	{
+		if (zerrno) {
+			zval_ptr_dtor(zerrno);
+			ZVAL_LONG(zerrno, err);
+		}
+		if (zerrstr && errstr) {
+			zval_ptr_dtor(zerrstr);
+			ZVAL_STR(zerrstr, errstr);
+		} else if (errstr) {
+			zend_string_release(errstr);
+		}
+		RETURN_NULL();
+	}
+
+	if (errstr) {
+		zend_string_release(errstr);
+	}
+
+	pthreads_stream_to_zval(threaded_stream, return_value);
+}
+/* }}} */
+
+#if HAVE_SOCKETPAIR
+/* {{{ pthreads_streams_api_socket_stream_socket_pair */
+void pthreads_streams_api_socket_stream_pair(zend_long domain, zend_long type, zend_long protocol, zval *return_value) {
+	pthreads_stream_t *s1, *s2;
+	php_socket_t pair[2];
+	zval obj1, obj2;
+
+	if (0 != socketpair((int)domain, (int)type, (int)protocol, pair)) {
+		char errbuf[256];
+		php_error_docref(NULL, E_WARNING, "failed to create sockets: [%d]: %s",
+			php_socket_errno(), php_socket_strerror(php_socket_errno(), errbuf, sizeof(errbuf)));
+		RETURN_FALSE;
+	}
+
+	array_init(return_value);
+
+	s1 = _pthreads_stream_sock_open_from_socket(pair[0], pthreads_socket_stream_entry);
+	s2 = _pthreads_stream_sock_open_from_socket(pair[1], pthreads_socket_stream_entry);
+
+	ZVAL_OBJ(&obj1, PTHREADS_STD_P(s1));
+	ZVAL_OBJ(&obj2, PTHREADS_STD_P(s2));
+
+	add_next_index_zval(return_value, &obj1);
+	add_next_index_zval(return_value, &obj2);
+}
+/* }}} */
+#endif
+
+/* {{{ pthreads_streams_api_socket_stream_accept */
+void pthreads_streams_api_socket_stream_accept(zval *object, double timeout, zval *zpeername, zval *return_value) {
+	pthreads_stream_t *threaded_stream = PTHREADS_FETCH_FROM(Z_OBJ_P(object));
+	pthreads_stream_t *clistream = NULL;
+	zend_string *peername = NULL;
+	pthreads_timeout_ull conv;
+	struct timeval tv;
+	zend_string *errstr = NULL;
+
+	/* prepare the timeout value for use */
+	conv = (pthreads_timeout_ull) (timeout * 1000000.0);
+#ifdef PHP_WIN32
+	tv.tv_sec = (long)(conv / 1000000);
+	tv.tv_usec = (long)(conv % 1000000);
+#else
+	tv.tv_sec = conv / 1000000;
+	tv.tv_usec = conv % 1000000;
+#endif
+	if (zpeername) {
+		zval_ptr_dtor(zpeername);
+		ZVAL_NULL(zpeername);
+	}
+
+	if (0 == pthreads_stream_xport_accept(threaded_stream, &clistream,
+				zpeername ? &peername : NULL,
+				NULL, NULL,
+				&tv, &errstr
+				) && clistream) {
+
+		if (peername) {
+			ZVAL_STR(zpeername, peername);
+		}
+		pthreads_stream_to_zval(clistream, return_value);
+	} else {
+		php_error_docref(NULL, E_WARNING, "accept failed: %s", errstr ? ZSTR_VAL(errstr) : "Unknown error");
+		RETVAL_FALSE;
+	}
+
+	if (errstr) {
+		zend_string_release(errstr);
+	}
+}
+/* }}} */
+
+/* {{{ pthreads_streams_api_socket_stream_get_name */
+void pthreads_streams_api_socket_stream_get_name(zval *object, zend_bool want_peer, zval *return_value) {
+	pthreads_stream_t *threaded_stream = PTHREADS_FETCH_FROM(Z_OBJ_P(object));
+	zend_string *name = NULL;
+
+	if (0 != pthreads_stream_xport_get_name(threaded_stream, want_peer,
+				&name,
+				NULL, NULL
+				) || !name) {
+		RETURN_NULL();
+	}
+
+	if ((ZSTR_LEN(name) == 0) || (ZSTR_VAL(name)[0] == 0)) {
+		zend_string_release(name);
+		RETURN_NULL();
+	}
+
+	RETVAL_STR(name);
+}
+/* }}} */
+
+/* {{{ pthreads_streams_api_socket_stream_recvfrom */
+void pthreads_streams_api_socket_stream_recvfrom(zval *object, zend_long to_read, zend_long flags, zval *zremote, zval *return_value) {
+	pthreads_stream_t *threaded_stream = PTHREADS_FETCH_FROM(Z_OBJ_P(object));
+	zend_string *remote_addr = NULL;
+	zend_string *read_buf;
+	int recvd;
+
+	if (zremote) {
+		zval_ptr_dtor(zremote);
+		ZVAL_NULL(zremote);
+	}
+
+	if (to_read <= 0) {
+		php_error_docref(NULL, E_WARNING, "Length parameter must be greater than 0");
+		RETURN_FALSE;
+	}
+
+	read_buf = zend_string_alloc(to_read, 0);
+
+	recvd = pthreads_stream_xport_recvfrom(threaded_stream, ZSTR_VAL(read_buf), to_read, (int)flags, NULL, NULL,
+			zremote ? &remote_addr : NULL
+			);
+
+	if (recvd >= 0) {
+		if (zremote && remote_addr) {
+			ZVAL_STR(zremote, remote_addr);
+		}
+		ZSTR_VAL(read_buf)[recvd] = '\0';
+		ZSTR_LEN(read_buf) = recvd;
+		RETURN_NEW_STR(read_buf);
+	}
+
+	zend_string_efree(read_buf);
+	RETURN_FALSE;
+}
+/* }}} */
+
+/* {{{ pthreads_streams_api_socket_stream_sendto */
+void pthreads_streams_api_socket_stream_sendto(zval *object, zend_string *data, zend_long flags, zend_string *target_addr, zval *return_value) {
+	pthreads_stream_t *threaded_stream = PTHREADS_FETCH_FROM(Z_OBJ_P(object));
+
+	php_sockaddr_storage sa;
+	socklen_t sl = 0;
+
+	if (target_addr) {
+		/* parse the address */
+		if (FAILURE == php_network_parse_network_address_with_port(ZSTR_VAL(target_addr), ZSTR_LEN(target_addr), (struct sockaddr*)&sa, &sl)) {
+			php_error_docref(NULL, E_WARNING, "Failed to parse `%s' into a valid network address", target_addr);
+			RETURN_FALSE;
+		}
+	}
+
+	RETURN_LONG(pthreads_stream_xport_sendto(threaded_stream, ZSTR_VAL(data), ZSTR_LEN(data), (int)flags, target_addr ? &sa : NULL, sl));
+}
+/* }}} */
+
+
+#ifdef HAVE_SHUTDOWN
+/* {{{ proto int SocketStream::shutdown(int how)
+	causes all or part of a full-duplex connection on the socket associated
+	with stream to be shut down.  If how is SHUT_RD,  further receptions will
+	be disallowed. If how is SHUT_WR, further transmissions will be disallowed.
+	If how is SHUT_RDWR,  further  receptions and transmissions will be
+	disallowed. */
+void pthreads_streams_api_socket_stream_shutdown(zval *object, zend_long how, zval *return_value) {
+	pthreads_stream_t *threaded_stream = PTHREADS_FETCH_FROM(Z_OBJ_P(object));
+
+	RETURN_BOOL(pthreads_stream_xport_shutdown(threaded_stream, (pthreads_stream_shutdown_t)how) == 0);
+}
+/* }}} */
+#endif
+
+
+#endif

--- a/src/streams/string_filters.c
+++ b/src/streams/string_filters.c
@@ -1,0 +1,180 @@
+/*
+  +----------------------------------------------------------------------+
+  | pthreads                                                             |
+  +----------------------------------------------------------------------+
+  | Copyright (c) Joe Watkins 2018                                       |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | http://www.php.net/license/3_01.txt                                  |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors: Bastian Schneider <b.schneider@badnoob.com>                 |
+  | Borrowed code from php-src                                           |
+  +----------------------------------------------------------------------+
+ */
+#ifndef HAVE_PTHREADS_STREAMS_STRING_FILTERS
+#define HAVE_PTHREADS_STREAMS_STRING_FILTERS
+
+#ifndef HAVE_PTHREADS_H
+#	include <src/pthreads.h>
+#endif
+
+#ifndef HAVE_PTHREADS_STREAM_H
+#	include <src/streams.h>
+#endif
+
+/**
+ * Rot13
+ */
+
+/* {{{ rot13 stream filter implementation */
+static const char pthreads_rot13_from[] = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
+static const char pthreads_rot13_to[] = "nopqrstuvwxyzabcdefghijklmNOPQRSTUVWXYZABCDEFGHIJKLM";
+
+static pthreads_stream_filter_status_t pthreads_strfilter_rot13_filter(
+	pthreads_stream_t *threaded_stream,
+	pthreads_stream_filter_t *threaded_thisfilter,
+	pthreads_stream_bucket_brigade_t *threaded_buckets_in,
+	pthreads_stream_bucket_brigade_t *threaded_buckets_out,
+	size_t *bytes_consumed,
+	int flags
+	)
+{
+	pthreads_stream_bucket_t *threaded_bucket;
+	pthreads_stream_bucket *bucket;
+	size_t consumed = 0;
+
+	while ((threaded_bucket = PTHREADS_FETCH_STREAMS_BRIGADE(threaded_buckets_in)->head) != NULL) {
+		bucket = pthreads_stream_bucket_fetch(threaded_bucket);
+
+		php_strtr(bucket->buf, bucket->buflen, pthreads_rot13_from, pthreads_rot13_to, 52);
+		consumed += bucket->buflen;
+
+		pthreads_stream_bucket_append(threaded_buckets_out, threaded_bucket, 0);
+	}
+
+	if (bytes_consumed) {
+		*bytes_consumed = consumed;
+	}
+
+	return PTHREADS_SFS_PASS_ON;
+}
+
+static const pthreads_stream_filter_ops pthreads_strfilter_rot13_ops = {
+	pthreads_strfilter_rot13_filter,
+	NULL,
+	"string.rot13"
+};
+
+static pthreads_stream_filter_t *pthreads_strfilter_rot13_create(const char *filtername, zval *filterparams)
+{
+	return pthreads_stream_filter_new(&pthreads_strfilter_rot13_ops, NULL);
+}
+
+static const pthreads_stream_filter_factory pthreads_strfilter_rot13_factory = {
+		pthreads_strfilter_rot13_create
+};
+/* }}} */
+
+/**
+ * toupper / tolower
+ */
+
+/* {{{ string.toupper / string.tolower stream filter implementation */
+static const char pthreads_lowercase[] = "abcdefghijklmnopqrstuvwxyz";
+static const char pthreads_uppercase[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+
+static pthreads_stream_filter_status_t pthreads_strfilter_toupper_filter(
+	pthreads_stream_t *threaded_stream,
+	pthreads_stream_filter_t *threaded_thisfilter,
+	pthreads_stream_bucket_brigade_t *threaded_buckets_in,
+	pthreads_stream_bucket_brigade_t *threaded_buckets_out,
+	size_t *bytes_consumed,
+	int flags
+	)
+{
+	pthreads_stream_bucket_t *threaded_bucket;
+	pthreads_stream_bucket *bucket;
+	size_t consumed = 0;
+
+	while ((threaded_bucket = PTHREADS_FETCH_STREAMS_BRIGADE(threaded_buckets_in)->head) != NULL) {
+		bucket = pthreads_stream_bucket_fetch(threaded_bucket);
+
+		php_strtr(bucket->buf, bucket->buflen, pthreads_lowercase, pthreads_uppercase, 26);
+		consumed += bucket->buflen;
+
+		pthreads_stream_bucket_append(threaded_buckets_out, threaded_bucket, 0);
+	}
+
+	if (bytes_consumed) {
+		*bytes_consumed = consumed;
+	}
+
+	return PTHREADS_SFS_PASS_ON;
+}
+
+static pthreads_stream_filter_status_t pthreads_strfilter_tolower_filter(
+	pthreads_stream_t *threaded_stream,
+	pthreads_stream_filter_t *threaded_thisfilter,
+	pthreads_stream_bucket_brigade_t *threaded_buckets_in,
+	pthreads_stream_bucket_brigade_t *threaded_buckets_out,
+	size_t *bytes_consumed,
+	int flags
+	)
+{
+	pthreads_stream_bucket_t *threaded_bucket;
+	pthreads_stream_bucket *bucket;
+	size_t consumed = 0;
+
+	while ((threaded_bucket = PTHREADS_FETCH_STREAMS_BRIGADE(threaded_buckets_in)->head) != NULL) {
+		bucket = pthreads_stream_bucket_fetch(threaded_bucket);
+
+		php_strtr(bucket->buf, bucket->buflen, pthreads_uppercase, pthreads_lowercase, 26);
+		consumed += bucket->buflen;
+
+		pthreads_stream_bucket_append(threaded_buckets_out, threaded_bucket, 0);
+	}
+
+	if (bytes_consumed) {
+		*bytes_consumed = consumed;
+	}
+
+	return PTHREADS_SFS_PASS_ON;
+}
+
+static const pthreads_stream_filter_ops pthreads_strfilter_toupper_ops = {
+	pthreads_strfilter_toupper_filter,
+	NULL,
+	"string.toupper"
+};
+
+static const pthreads_stream_filter_ops pthreads_strfilter_tolower_ops = {
+	pthreads_strfilter_tolower_filter,
+	NULL,
+	"string.tolower"
+};
+
+static pthreads_stream_filter_t *pthreads_strfilter_toupper_create(const char *filtername, zval *filterparams)
+{
+	return pthreads_stream_filter_new(&pthreads_strfilter_toupper_ops, NULL);
+}
+
+static pthreads_stream_filter_t *pthreads_strfilter_tolower_create(const char *filtername, zval *filterparams)
+{
+	return pthreads_stream_filter_new(&pthreads_strfilter_tolower_ops, NULL);
+}
+
+static const pthreads_stream_filter_factory pthreads_strfilter_toupper_factory = {
+	pthreads_strfilter_toupper_create
+};
+
+static const pthreads_stream_filter_factory pthreads_strfilter_tolower_factory = {
+	pthreads_strfilter_tolower_create
+};
+/* }}} */
+
+#endif

--- a/src/streams/transports.c
+++ b/src/streams/transports.c
@@ -1,0 +1,526 @@
+/*
+  +----------------------------------------------------------------------+
+  | pthreads                                                             |
+  +----------------------------------------------------------------------+
+  | Copyright (c) Joe Watkins 2018                                       |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | http://www.php.net/license/3_01.txt                                  |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors: Bastian Schneider <b.schneider@badnoob.com>                 |
+  | Borrowed code from php-src                                           |
+  +----------------------------------------------------------------------+
+ */
+#ifndef HAVE_PTHREADS_STREAMS_TRANSPORTS
+#define HAVE_PTHREADS_STREAMS_TRANSPORTS
+
+#ifndef HAVE_PTHREADS_H
+#	include <src/pthreads.h>
+#endif
+
+#ifndef HAVE_PTHREADS_STREAM_H
+#	include <src/streams.h>
+#endif
+
+#ifndef HAVE_PTHREADS_HASH_H
+#	include <src/hash.h>
+#endif
+
+#ifndef HAVE_PTHREADS_STREAMS_TRANSPORTS_H
+#	include "src/streams/transports.h"
+#endif
+
+int pthreads_init_stream_transports() {
+	return (pthreads_stream_xport_register("tcp", pthreads_stream_generic_socket_factory) == SUCCESS
+			&&
+			pthreads_stream_xport_register("udp", pthreads_stream_generic_socket_factory) == SUCCESS
+#if defined(AF_UNIX) && !(defined(PHP_WIN32) || defined(__riscos__))
+			&&
+			pthreads_stream_xport_register("unix", pthreads_stream_generic_socket_factory) == SUCCESS
+			&&
+			pthreads_stream_xport_register("udg", pthreads_stream_generic_socket_factory) == SUCCESS
+#endif
+		) ? SUCCESS : FAILURE;
+}
+
+pthreads_hashtable *pthreads_stream_xport_get_hash(void)
+{
+	return &PTHREADS_STREAMG(xport_hash);
+}
+
+int pthreads_stream_xport_register(const char *protocol, pthreads_stream_transport_factory factory)
+{
+	pthreads_hashtable *xport_hash = &PTHREADS_STREAMG(xport_hash);
+	zend_string *str = zend_string_init_interned(protocol, strlen(protocol), 1);
+
+	if(MONITOR_LOCK(xport_hash)) {
+		zend_hash_update_ptr(&xport_hash->ht, str, factory);
+		MONITOR_UNLOCK(xport_hash);
+	}
+	return SUCCESS;
+}
+
+int pthreads_stream_xport_unregister(const char *protocol)
+{
+	pthreads_hashtable *xport_hash = &PTHREADS_STREAMG(xport_hash);
+	int result = FAILURE;
+
+	if(MONITOR_LOCK(xport_hash)) {
+		result = zend_hash_str_del(&xport_hash->ht, protocol, strlen(protocol));
+		MONITOR_UNLOCK(xport_hash);
+	}
+	return result;
+}
+
+#define PTHREADS_ERR_REPORT(out_err, fmt, arg) \
+	if (out_err) { *out_err = strpprintf(0, fmt, arg); } \
+	else { php_error_docref(NULL, E_WARNING, fmt, arg); }
+
+#define PTHREADS_ERR_RETURN(out_err, local_err, fmt) \
+	if (out_err) { *out_err = local_err; } \
+	else { php_error_docref(NULL, E_WARNING, fmt, local_err ? ZSTR_VAL(local_err) : "Unspecified error"); \
+		if (local_err) { zend_string_release(local_err); local_err = NULL; } \
+	}
+
+pthreads_stream_t *_pthreads_stream_xport_create(const char *name, size_t namelen, int options,
+		int flags,
+		struct timeval *timeout,
+		pthreads_stream_context_t *threaded_context,
+		zend_string **error_string,
+		int *error_code)
+{
+	pthreads_stream_t *threaded_stream = NULL;
+	pthreads_stream *stream = NULL;
+	pthreads_stream_transport_factory factory = NULL;
+	const char *p, *protocol = NULL;
+	size_t n = 0;
+	int failed = 0;
+	zend_string *error_text = NULL;
+	struct timeval default_timeout = { 0, 0 };
+
+	default_timeout.tv_sec = FG(default_socket_timeout);
+
+	if (timeout == NULL) {
+		timeout = &default_timeout;
+	}
+
+	for (p = name; isalnum((int)*p) || *p == '+' || *p == '-' || *p == '.'; p++) {
+		n++;
+	}
+
+	if ((*p == ':') && (n > 1) && !strncmp("://", p, 3)) {
+		protocol = name;
+		name = p + 3;
+		namelen -= n + 3;
+	} else {
+		protocol = "tcp";
+		n = 3;
+	}
+
+	if (protocol) {
+		pthreads_hashtable *xport_hash = &PTHREADS_STREAMG(xport_hash);
+
+		if(MONITOR_LOCK(xport_hash)) {
+			factory = zend_hash_str_find_ptr(&xport_hash->ht, protocol, n);
+			MONITOR_UNLOCK(xport_hash);
+		}
+
+		if (NULL == factory) {
+			char wrapper_name[32];
+
+			if (n >= sizeof(wrapper_name))
+				n = sizeof(wrapper_name) - 1;
+			PHP_STRLCPY(wrapper_name, protocol, sizeof(wrapper_name), n);
+
+			ERR_REPORT(error_string, "Unable to find the socket transport \"%s\" - did you forget to enable it when you configured PHP?",
+					wrapper_name);
+
+			return NULL;
+		}
+	}
+
+	if (factory == NULL) {
+		/* should never happen */
+		php_error_docref(NULL, E_WARNING, "Could not find a factory !?");
+		return NULL;
+	}
+	threaded_stream = (factory)(protocol, n, (char*)name, namelen, options, flags, timeout, threaded_context);
+
+	if (threaded_stream) {
+		pthreads_stream_context_set(threaded_stream, threaded_context);
+
+		if ((flags & PTHREADS_STREAM_XPORT_SERVER) == 0) {
+			/* client */
+
+			if (flags & (PTHREADS_STREAM_XPORT_CONNECT|PTHREADS_STREAM_XPORT_CONNECT_ASYNC)) {
+				if (-1 == pthreads_stream_xport_connect(threaded_stream, name, namelen,
+							flags & PTHREADS_STREAM_XPORT_CONNECT_ASYNC ? 1 : 0,
+							timeout, &error_text, error_code)) {
+
+					PTHREADS_ERR_RETURN(error_string, error_text, "connect() failed: %s");
+
+					failed = 1;
+				}
+			}
+
+		} else {
+			/* server */
+			if (flags & PTHREADS_STREAM_XPORT_BIND) {
+				if (0 != pthreads_stream_xport_bind(threaded_stream, name, namelen, &error_text)) {
+					PTHREADS_ERR_RETURN(error_string, error_text, "bind() failed: %s");
+					failed = 1;
+				} else if (flags & PTHREADS_STREAM_XPORT_LISTEN) {
+					zval *zbacklog = NULL;
+					int backlog = 32;
+					stream = PTHREADS_FETCH_STREAMS_STREAM(threaded_stream);
+					threaded_context = pthreads_stream_get_context(threaded_stream);
+
+					if (threaded_context && (zbacklog = pthreads_stream_context_get_option(threaded_context, "socket", "backlog")) != NULL) {
+						backlog = zval_get_long(zbacklog);
+					}
+
+					if (0 != pthreads_stream_xport_listen(threaded_stream, backlog, &error_text)) {
+						PTHREADS_ERR_RETURN(error_string, error_text, "listen() failed: %s");
+						failed = 1;
+					}
+				}
+			}
+		}
+	}
+
+	if (failed) {
+		/* failure means that they don't get a stream to play with */
+		pthreads_stream_close(threaded_stream, PTHREADS_STREAM_FREE_CLOSE);
+		threaded_stream = NULL;
+	}
+
+	return threaded_stream;
+}
+
+/* Bind the stream to a local address */
+int pthreads_stream_xport_bind(pthreads_stream_t *threaded_stream,
+		const char *name, size_t namelen,
+		zend_string **error_text
+		)
+{
+	pthreads_stream_xport_param param;
+	int ret;
+
+	memset(&param, 0, sizeof(param));
+	param.op = PTHREADS_STREAM_XPORT_OP_BIND;
+	param.inputs.name = (char*)name;
+	param.inputs.namelen = namelen;
+	param.want_errortext = error_text ? 1 : 0;
+
+	ret = pthreads_stream_set_option(threaded_stream, PTHREADS_STREAM_OPTION_XPORT_API, 0, &param);
+
+	if (ret == PTHREADS_STREAM_OPTION_RETURN_OK) {
+		if (error_text) {
+			*error_text = param.outputs.error_text;
+		}
+		return param.outputs.returncode;
+	}
+
+	return ret;
+}
+
+/* Connect to a remote address */
+int pthreads_stream_xport_connect(pthreads_stream_t *threaded_stream,
+		const char *name, size_t namelen,
+		int asynchronous,
+		struct timeval *timeout,
+		zend_string **error_text,
+		int *error_code
+		)
+{
+	pthreads_stream_xport_param param;
+	int ret;
+
+	memset(&param, 0, sizeof(param));
+	param.op = asynchronous ? PTHREADS_STREAM_XPORT_OP_CONNECT_ASYNC : PTHREADS_STREAM_XPORT_OP_CONNECT;
+	param.inputs.name = (char*)name;
+	param.inputs.namelen = namelen;
+	param.inputs.timeout = timeout;
+
+	param.want_errortext = error_text ? 1 : 0;
+
+	ret = pthreads_stream_set_option(threaded_stream, PTHREADS_STREAM_OPTION_XPORT_API, 0, &param);
+
+	if (ret == PTHREADS_STREAM_OPTION_RETURN_OK) {
+		if (error_text) {
+			*error_text = param.outputs.error_text;
+		}
+		if (error_code) {
+			*error_code = param.outputs.error_code;
+		}
+		return param.outputs.returncode;
+	}
+
+	return ret;
+}
+
+/* Prepare to listen */
+int pthreads_stream_xport_listen(pthreads_stream_t *threaded_stream, int backlog, zend_string **error_text)
+{
+	pthreads_stream_xport_param param;
+	int ret;
+
+	memset(&param, 0, sizeof(param));
+	param.op = PTHREADS_STREAM_XPORT_OP_LISTEN;
+	param.inputs.backlog = backlog;
+	param.want_errortext = error_text ? 1 : 0;
+
+	ret = pthreads_stream_set_option(threaded_stream, PTHREADS_STREAM_OPTION_XPORT_API, 0, &param);
+
+	if (ret == PTHREADS_STREAM_OPTION_RETURN_OK) {
+		if (error_text) {
+			*error_text = param.outputs.error_text;
+		}
+
+		return param.outputs.returncode;
+	}
+
+	return ret;
+}
+
+/* Get the next client and their address (as a string) */
+int pthreads_stream_xport_accept(pthreads_stream_t *threaded_stream, pthreads_stream_t **threaded_client,
+		zend_string **textaddr,
+		void **addr, socklen_t *addrlen,
+		struct timeval *timeout,
+		zend_string **error_text
+		)
+{
+	pthreads_stream_xport_param param;
+	int ret;
+
+	memset(&param, 0, sizeof(param));
+
+	param.op = PTHREADS_STREAM_XPORT_OP_ACCEPT;
+	param.inputs.timeout = timeout;
+	param.want_addr = addr ? 1 : 0;
+	param.want_textaddr = textaddr ? 1 : 0;
+	param.want_errortext = error_text ? 1 : 0;
+
+	ret = pthreads_stream_set_option(threaded_stream, PTHREADS_STREAM_OPTION_XPORT_API, 0, &param);
+
+	if (ret == PTHREADS_STREAM_OPTION_RETURN_OK) {
+		*threaded_client = param.outputs.client;
+		if (addr) {
+			*addr = param.outputs.addr;
+			*addrlen = param.outputs.addrlen;
+		}
+		if (textaddr) {
+			*textaddr = param.outputs.textaddr;
+		}
+		if (error_text) {
+			*error_text = param.outputs.error_text;
+		}
+
+		return param.outputs.returncode;
+	}
+	return ret;
+}
+
+int pthreads_stream_xport_get_name(pthreads_stream_t *threaded_stream, int want_peer, zend_string **textaddr, void **addr, socklen_t *addrlen ) {
+	pthreads_stream_xport_param param;
+	int ret;
+
+	memset(&param, 0, sizeof(param));
+
+	param.op = want_peer ? PTHREADS_STREAM_XPORT_OP_GET_PEER_NAME : PTHREADS_STREAM_XPORT_OP_GET_NAME;
+	param.want_addr = addr ? 1 : 0;
+	param.want_textaddr = textaddr ? 1 : 0;
+
+	ret = pthreads_stream_set_option(threaded_stream, PTHREADS_STREAM_OPTION_XPORT_API, 0, &param);
+
+	if (ret == PTHREADS_STREAM_OPTION_RETURN_OK) {
+		if (addr) {
+			*addr = param.outputs.addr;
+			*addrlen = param.outputs.addrlen;
+		}
+		if (textaddr) {
+			*textaddr = param.outputs.textaddr;
+		}
+
+		return param.outputs.returncode;
+	}
+	return ret;
+}
+
+int pthreads_stream_xport_crypto_setup(pthreads_stream_t *threaded_stream, pthreads_stream_xport_crypt_method_t crypto_method, pthreads_stream_t *threaded_session_stream) {
+	pthreads_stream_xport_crypto_param param;
+	int ret;
+
+	memset(&param, 0, sizeof(param));
+	param.op = PTHREADS_STREAM_XPORT_CRYPTO_OP_SETUP;
+	param.inputs.method = crypto_method;
+	param.inputs.session = threaded_session_stream;
+
+	ret = pthreads_stream_set_option(threaded_stream, PTHREADS_STREAM_OPTION_CRYPTO_API, 0, &param);
+
+	if (ret == PTHREADS_STREAM_OPTION_RETURN_OK) {
+		return param.outputs.returncode;
+	}
+
+	php_error_docref("streams.crypto", E_WARNING, "this stream does not support SSL/crypto");
+
+	return ret;
+}
+
+int pthreads_stream_xport_crypto_enable(pthreads_stream_t *threaded_stream, int activate) {
+	pthreads_stream_xport_crypto_param param;
+	int ret;
+
+	memset(&param, 0, sizeof(param));
+	param.op = PTHREADS_STREAM_XPORT_CRYPTO_OP_ENABLE;
+	param.inputs.activate = activate;
+
+	ret = pthreads_stream_set_option(threaded_stream, PTHREADS_STREAM_OPTION_CRYPTO_API, 0, &param);
+
+	if (ret == PTHREADS_STREAM_OPTION_RETURN_OK) {
+		return param.outputs.returncode;
+	}
+
+	php_error_docref("streams.crypto", E_WARNING, "this stream does not support SSL/crypto");
+
+	return ret;
+}
+
+/* Similar to recv() system call; read data from the stream, optionally
+ * peeking, optionally retrieving OOB data */
+int pthreads_stream_xport_recvfrom(pthreads_stream_t *threaded_stream, char *buf, size_t buflen, int flags, void **addr, socklen_t *addrlen, zend_string **textaddr)
+{
+	pthreads_stream_xport_param param;
+	int ret = 0;
+	int recvd_len = 0;
+#if 0
+	int oob;
+
+	if (flags == 0 && addr == NULL) {
+		return pthreads_stream_read(threaded_stream, buf, buflen);
+	}
+
+	if (pthreads_chain_has_head(pthreads_stream_get_readfilters(threaded_stream))) {
+		php_error_docref(NULL, E_WARNING, "cannot peek or fetch OOB data from a filtered stream");
+		return -1;
+	}
+
+	oob = (flags & PTHREADS_STREAM_OOB) == PTHREADS_STREAM_OOB;
+
+	if (!oob && addr == NULL) {
+		/* must be peeking at regular data; copy content from the buffer
+		 * first, then adjust the pointer/len before handing off to the
+		 * stream */
+		recvd_len = threaded_stream->writepos - threaded_stream->readpos;
+		if (recvd_len > buflen) {
+			recvd_len = buflen;
+		}
+		if (recvd_len) {
+			memcpy(buf, threaded_stream->readbuf, recvd_len);
+			buf += recvd_len;
+			buflen -= recvd_len;
+		}
+		/* if we filled their buffer, return */
+		if (buflen == 0) {
+			return recvd_len;
+		}
+	}
+#endif
+
+	/* otherwise, we are going to bypass the buffer */
+
+	memset(&param, 0, sizeof(param));
+
+	param.op = PTHREADS_STREAM_XPORT_OP_RECV;
+	param.want_addr = addr ? 1 : 0;
+	param.want_textaddr = textaddr ? 1 : 0;
+	param.inputs.buf = buf;
+	param.inputs.buflen = buflen;
+	param.inputs.flags = flags;
+
+	ret = pthreads_stream_set_option(threaded_stream, PTHREADS_STREAM_OPTION_XPORT_API, 0, &param);
+
+	if (ret == PTHREADS_STREAM_OPTION_RETURN_OK) {
+		if (addr) {
+			*addr = param.outputs.addr;
+			*addrlen = param.outputs.addrlen;
+		}
+		if (textaddr) {
+			*textaddr = param.outputs.textaddr;
+		}
+		return recvd_len + param.outputs.returncode;
+	}
+	return recvd_len ? recvd_len : -1;
+}
+
+/* Similar to send() system call; send data to the stream, optionally
+ * sending it as OOB data */
+int pthreads_stream_xport_sendto(pthreads_stream_t *threaded_stream, const char *buf, size_t buflen,
+		int flags, void *addr, socklen_t addrlen) {
+	pthreads_stream *stream = PTHREADS_FETCH_STREAMS_STREAM(threaded_stream);
+	pthreads_stream_xport_param param;
+	int ret = 0;
+	int oob;
+
+#if 0
+	if (flags == 0 && addr == NULL) {
+		return pthreads_stream_write(threaded_stream, buf, buflen);
+	}
+#endif
+
+	if(stream_lock(threaded_stream)) {
+		oob = (flags & PTHREADS_STREAM_OOB) == PTHREADS_STREAM_OOB;
+
+		if ((oob || addr) && pthreads_chain_has_head(pthreads_stream_get_writefilters(threaded_stream))) {
+			stream_unlock(threaded_stream);
+			php_error_docref(NULL, E_WARNING, "cannot write OOB data, or data to a targeted address on a filtered stream");
+			return -1;
+		}
+
+		memset(&param, 0, sizeof(param));
+
+		param.op = PTHREADS_STREAM_XPORT_OP_SEND;
+		param.want_addr = addr ? 1 : 0;
+		param.inputs.buf = (char*)buf;
+		param.inputs.buflen = buflen;
+		param.inputs.flags = flags;
+		param.inputs.addr = addr;
+		param.inputs.addrlen = addrlen;
+
+		ret = pthreads_stream_set_option(threaded_stream, PTHREADS_STREAM_OPTION_XPORT_API, 0, &param);
+
+		if (ret == PTHREADS_STREAM_OPTION_RETURN_OK) {
+			stream_unlock(threaded_stream);
+			return param.outputs.returncode;
+		}
+		stream_unlock(threaded_stream);
+	}
+	return -1;
+}
+
+/* Similar to shutdown() system call; shut down part of a full-duplex connection */
+int pthreads_stream_xport_shutdown(pthreads_stream_t *threaded_stream, pthreads_stream_shutdown_t how)
+{
+	pthreads_stream_xport_param param;
+	int ret = 0;
+
+	memset(&param, 0, sizeof(param));
+
+	param.op = PTHREADS_STREAM_XPORT_OP_SHUTDOWN;
+	param.how = how;
+
+	ret = pthreads_stream_set_option(threaded_stream, PTHREADS_STREAM_OPTION_XPORT_API, 0, &param);
+
+	if (ret == PTHREADS_STREAM_OPTION_RETURN_OK) {
+		return param.outputs.returncode;
+	}
+	return -1;
+}
+
+#endif

--- a/src/streams/transports.h
+++ b/src/streams/transports.h
@@ -1,0 +1,219 @@
+/*
+  +----------------------------------------------------------------------+
+  | pthreads                                                             |
+  +----------------------------------------------------------------------+
+  | Copyright (c) Joe Watkins 2018                                       |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | http://www.php.net/license/3_01.txt                                  |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors: Bastian Schneider <b.schneider@badnoob.com>                 |
+  | Borrowed code from php-src                                           |
+  +----------------------------------------------------------------------+
+ */
+#ifndef HAVE_PTHREADS_STREAMS_TRANSPORTS_H
+#define HAVE_PTHREADS_STREAMS_TRANSPORTS_H
+
+#ifdef PHP_WIN32
+#include "config.w32.h"
+#include <Ws2tcpip.h>
+#endif
+
+#if HAVE_SYS_SOCKET_H
+# include <sys/socket.h>
+#endif
+
+#ifndef HAVE_PTHREADS_HASH_H
+#	include "src/hash.h"
+#endif
+
+#ifndef HAVE_PTHREADS_STREAM_GLOBALS_H
+#	include "src/streams/streamglobals.h"
+#endif
+
+#define PTHREADS_STREAM_XPORT_CLIENT		0
+#define PTHREADS_STREAM_XPORT_SERVER		1
+
+#define PTHREADS_STREAM_XPORT_CONNECT		2
+#define PTHREADS_STREAM_XPORT_BIND			4
+#define PTHREADS_STREAM_XPORT_LISTEN		8
+#define PTHREADS_STREAM_XPORT_CONNECT_ASYNC	16
+
+typedef pthreads_stream_t *(pthreads_stream_transport_factory_func)(const char *proto, size_t protolen,
+		const char *resourcename, size_t resourcenamelen,
+		int options, int flags, struct timeval *timeout,
+		pthreads_stream_context_t *threaded_context);
+typedef pthreads_stream_transport_factory_func *pthreads_stream_transport_factory;
+
+int pthreads_stream_xport_register(const char *protocol, pthreads_stream_transport_factory factory);
+int pthreads_stream_xport_unregister(const char *protocol);
+
+/* Open a client or server socket connection */
+pthreads_stream_t *_pthreads_stream_xport_create(const char *name, size_t namelen, int options,
+		int flags, struct timeval *timeout,
+		pthreads_stream_context_t *threaded_context,
+		zend_string **error_string,
+		int *error_code);
+
+#define pthreads_stream_xport_create(name, namelen, options, flags, timeout, context, estr, ecode) \
+	_pthreads_stream_xport_create(name, namelen, options, flags, timeout, context, estr, ecode)
+
+/* Bind the stream to a local address */
+int pthreads_stream_xport_bind(pthreads_stream_t *threaded_stream,
+		const char *name, size_t namelen,
+		zend_string **error_text
+		);
+
+/* Connect to a remote address */
+int pthreads_stream_xport_connect(pthreads_stream_t *threaded_stream,
+		const char *name, size_t namelen,
+		int asynchronous,
+		struct timeval *timeout,
+		zend_string **error_text,
+		int *error_code
+		);
+
+/* Prepare to listen */
+int pthreads_stream_xport_listen(pthreads_stream_t *threaded_stream,
+		int backlog,
+		zend_string **error_text
+		);
+
+/* Get the next client and their address as a string, or the underlying address
+ * structure.  You must efree either of these if you request them */
+int pthreads_stream_xport_accept(pthreads_stream_t *threaded_stream, pthreads_stream_t **threaded_client,
+		zend_string **textaddr,
+		void **addr, socklen_t *addrlen,
+		struct timeval *timeout,
+		zend_string **error_text
+		);
+
+/* Get the name of either the socket or it's peer */
+int pthreads_stream_xport_get_name(pthreads_stream_t *threaded_stream, int want_peer,
+		zend_string **textaddr,
+		void **addr, socklen_t *addrlen
+		);
+
+enum pthreads_stream_xport_send_recv_flags {
+	PTHREADS_STREAM_OOB = 1,
+	PTHREADS_STREAM_PEEK = 2
+};
+
+/* Similar to recv() system call; read data from the stream, optionally
+ * peeking, optionally retrieving OOB data */
+int pthreads_stream_xport_recvfrom(pthreads_stream_t *threaded_stream, char *buf, size_t buflen,
+		int flags, void **addr, socklen_t *addrlen,
+		zend_string **textaddr);
+
+/* Similar to send() system call; send data to the stream, optionally
+ * sending it as OOB data */
+int pthreads_stream_xport_sendto(pthreads_stream_t *threaded_stream, const char *buf, size_t buflen,
+		int flags, void *addr, socklen_t addrlen);
+
+typedef enum {
+	PTHREADS_STREAM_SHUT_RD,
+	PTHREADS_STREAM_SHUT_WR,
+	PTHREADS_STREAM_SHUT_RDWR
+} pthreads_stream_shutdown_t;
+
+/* Similar to shutdown() system call; shut down part of a full-duplex connection */
+int pthreads_stream_xport_shutdown(pthreads_stream_t *threaded_stream, pthreads_stream_shutdown_t how);
+
+
+/* Structure definition for the set_option interface that the above functions wrap */
+
+typedef struct _pthreads_stream_xport_param {
+	enum {
+		PTHREADS_STREAM_XPORT_OP_BIND, PTHREADS_STREAM_XPORT_OP_CONNECT,
+		PTHREADS_STREAM_XPORT_OP_LISTEN, PTHREADS_STREAM_XPORT_OP_ACCEPT,
+		PTHREADS_STREAM_XPORT_OP_CONNECT_ASYNC,
+		PTHREADS_STREAM_XPORT_OP_GET_NAME,
+		PTHREADS_STREAM_XPORT_OP_GET_PEER_NAME,
+		PTHREADS_STREAM_XPORT_OP_RECV,
+		PTHREADS_STREAM_XPORT_OP_SEND,
+		PTHREADS_STREAM_XPORT_OP_SHUTDOWN
+	} op;
+	unsigned int want_addr:1;
+	unsigned int want_textaddr:1;
+	unsigned int want_errortext:1;
+	unsigned int how:2;
+
+	struct {
+		char *name;
+		size_t namelen;
+		struct timeval *timeout;
+		struct sockaddr *addr;
+		char *buf;
+		size_t buflen;
+		socklen_t addrlen;
+		int backlog;
+		int flags;
+	} inputs;
+	struct {
+		pthreads_stream_t *client;
+		struct sockaddr *addr;
+		socklen_t addrlen;
+		zend_string *textaddr;
+		zend_string *error_text;
+		int returncode;
+		int error_code;
+	} outputs;
+} pthreads_stream_xport_param;
+
+/* Because both client and server streams use the same mechanisms
+   for encryption we use the LSB to denote clients.
+*/
+typedef enum {
+	PTHREADS_STREAM_CRYPTO_METHOD_SSLv2_CLIENT = (1 << 1 | 1),
+	PTHREADS_STREAM_CRYPTO_METHOD_SSLv3_CLIENT = (1 << 2 | 1),
+	/* v23 no longer negotiates SSL2 or SSL3 */
+	PTHREADS_STREAM_CRYPTO_METHOD_SSLv23_CLIENT = ((1 << 3) | (1 << 4) | (1 << 5) | 1),
+	PTHREADS_STREAM_CRYPTO_METHOD_TLSv1_0_CLIENT = (1 << 3 | 1),
+	PTHREADS_STREAM_CRYPTO_METHOD_TLSv1_1_CLIENT = (1 << 4 | 1),
+	PTHREADS_STREAM_CRYPTO_METHOD_TLSv1_2_CLIENT = (1 << 5 | 1),
+	/* TLS equates to TLS_ANY as of PHP 7.2 */
+	PTHREADS_STREAM_CRYPTO_METHOD_TLS_CLIENT = ((1 << 3) | (1 << 4) | (1 << 5) | 1),
+	PTHREADS_STREAM_CRYPTO_METHOD_TLS_ANY_CLIENT = ((1 << 3) | (1 << 4) | (1 << 5) | 1),
+	PTHREADS_STREAM_CRYPTO_METHOD_ANY_CLIENT = ((1 << 1) | (1 << 2) | (1 << 3) | (1 << 4) | (1 << 5) | 1),
+	PTHREADS_STREAM_CRYPTO_METHOD_SSLv2_SERVER = (1 << 1),
+	PTHREADS_STREAM_CRYPTO_METHOD_SSLv3_SERVER = (1 << 2),
+	/* v23 no longer negotiates SSL2 or SSL3 */
+	PTHREADS_STREAM_CRYPTO_METHOD_SSLv23_SERVER = ((1 << 3) | (1 << 4) | (1 << 5)),
+	PTHREADS_STREAM_CRYPTO_METHOD_TLSv1_0_SERVER = (1 << 3),
+	PTHREADS_STREAM_CRYPTO_METHOD_TLSv1_1_SERVER = (1 << 4),
+	PTHREADS_STREAM_CRYPTO_METHOD_TLSv1_2_SERVER = (1 << 5),
+	/* TLS equates to TLS_ANY as of PHP 7.2 */
+	PTHREADS_STREAM_CRYPTO_METHOD_TLS_SERVER = ((1 << 3) | (1 << 4) | (1 << 5)),
+	PTHREADS_STREAM_CRYPTO_METHOD_TLS_ANY_SERVER = ((1 << 3) | (1 << 4) | (1 << 5)),
+	PTHREADS_STREAM_CRYPTO_METHOD_ANY_SERVER = ((1 << 1) | (1 << 2) | (1 << 3) | (1 << 4) | (1 << 5))
+} pthreads_stream_xport_crypt_method_t;
+
+/* These functions provide crypto support on the underlying transport */
+
+int pthreads_stream_xport_crypto_setup(pthreads_stream_t *threaded_stream, pthreads_stream_xport_crypt_method_t crypto_method, pthreads_stream_t *session_stream);
+int pthreads_stream_xport_crypto_enable(pthreads_stream_t *threaded_stream, int activate);
+
+typedef struct _pthreads_stream_xport_crypto_param {
+	struct {
+		pthreads_stream_t *session;
+		int activate;
+		pthreads_stream_xport_crypt_method_t method;
+	} inputs;
+	struct {
+		int returncode;
+	} outputs;
+	enum {
+		PTHREADS_STREAM_XPORT_CRYPTO_OP_SETUP,
+		PTHREADS_STREAM_XPORT_CRYPTO_OP_ENABLE
+	} op;
+} pthreads_stream_xport_crypto_param;
+
+pthreads_hashtable *pthreads_stream_xport_get_hash(void);
+pthreads_stream_transport_factory_func pthreads_stream_generic_socket_factory;
+
+#endif

--- a/src/streams/wrappers.c
+++ b/src/streams/wrappers.c
@@ -1,0 +1,708 @@
+/*
+  +----------------------------------------------------------------------+
+  | pthreads                                                             |
+  +----------------------------------------------------------------------+
+  | Copyright (c) Joe Watkins 2018                                       |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | http://www.php.net/license/3_01.txt                                  |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors: Bastian Schneider <b.schneider@badnoob.com>                 |
+  | Borrowed code from php-src                                           |
+  +----------------------------------------------------------------------+
+ */
+#ifndef HAVE_PTHREADS_STREAMS_WRAPPERS
+#define HAVE_PTHREADS_STREAMS_WRAPPERS
+
+#ifndef HAVE_PTHREADS_H
+#	include <src/pthreads.h>
+#endif
+
+#ifndef HAVE_PTHREADS_STREAMS_WRAPPERS_H
+#	include <src/streams/wrappers.h>
+#endif
+
+int pthreads_init_stream_wrappers() {
+	return (pthreads_register_url_stream_wrapper("php", PTHREADS_STREAMG(stream_php_wrapper)) == SUCCESS &&
+			pthreads_register_url_stream_wrapper("file", PTHREADS_STREAMG(plain_files_wrapper)) == SUCCESS &&
+#ifdef HAVE_GLOB
+			pthreads_register_url_stream_wrapper("glob", PTHREADS_STREAMG(glob_stream_wrapper)) == SUCCESS &&
+#endif
+			pthreads_register_url_stream_wrapper("data", PTHREADS_STREAMG(stream_rfc2397_wrapper)) == SUCCESS &&
+			pthreads_register_url_stream_wrapper("http", PTHREADS_STREAMG(stream_http_wrapper)) == SUCCESS &&
+			pthreads_register_url_stream_wrapper("ftp", PTHREADS_STREAMG(stream_ftp_wrapper)) == SUCCESS
+		) ? SUCCESS : FAILURE;
+}
+
+int pthreads_shutdown_stream_wrappers() {
+	return (pthreads_unregister_url_stream_wrapper("php") == SUCCESS &&
+			pthreads_unregister_url_stream_wrapper("file") == SUCCESS &&
+#ifdef HAVE_GLOB
+			pthreads_unregister_url_stream_wrapper("glob") == SUCCESS &&
+#endif
+			pthreads_unregister_url_stream_wrapper("data") == SUCCESS &&
+			pthreads_unregister_url_stream_wrapper("http") == SUCCESS &&
+			pthreads_unregister_url_stream_wrapper("ftp") == SUCCESS
+		) ? SUCCESS : FAILURE;
+}
+
+/* {{{ wrapper error reporting */
+static zend_llist *pthreads_get_wrapper_errors_list(pthreads_stream_wrapper_t *threaded_wrapper) {
+	pthreads_hashtable *wrapper_errors = &PTHREADS_STREAMG(wrapper_errors);
+	zend_llist *result = NULL;
+
+	if(MONITOR_LOCK(wrapper_errors)) {
+		result = (zend_llist*) zend_hash_str_find_ptr(&wrapper_errors->ht, (const char*)&threaded_wrapper, sizeof(threaded_wrapper));
+
+        MONITOR_UNLOCK(wrapper_errors);
+	}
+	return result;
+}
+
+void pthreads_stream_display_wrapper_errors(pthreads_stream_wrapper_t *threaded_wrapper, const char *path, const char *caption) {
+	char *tmp = estrdup(path);
+	char *msg;
+	int free_msg = 0;
+
+	if (threaded_wrapper) {
+		pthreads_hashtable *pht = &PTHREADS_STREAMG(wrapper_errors);
+
+		if(pthreads_monitor_lock(pht->monitor)) {
+			zend_llist *err_list = pthreads_get_wrapper_errors_list(threaded_wrapper);
+			if (err_list) {
+				size_t l = 0;
+				int brlen;
+				int i;
+				int count = (int)zend_llist_count(err_list);
+				const char *br;
+				const char **err_buf_p;
+				zend_llist_position pos;
+
+				if (PG(html_errors)) {
+					brlen = 7;
+					br = "<br />\n";
+				} else {
+					brlen = 1;
+					br = "\n";
+				}
+
+				for (err_buf_p = zend_llist_get_first_ex(err_list, &pos), i = 0;
+						err_buf_p;
+						err_buf_p = zend_llist_get_next_ex(err_list, &pos), i++) {
+					l += strlen(*err_buf_p);
+					if (i < count - 1) {
+						l += brlen;
+					}
+				}
+				msg = emalloc(l + 1);
+				msg[0] = '\0';
+				for (err_buf_p = zend_llist_get_first_ex(err_list, &pos), i = 0;
+						err_buf_p;
+						err_buf_p = zend_llist_get_next_ex(err_list, &pos), i++) {
+					strcat(msg, *err_buf_p);
+					if (i < count - 1) {
+						strcat(msg, br);
+					}
+				}
+
+				free_msg = 1;
+			} else {
+				if (threaded_wrapper == PTHREADS_STREAMG(plain_files_wrapper)) {
+					msg = strerror(errno); /* TODO: not ts on linux */
+				} else {
+					msg = "operation failed";
+				}
+			}
+	        pthreads_monitor_unlock(pht->monitor);
+		}
+	} else {
+		msg = "no suitable wrapper could be found";
+	}
+
+	php_strip_url_passwd(tmp);
+	php_error_docref1(NULL, tmp, E_WARNING, "%s: %s", caption, msg);
+	efree(tmp);
+	if (free_msg && msg) {
+		efree(msg);
+	}
+}
+
+void pthreads_stream_tidy_wrapper_error_log(pthreads_stream_wrapper_t *threaded_wrapper) {
+	if (!threaded_wrapper) {
+		return;
+	}
+	pthreads_hashtable *wrapper_errors = &PTHREADS_STREAMG(wrapper_errors);
+
+	if(MONITOR_LOCK(wrapper_errors)) {
+		zend_hash_str_del(&wrapper_errors->ht, (const char*)&threaded_wrapper, sizeof(threaded_wrapper));
+		MONITOR_UNLOCK(wrapper_errors);
+	}
+}
+
+static void wrapper_error_dtor(void *error) {
+	free(*(char**)error);
+}
+
+void pthreads_stream_wrapper_log_error(const pthreads_stream_wrapper_t *threaded_wrapper, int options, const char *fmt, ...) {
+	va_list args;
+	char *buffer = NULL;
+
+	va_start(args, fmt);
+	vspprintf(&buffer, 0, fmt, args);
+	va_end(args);
+
+	if (options & PTHREADS_REPORT_ERRORS || threaded_wrapper == NULL) {
+		php_error_docref(NULL, E_WARNING, "%s", buffer);
+		efree(buffer);
+	} else {
+		pthreads_hashtable *wrapper_errors = &PTHREADS_STREAMG(wrapper_errors);
+
+		if(MONITOR_LOCK(wrapper_errors)) {
+			zend_llist *list = zend_hash_str_find_ptr(&wrapper_errors->ht, (const char*)&threaded_wrapper, sizeof(threaded_wrapper));
+
+			if (!list) {
+				zend_llist new_list;
+				zend_llist_init(&new_list, sizeof(buffer), wrapper_error_dtor, 1);
+				list = zend_hash_str_update_mem(&wrapper_errors->ht, (const char*)&threaded_wrapper,
+						sizeof(threaded_wrapper), &new_list, sizeof(new_list));
+			}
+			char *buf = strdup(buffer);
+			efree(buffer);
+
+			/* append to linked list */
+			zend_llist_add_element(list, &buf);
+			MONITOR_UNLOCK(wrapper_errors);
+		}
+	}
+}
+
+/* }}} */
+
+/* Validate protocol scheme names during registration
+ * Must conform to /^[a-zA-Z0-9+.-]+$/
+ */
+static inline int pthreads_stream_wrapper_scheme_validate(const char *protocol, unsigned int protocol_len) {
+	unsigned int i;
+
+	for(i = 0; i < protocol_len; i++) {
+		if (!isalnum((int)protocol[i]) &&
+			protocol[i] != '+' &&
+			protocol[i] != '-' &&
+			protocol[i] != '.') {
+			return FAILURE;
+		}
+	}
+
+	return SUCCESS;
+}
+
+void pthreads_stream_wrapper_free(pthreads_stream_wrapper *wrapper) {
+	free(wrapper);
+}
+
+pthreads_stream_wrapper *pthreads_stream_wrapper_alloc(void) {
+	pthreads_stream_wrapper *wrapper = calloc(1, sizeof(pthreads_stream_wrapper));
+
+	return wrapper;
+}
+
+/* {{{  API for registering GLOBAL wrappers */
+pthreads_hashtable *_pthreads_stream_get_url_stream_wrappers_hash(void) {
+	return &PTHREADS_STREAMG(url_stream_wrappers_hash);
+}
+
+int pthreads_register_url_stream_wrapper(const char *protocol, pthreads_stream_wrapper_t *threaded_wrapper) {
+	pthreads_hashtable *url_stream_wrappers_hash = &PTHREADS_STREAMG(url_stream_wrappers_hash);
+	unsigned int protocol_len = (unsigned int)strlen(protocol);
+	int result = FAILURE;
+
+	if (pthreads_stream_wrapper_scheme_validate(protocol, protocol_len) == FAILURE) {
+		return result;
+	}
+
+	if(MONITOR_LOCK(url_stream_wrappers_hash)) {
+		result = zend_hash_add_ptr(&url_stream_wrappers_hash->ht, zend_string_init_interned(protocol, protocol_len, 1), threaded_wrapper) ? SUCCESS : FAILURE;
+		MONITOR_UNLOCK(url_stream_wrappers_hash);
+	}
+	return result;
+}
+
+int pthreads_unregister_url_stream_wrapper(const char *protocol) {
+	pthreads_hashtable *url_stream_wrappers_hash = &PTHREADS_STREAMG(url_stream_wrappers_hash);
+	int result = FAILURE;
+
+	if(MONITOR_LOCK(url_stream_wrappers_hash)) {
+		result = zend_hash_str_del(&url_stream_wrappers_hash->ht, protocol, strlen(protocol));
+		MONITOR_UNLOCK(url_stream_wrappers_hash);
+	}
+	return result;
+}
+/* }}} */
+
+/* {{{ pthreads_stream_locate_url_wrapper */
+pthreads_stream_wrapper_t *pthreads_stream_locate_url_wrapper(const char *path, const char **path_for_open, int options) {
+	pthreads_hashtable *wrapper_hash = &PTHREADS_STREAMG(url_stream_wrappers_hash);
+	pthreads_stream_wrapper *wrapper = NULL;
+	pthreads_stream_wrapper_t *threaded_wrapper = NULL;
+	const char *p, *protocol = NULL;
+	size_t n = 0;
+
+	if (path_for_open) {
+		*path_for_open = (char*)path;
+	}
+
+	if (options & IGNORE_URL) {
+		return (options & PTHREADS_STREAM_LOCATE_WRAPPERS_ONLY) ? NULL : PTHREADS_STREAMG(plain_files_wrapper);
+	}
+
+	for (p = path; isalnum((int)*p) || *p == '+' || *p == '-' || *p == '.'; p++) {
+		n++;
+	}
+
+	if ((*p == ':') && (n > 1) && (!strncmp("//", p+1, 2) || (n == 4 && !memcmp("data:", path, 5)))) {
+		protocol = path;
+	}
+
+	if (protocol) {
+		char *tmp = estrndup(protocol, n);
+		if(MONITOR_LOCK(wrapper_hash)) {
+			if (NULL == (threaded_wrapper = zend_hash_str_find_ptr(&wrapper_hash->ht, (char*)tmp, n))) {
+				php_strtolower(tmp, n);
+				if (NULL == (threaded_wrapper = zend_hash_str_find_ptr(&wrapper_hash->ht, (char*)tmp, n))) {
+					char wrapper_name[32];
+
+					if (n >= sizeof(wrapper_name)) {
+						n = sizeof(wrapper_name) - 1;
+					}
+					PHP_STRLCPY(wrapper_name, protocol, sizeof(wrapper_name), n);
+
+					php_error_docref(NULL, E_WARNING, "Unable to find the wrapper \"%s\" - did you forget to enable it when you configured PHP?", wrapper_name);
+
+					threaded_wrapper = NULL;
+					protocol = NULL;
+				}
+			}
+			MONITOR_UNLOCK(wrapper_hash);
+		}
+		efree(tmp);
+	}
+	/* TODO: curl based streams probably support file:// properly */
+	if (!protocol || !strncasecmp(protocol, "file", n))	{
+		/* fall back on regular file access */
+		pthreads_stream_wrapper_t *plain_files_wrapper = PTHREADS_STREAMG(plain_files_wrapper);
+
+		if (protocol) {
+			int localhost = 0;
+
+			if (!strncasecmp(path, "file://localhost/", 17)) {
+				localhost = 1;
+			}
+
+#ifdef PHP_WIN32
+			if (localhost == 0 && path[n+3] != '\0' && path[n+3] != '/' && path[n+4] != ':')	{
+#else
+			if (localhost == 0 && path[n+3] != '\0' && path[n+3] != '/') {
+#endif
+				if (options & REPORT_ERRORS) {
+					php_error_docref(NULL, E_WARNING, "remote host file access not supported, %s", path);
+				}
+				return NULL;
+			}
+
+			if (path_for_open) {
+				/* skip past protocol and :/, but handle windows correctly */
+				*path_for_open = (char*)path + n + 1;
+				if (localhost == 1) {
+					(*path_for_open) += 11;
+				}
+				while (*(++*path_for_open)=='/') {
+					/* intentionally empty */
+				}
+#ifdef PHP_WIN32
+				if (*(*path_for_open + 1) != ':')
+#endif
+					(*path_for_open)--;
+			}
+		}
+
+		if (options & PTHREADS_STREAM_LOCATE_WRAPPERS_ONLY) {
+			return NULL;
+		}
+
+		if (threaded_wrapper) {
+			/* It was found so go ahead and provide it */
+			return threaded_wrapper;
+		}
+
+		/* Check again, the original check might have not known the protocol name */
+		if(MONITOR_LOCK(wrapper_hash)) {
+			threaded_wrapper = zend_hash_str_find_ptr(&wrapper_hash->ht, "file", sizeof("file")-1);
+			MONITOR_UNLOCK(wrapper_hash);
+
+			if (threaded_wrapper != NULL) {
+				return threaded_wrapper;
+			}
+		}
+
+		return plain_files_wrapper;
+	}
+
+	if(threaded_wrapper) {
+		wrapper = PTHREADS_FETCH_STREAMS_WRAPPER(threaded_wrapper);
+
+		if (wrapper && wrapper->is_url &&
+			(options & PTHREADS_STREAM_DISABLE_URL_PROTECTION) == 0 &&
+			(!PG(allow_url_fopen) ||
+			 (((options & PTHREADS_STREAM_OPEN_FOR_INCLUDE) ||
+			   PG(in_user_include)) && !PG(allow_url_include)))) {
+			if (options & PTHREADS_REPORT_ERRORS) {
+				/* protocol[n] probably isn't '\0' */
+				char *protocol_dup = estrndup(protocol, n);
+				if (!PG(allow_url_fopen)) {
+					php_error_docref(NULL, E_WARNING, "%s:// wrapper is disabled in the server configuration by allow_url_fopen=0", protocol_dup);
+				} else {
+					php_error_docref(NULL, E_WARNING, "%s:// wrapper is disabled in the server configuration by allow_url_include=0", protocol_dup);
+				}
+				efree(protocol_dup);
+			}
+			return NULL;
+		}
+	}
+	return threaded_wrapper;
+}
+/* }}} */
+
+/* {{{ _pthreads_stream_mkdir */
+int _pthreads_stream_mkdir(const char *path, int mode, int options, pthreads_stream_context_t *threaded_context) {
+	pthreads_stream_wrapper_t *threaded_wrapper = NULL;
+	pthreads_stream_wrapper *wrapper = NULL;
+	int result = FAILURE;
+
+	threaded_wrapper = pthreads_stream_locate_url_wrapper(path, NULL, 0);
+	if (!threaded_wrapper) {
+		return result;
+	}
+	wrapper = PTHREADS_FETCH_STREAMS_WRAPPER(threaded_wrapper);
+
+	if(MONITOR_LOCK(threaded_wrapper)) {
+		if(!wrapper->wops || !wrapper->wops->stream_mkdir) {
+			MONITOR_UNLOCK(threaded_wrapper);
+			return result;
+		}
+		result = wrapper->wops->stream_mkdir(threaded_wrapper, path, mode, options, threaded_context);
+
+		MONITOR_UNLOCK(threaded_wrapper);
+	}
+	return result;
+}
+/* }}} */
+
+/* {{{ _pthreads_stream_rmdir */
+int _pthreads_stream_rmdir(const char *path, int options, pthreads_stream_context_t *threaded_context) {
+	pthreads_stream_wrapper_t *threaded_wrapper = NULL;
+	pthreads_stream_wrapper *wrapper = NULL;
+	int result = FAILURE;
+
+	threaded_wrapper = pthreads_stream_locate_url_wrapper(path, NULL, 0);
+	if (!threaded_wrapper) {
+		return result;
+	}
+	wrapper = PTHREADS_FETCH_STREAMS_WRAPPER(threaded_wrapper);
+
+	if(MONITOR_LOCK(threaded_wrapper)) {
+		if(!wrapper->wops || !wrapper->wops->stream_rmdir) {
+			MONITOR_UNLOCK(threaded_wrapper);
+			return result;
+		}
+		result = wrapper->wops->stream_rmdir(threaded_wrapper, path, options, threaded_context);
+
+		MONITOR_UNLOCK(threaded_wrapper);
+	}
+	return result;
+}
+/* }}} */
+
+/* {{{ pthreads_stream_stat_path */
+int _pthreads_stream_stat_path(const char *path, int flags, pthreads_stream_statbuf *ssb, pthreads_stream_context_t *threaded_context) {
+	pthreads_stream_wrapper_t *threaded_wrapper = NULL;
+	pthreads_stream_wrapper *wrapper = NULL;
+	const char *path_to_open = path;
+	int ret;
+
+	if (!(flags & PTHREADS_STREAM_URL_STAT_NOCACHE)) {
+		if(pthreads_stream_globals_lock()) {
+			/* Try to hit the cache first */
+			if (flags & PTHREADS_STREAM_URL_STAT_LINK) {
+				if (PTHREADS_STREAMG(CurrentLStatFile) && strcmp(path, PTHREADS_STREAMG(CurrentLStatFile)) == 0) {
+					memcpy(ssb, &PTHREADS_STREAMG(lssb), sizeof(pthreads_stream_statbuf));
+					return 0;
+				}
+			} else {
+				if (PTHREADS_STREAMG(CurrentStatFile) && strcmp(path, PTHREADS_STREAMG(CurrentStatFile)) == 0) {
+					memcpy(ssb, &PTHREADS_STREAMG(ssb), sizeof(pthreads_stream_statbuf));
+					return 0;
+				}
+			}
+			pthreads_stream_globals_unlock();
+		}
+	}
+
+	threaded_wrapper = pthreads_stream_locate_url_wrapper(path, &path_to_open, 0);
+	if (threaded_wrapper) {
+		wrapper = PTHREADS_FETCH_STREAMS_WRAPPER(threaded_wrapper);
+
+		if(MONITOR_LOCK(threaded_wrapper)) {
+			if(wrapper->wops->url_stat) {
+				ret = wrapper->wops->url_stat(threaded_wrapper, path_to_open, flags, ssb, threaded_context);
+				if (ret == 0) {
+					if (!(flags & PTHREADS_STREAM_URL_STAT_NOCACHE)) {
+						if(pthreads_stream_globals_lock()) {
+							/* Drop into cache */
+							if (flags & PTHREADS_STREAM_URL_STAT_LINK) {
+								if (PTHREADS_STREAMG(CurrentLStatFile)) {
+									free(PTHREADS_STREAMG(CurrentLStatFile));
+								}
+								PTHREADS_STREAMG(CurrentLStatFile) = strdup(path);
+								memcpy(&PTHREADS_STREAMG(lssb), ssb, sizeof(pthreads_stream_statbuf));
+							} else {
+								if (PTHREADS_STREAMG(CurrentStatFile)) {
+									free(BG(CurrentStatFile));
+								}
+								PTHREADS_STREAMG(CurrentStatFile) = strdup(path);
+								memcpy(&PTHREADS_STREAMG(ssb), ssb, sizeof(pthreads_stream_statbuf));
+							}
+							pthreads_stream_globals_unlock();
+						}
+					}
+				}
+			}
+			MONITOR_UNLOCK(threaded_wrapper);
+		}
+		return ret;
+	}
+	return -1;
+}
+/* }}} */
+
+/* {{{ pthreads_stream_opendir */
+pthreads_stream_t *_pthreads_stream_opendir(const char *path, int options, pthreads_stream_context_t *threaded_context, zend_class_entry *ce) {
+	pthreads_stream_t *threaded_stream = NULL;
+	pthreads_stream *stream = NULL;
+	pthreads_stream_wrapper_t *threaded_wrapper = NULL;
+	pthreads_stream_wrapper *wrapper = NULL;
+	const char *path_to_open;
+
+	if (!path || !*path) {
+		return NULL;
+	}
+	path_to_open = path;
+
+	threaded_wrapper = pthreads_stream_locate_url_wrapper(path, &path_to_open, options);
+
+	if (threaded_wrapper) {
+		wrapper = PTHREADS_FETCH_STREAMS_WRAPPER(threaded_wrapper);
+		if(MONITOR_LOCK(threaded_wrapper)) {
+			if(wrapper->wops->dir_opener) {
+				if(ce == NULL) {
+					ce = pthreads_stream_entry;
+				}
+				threaded_stream = wrapper->wops->dir_opener(threaded_wrapper,
+								  path_to_open, "r", options ^ PTHREADS_REPORT_ERRORS, NULL,
+								  threaded_context, ce);
+
+				if (threaded_stream) {
+					stream = PTHREADS_FETCH_STREAMS_STREAM(threaded_stream);
+					stream->wrapper = threaded_wrapper;
+					stream->flags |= PTHREADS_STREAM_FLAG_NO_BUFFER | PTHREADS_STREAM_FLAG_IS_DIR;
+				}
+			} else if (threaded_wrapper) {
+				pthreads_stream_wrapper_log_error(threaded_wrapper, options ^ PTHREADS_REPORT_ERRORS, "not implemented");
+			}
+			MONITOR_UNLOCK(threaded_wrapper);
+		}
+	}
+	if (threaded_stream == NULL && (options & PTHREADS_REPORT_ERRORS)) {
+		pthreads_stream_display_wrapper_errors(threaded_wrapper, path, "failed to open dir");
+	}
+	pthreads_stream_tidy_wrapper_error_log(threaded_wrapper);
+
+	return threaded_stream;
+}
+/* }}} */
+
+/* {{{ _pthreads_stream_readdir */
+pthreads_stream_dirent *_pthreads_stream_readdir(pthreads_stream_t *threaded_dirstream, pthreads_stream_dirent *ent) {
+	if (sizeof(pthreads_stream_dirent) == pthreads_stream_read(threaded_dirstream, (char*)ent, sizeof(pthreads_stream_dirent))) {
+		return ent;
+	}
+	return NULL;
+}
+/* }}} */
+
+/* {{{ pthreads_stream_open_wrapper_ex */
+pthreads_stream_t *_pthreads_stream_open_wrapper_ex(const char *path, const char *mode, int options,
+		zend_string **opened_path, pthreads_stream_context_t *threaded_context, zend_class_entry *ce) {
+	pthreads_stream_t *threaded_stream = NULL;
+	pthreads_stream *stream = NULL;
+	pthreads_stream_wrapper_t *threaded_wrapper = NULL;
+	pthreads_stream_wrapper *wrapper = NULL;
+	const char *path_to_open;
+	zend_string *resolved_path = NULL;
+	char *copy_of_path = NULL;
+
+	if (opened_path) {
+		*opened_path = NULL;
+	}
+
+	if (!path || !*path) {
+		php_error_docref(NULL, E_WARNING, "Filename cannot be empty");
+		return NULL;
+	}
+
+	if (options & PTHREADS_USE_PATH) {
+		resolved_path = zend_resolve_path(path, (int)strlen(path));
+		if (resolved_path) {
+			path = ZSTR_VAL(resolved_path);
+			/* we've found this file, don't re-check include_path or run realpath */
+			options |= PTHREADS_STREAM_ASSUME_REALPATH;
+			options &= ~PTHREADS_USE_PATH;
+		}
+	}
+
+	path_to_open = path;
+
+	threaded_wrapper = pthreads_stream_locate_url_wrapper(path, &path_to_open, options);
+
+	if(threaded_wrapper) {
+		wrapper = PTHREADS_FETCH_STREAMS_WRAPPER(threaded_wrapper);
+	}
+
+	if (options & PTHREADS_STREAM_USE_URL && (!wrapper || !wrapper->is_url)) {
+		php_error_docref(NULL, E_WARNING, "This function may only be used against URLs");
+		if (resolved_path) {
+			zend_string_release(resolved_path);
+		}
+		return NULL;
+	}
+
+	if (wrapper) {
+		if (!wrapper->wops->stream_opener) {
+			pthreads_stream_wrapper_log_error(threaded_wrapper, options ^ PTHREADS_REPORT_ERRORS,
+					"wrapper does not support stream open");
+		} else {
+			if(MONITOR_LOCK(threaded_wrapper)) {
+				threaded_stream = wrapper->wops->stream_opener(threaded_wrapper,
+					path_to_open, mode, options ^ PTHREADS_REPORT_ERRORS,
+					opened_path, threaded_context, ce);
+
+				MONITOR_UNLOCK(threaded_wrapper);
+			}
+		}
+
+		if (threaded_stream) {
+			stream = PTHREADS_FETCH_STREAMS_STREAM(threaded_stream);
+			stream->wrapper = threaded_wrapper;
+		}
+	}
+
+	if (threaded_stream) {
+		if (opened_path && !*opened_path && resolved_path) {
+			*opened_path = resolved_path;
+			resolved_path = NULL;
+		}
+
+		if(stream_lock(threaded_stream)) {
+			stream = PTHREADS_FETCH_STREAMS_STREAM(threaded_stream);
+
+			if (stream->orig_path) {
+				free(stream->orig_path);
+			}
+			copy_of_path = strdup(path);
+			stream->orig_path = copy_of_path;
+
+			stream_unlock(threaded_stream);
+		}
+
+		if (options & PTHREADS_STREAM_MUST_SEEK) {
+			pthreads_stream_t *threaded_newstream;
+			pthreads_stream *newstream;
+
+			switch(pthreads_stream_make_seekable(threaded_stream, &threaded_newstream,
+						(options & PTHREADS_STREAM_WILL_CAST)
+							? PTHREADS_STREAM_PREFER_STDIO : PTHREADS_STREAM_NO_PREFERENCE)) {
+				case PTHREADS_STREAM_UNCHANGED:
+					if (resolved_path) {
+						zend_string_release(resolved_path);
+					}
+					return threaded_stream;
+				case PTHREADS_STREAM_RELEASED:
+					newstream = PTHREADS_FETCH_STREAMS_STREAM(threaded_newstream);
+
+					if(stream_lock(threaded_newstream)) {
+						if (newstream->orig_path) {
+							free(newstream->orig_path);
+						}
+						newstream->orig_path = strdup(path);
+
+						stream_unlock(threaded_newstream);
+					}
+					if (resolved_path) {
+						zend_string_release(resolved_path);
+					}
+					return threaded_newstream;
+				default:
+					pthreads_stream_close(threaded_stream, PTHREADS_STREAM_FREE_CLOSE);
+					threaded_stream = NULL;
+					stream = NULL;
+					if (options & PTHREADS_REPORT_ERRORS) {
+						char *tmp = estrdup(path);
+						php_strip_url_passwd(tmp);
+						php_error_docref1(NULL, tmp, E_WARNING, "could not make seekable - %s",
+								tmp);
+						efree(tmp);
+
+						options ^= PTHREADS_REPORT_ERRORS;
+					}
+			}
+		}
+
+		if(stream_lock(threaded_stream)) {
+			if(stream->ops->seek && (stream->flags & PTHREADS_STREAM_FLAG_NO_SEEK) == 0 && strchr(mode, 'a') && stream->position == 0)
+			{
+				zend_off_t newpos = 0;
+
+				/* if opened for append, we need to revise our idea of the initial file position */
+				if (0 == stream->ops->seek(threaded_stream, 0, SEEK_CUR, &newpos)) {
+					stream->position = newpos;
+				}
+			}
+			stream_unlock(threaded_stream);
+		}
+	} else if(options & PTHREADS_REPORT_ERRORS) {
+		pthreads_stream_display_wrapper_errors(threaded_wrapper, path, "failed to open stream");
+		if (opened_path && *opened_path) {
+			zend_string_release(*opened_path);
+			*opened_path = NULL;
+		}
+	}
+	pthreads_stream_tidy_wrapper_error_log(threaded_wrapper);
+
+#if ZEND_DEBUG
+	if (stream == NULL && copy_of_path != NULL) {
+		free(copy_of_path);
+	}
+#endif
+	if (resolved_path) {
+		zend_string_release(resolved_path);
+	}
+
+	return threaded_stream;
+}
+/* }}} */
+
+#endif

--- a/src/streams/wrappers.h
+++ b/src/streams/wrappers.h
@@ -1,0 +1,64 @@
+/*
+  +----------------------------------------------------------------------+
+  | pthreads                                                             |
+  +----------------------------------------------------------------------+
+  | Copyright (c) Joe Watkins 2018                                       |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | http://www.php.net/license/3_01.txt                                  |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors: Bastian Schneider <b.schneider@badnoob.com>                 |
+  | Borrowed code from php-src                                           |
+  +----------------------------------------------------------------------+
+ */
+#ifndef HAVE_PTHREADS_STREAMS_WRAPPERS_H
+#define HAVE_PTHREADS_STREAMS_WRAPPERS_H
+
+#ifndef HAVE_PTHREADS_STREAMS_H
+#	include <src/streams.h>
+#endif
+
+int pthreads_init_stream_wrappers();
+int pthreads_shutdown_stream_wrappers();
+
+/* pushes an error message onto the stack for a wrapper instance */
+void pthreads_stream_wrapper_log_error(const pthreads_stream_wrapper_t *threaded_wrapper, int options, const char *fmt, ...) PHP_ATTRIBUTE_FORMAT(printf, 3, 4);
+
+void pthreads_stream_wrapper_free(pthreads_stream_wrapper *wrapper);
+pthreads_stream_wrapper *pthreads_stream_wrapper_alloc(void);
+
+
+int pthreads_register_url_stream_wrapper(const char *protocol, pthreads_stream_wrapper_t *threaded_wrapper);
+int pthreads_unregister_url_stream_wrapper(const char *protocol);
+
+pthreads_stream_t *_pthreads_stream_open_wrapper_ex(const char *path, const char *mode, int options, zend_string **opened_path,
+		pthreads_stream_context_t *threaded_context, zend_class_entry *ce);
+pthreads_stream_wrapper_t *pthreads_stream_locate_url_wrapper(const char *path, const char **path_for_open, int options);
+
+int _pthreads_stream_mkdir(const char *path, int mode, int options, pthreads_stream_context_t *threaded_context);
+#define pthreads_stream_mkdir(path, mode, options, threaded_context)	_pthreads_stream_mkdir(path, mode, options, threaded_context)
+
+int _pthreads_stream_rmdir(const char *path, int options, pthreads_stream_context_t *threaded_context);
+#define pthreads_stream_rmdir(path, options, threaded_context)	_pthreads_stream_rmdir(path, options, threaded_context)
+
+int _pthreads_stream_stat_path(const char *path, int flags, pthreads_stream_statbuf *ssb, pthreads_stream_context_t *threaded_context);
+#define pthreads_stream_stat_path(path, ssb)	_pthreads_stream_stat_path((path), 0, (ssb), NULL)
+#define pthreads_stream_stat_path_ex(path, flags, ssb, threaded_context)	_pthreads_stream_stat_path((path), (flags), (ssb), (threaded_context))
+
+pthreads_stream_t *_pthreads_stream_opendir(const char *path, int options, pthreads_stream_context_t *threaded_context, zend_class_entry *ce);
+#define pthreads_stream_opendir(path, options, context)	_pthreads_stream_opendir((path), (options), (threaded_context), NULL)
+
+pthreads_stream_dirent *_pthreads_stream_readdir(pthreads_stream_t *threaded_dirstream, pthreads_stream_dirent *ent);
+#define pthreads_stream_readdir(threaded_dirstream, dirent)	_pthreads_stream_readdir((threaded_dirstream), (dirent))
+
+#define pthreads_stream_open_wrapper(path, mode, options, opened)	\
+	_pthreads_stream_open_wrapper_ex((path), (mode), (options), (opened), NULL, NULL)
+#define pthreads_stream_open_wrapper_ex(path, mode, options, opened, threaded_context, ce)	\
+	_pthreads_stream_open_wrapper_ex((path), (mode), (options), (opened), (threaded_context), (ce))
+
+#endif

--- a/src/streams/wrappers/fopen_wrapper.c
+++ b/src/streams/wrappers/fopen_wrapper.c
@@ -1,0 +1,352 @@
+/*
+  +----------------------------------------------------------------------+
+  | pthreads                                                             |
+  +----------------------------------------------------------------------+
+  | Copyright (c) Joe Watkins 2018                                       |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | http://www.php.net/license/3_01.txt                                  |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors: Bastian Schneider <b.schneider@badnoob.com>                 |
+  | Borrowed code from php-src                                           |
+  +----------------------------------------------------------------------+
+ */
+#ifndef HAVE_PTHREADS_STREAMS_WRAPPERS_FOPEN_WRAPPER
+#define HAVE_PTHREADS_STREAMS_WRAPPERS_FOPEN_WRAPPER
+
+#ifndef HAVE_PTHREADS_H
+#	include <src/pthreads.h>
+#endif
+
+#ifndef HAVE_PTHREADS_STREAM_H
+#	include <src/streams.h>
+#endif
+
+#include <stdio.h>
+#include <stdlib.h>
+#if HAVE_UNISTD_H
+#include <unistd.h>
+#endif
+
+#ifndef HAVE_PTHREADS_STREAMS_MEMORY_H
+#	include <src/streams/memory.h>
+#endif
+
+#ifndef HAVE_PTHREADS_STREAMS_WRAPPERS_FOPEN_WRAPPER_H
+#	include <src/streams/wrappers/fopen_wrapper.h>
+#endif
+
+#ifndef HAVE_PTHREADS_NETWORK_H
+#	include <src/network.h>
+#endif
+
+/* {{{ */
+static size_t pthreads_stream_output_write(pthreads_stream_t *threaded_stream, const char *buf, size_t count) {
+	PHPWRITE(buf, count);
+	return count;
+}
+/* }}} */
+
+/* {{{ */
+static size_t pthreads_stream_output_read(pthreads_stream_t *threaded_stream, char *buf, size_t count) {
+	pthreads_stream *stream = PTHREADS_FETCH_STREAMS_STREAM(threaded_stream);
+	stream->eof = 1;
+	return 0;
+}
+/* }}} */
+
+/* {{{ */
+static int pthreads_stream_output_close(pthreads_stream_t *threaded_stream, int close_handle) {
+	return 0;
+}
+/* }}} */
+
+/* {{{ */
+static void pthreads_stream_output_free(pthreads_stream_t *threaded_stream, int close_handle) { }
+/* }}} */
+
+const pthreads_stream_ops pthreads_stream_output_ops = {
+	pthreads_stream_output_write,
+	pthreads_stream_output_read,
+	pthreads_stream_output_close,
+	pthreads_stream_output_free,
+	NULL, /* flush */
+	"Output",
+	NULL, /* seek */
+	NULL, /* cast */
+	NULL, /* stat */
+	NULL  /* set_option */
+};
+
+/* {{{ */
+static void pthreads_stream_apply_filter_list(pthreads_stream_t *threaded_stream, char *filterlist, int read_chain, int write_chain) {
+	pthreads_stream *stream = PTHREADS_FETCH_STREAMS_STREAM(threaded_stream);
+	char *p, *token = NULL;
+	pthreads_stream_filter_t *temp_filter;
+
+	p = php_strtok_r(filterlist, "|", &token);
+	while (p) {
+		php_url_decode(p, strlen(p));
+		if (read_chain) {
+			if ((temp_filter = pthreads_stream_filter_create(p, NULL))) {
+				pthreads_stream_filter_append(pthreads_stream_get_readfilters(threaded_stream), temp_filter);
+			} else {
+				php_error_docref(NULL, E_WARNING, "Unable to create filter (%s)", p);
+			}
+		}
+		if (write_chain) {
+			if ((temp_filter = pthreads_stream_filter_create(p, NULL))) {
+				pthreads_stream_filter_append(pthreads_stream_get_writefilters(threaded_stream), temp_filter);
+			} else {
+				php_error_docref(NULL, E_WARNING, "Unable to create filter (%s)", p);
+			}
+		}
+		p = php_strtok_r(NULL, "|", &token);
+	}
+}
+/* }}} */
+
+/* {{{ */
+pthreads_stream_t * pthreads_stream_url_wrap_php(pthreads_stream_wrapper_t *threaded_wrapper, const char *path, const char *mode, int options,
+									 zend_string **opened_path, pthreads_stream_context_t *threaded_context, zend_class_entry *ce) {
+	int fd = -1;
+	int mode_rw = 0;
+	pthreads_stream_t *threaded_stream = NULL;
+	pthreads_stream *stream = NULL;
+	char *p, *token, *pathdup;
+	zend_long max_memory;
+	FILE *file = NULL;
+#ifdef PHP_WIN32
+	int pipe_requested = 0;
+#endif
+
+	if (!strncasecmp(path, "php://", 6)) {
+		path += 6;
+	}
+
+	if (!strncasecmp(path, "temp", 4)) {
+		path += 4;
+		max_memory = PTHREADS_STREAM_MAX_MEM;
+		if (!strncasecmp(path, "/maxmemory:", 11)) {
+			path += 11;
+			max_memory = ZEND_STRTOL(path, NULL, 10);
+			if (max_memory < 0) {
+				zend_throw_error(NULL, "Max memory must be >= 0");
+				return NULL;
+			}
+		}
+		mode_rw = pthreads_stream_mode_from_str(mode);
+		return pthreads_stream_temp_create(mode_rw, max_memory, ce);
+	}
+
+	if (!strcasecmp(path, "memory")) {
+		mode_rw = pthreads_stream_mode_from_str(mode);
+		return pthreads_stream_memory_create(mode_rw, ce);
+	}
+
+	if (!strcasecmp(path, "output")) {
+		return PTHREADS_STREAM_CLASS_NEW(&pthreads_stream_output_ops, NULL, "wb", ce);
+	}
+
+	if (!strcasecmp(path, "stdin")) {
+		if ((options & PTHREADS_STREAM_OPEN_FOR_INCLUDE) && !PG(allow_url_include) ) {
+			if (options & PTHREADS_REPORT_ERRORS) {
+				php_error_docref(NULL, E_WARNING, "URL file-access is disabled in the server configuration");
+			}
+			return NULL;
+		}
+		if (!strcmp(sapi_module.name, "cli")) {
+			static int cli_in = 0;
+			fd = STDIN_FILENO;
+			if (cli_in) {
+				fd = dup(fd);
+			} else {
+				cli_in = 1;
+				file = stdin;
+			}
+		} else {
+			fd = dup(STDIN_FILENO);
+		}
+#ifdef PHP_WIN32
+		pipe_requested = 1;
+#endif
+	} else if (!strcasecmp(path, "stdout")) {
+		if (!strcmp(sapi_module.name, "cli")) {
+			static int cli_out = 0;
+			fd = STDOUT_FILENO;
+			if (cli_out) {
+				fd = dup(fd);
+			} else {
+				cli_out = 1;
+				file = stdout;
+			}
+		} else {
+			fd = dup(STDOUT_FILENO);
+		}
+#ifdef PHP_WIN32
+		pipe_requested = 1;
+#endif
+	} else if (!strcasecmp(path, "stderr")) {
+		if (!strcmp(sapi_module.name, "cli")) {
+			static int cli_err = 0;
+			fd = STDERR_FILENO;
+			if (cli_err) {
+				fd = dup(fd);
+			} else {
+				cli_err = 1;
+				file = stderr;
+			}
+		} else {
+			fd = dup(STDERR_FILENO);
+		}
+#ifdef PHP_WIN32
+		pipe_requested = 1;
+#endif
+	} else if (!strncasecmp(path, "fd/", 3)) {
+		const char *start;
+		char       *end;
+		zend_long  fildes_ori;
+		int		   dtablesize;
+
+		if (strcmp(sapi_module.name, "cli")) {
+			if (options & PTHREADS_REPORT_ERRORS) {
+				php_error_docref(NULL, E_WARNING, "Direct access to file descriptors is only available from command-line PHP");
+			}
+			return NULL;
+		}
+
+		if ((options & PTHREADS_STREAM_OPEN_FOR_INCLUDE) && !PG(allow_url_include)) {
+			if (options & PTHREADS_REPORT_ERRORS) {
+				php_error_docref(NULL, E_WARNING, "URL file-access is disabled in the server configuration");
+			}
+			return NULL;
+		}
+
+		start = &path[3];
+		fildes_ori = ZEND_STRTOL(start, &end, 10);
+		if (end == start || *end != '\0') {
+			pthreads_stream_wrapper_log_error(threaded_wrapper, options,
+				"php://fd/ stream must be specified in the form php://fd/<orig fd>");
+			return NULL;
+		}
+
+#if HAVE_UNISTD_H
+		dtablesize = getdtablesize();
+#else
+		dtablesize = INT_MAX;
+#endif
+
+		if (fildes_ori < 0 || fildes_ori >= dtablesize) {
+			pthreads_stream_wrapper_log_error(threaded_wrapper, options,
+				"The file descriptors must be non-negative numbers smaller than %d", dtablesize);
+			return NULL;
+		}
+
+		fd = dup((int)fildes_ori);
+		if (fd == -1) {
+			pthreads_stream_wrapper_log_error(threaded_wrapper, options,
+				"Error duping file descriptor " ZEND_LONG_FMT "; possibly it doesn't exist: "
+				"[%d]: %s", fildes_ori, errno, strerror(errno));
+			return NULL;
+		}
+	} else if (!strncasecmp(path, "filter/", 7)) {
+		/* Save time/memory when chain isn't specified */
+		if (strchr(mode, 'r') || strchr(mode, '+')) {
+			mode_rw |= PTHREADS_STREAM_FILTER_READ;
+		}
+		if (strchr(mode, 'w') || strchr(mode, '+') || strchr(mode, 'a')) {
+			mode_rw |= PTHREADS_STREAM_FILTER_WRITE;
+		}
+		pathdup = estrndup(path + 6, strlen(path + 6));
+		p = strstr(pathdup, "/resource=");
+		if (!p) {
+			zend_throw_error(NULL, "No URL resource specified");
+			efree(pathdup);
+			return NULL;
+		}
+
+		if (!(threaded_stream = pthreads_stream_open_wrapper(p + 10, mode, options, opened_path))) {
+			efree(pathdup);
+			return NULL;
+		}
+
+		*p = '\0';
+
+		p = php_strtok_r(pathdup + 1, "/", &token);
+		while (p) {
+			if (!strncasecmp(p, "read=", 5)) {
+				pthreads_stream_apply_filter_list(threaded_stream, p + 5, 1, 0);
+			} else if (!strncasecmp(p, "write=", 6)) {
+				pthreads_stream_apply_filter_list(threaded_stream, p + 6, 0, 1);
+			} else {
+				pthreads_stream_apply_filter_list(threaded_stream, p, mode_rw & PTHREADS_STREAM_FILTER_READ, mode_rw & PTHREADS_STREAM_FILTER_WRITE);
+			}
+			p = php_strtok_r(NULL, "/", &token);
+		}
+		efree(pathdup);
+
+		return threaded_stream;
+	} else {
+		/* invalid php://thingy */
+		php_error_docref(NULL, E_WARNING, "Invalid php:// URL specified");
+		return NULL;
+	}
+
+	/* must be stdin, stderr or stdout */
+	if (fd == -1)	{
+		/* failed to dup */
+		return NULL;
+	}
+
+#if defined(S_IFSOCK) && !defined(PHP_WIN32)
+	do {
+		zend_stat_t st;
+		memset(&st, 0, sizeof(st));
+		if (zend_fstat(fd, &st) == 0 && (st.st_mode & S_IFMT) == S_IFSOCK) {
+			threaded_stream = _pthreads_stream_sock_open_from_socket(fd, pthreads_socket_stream_entry);
+			if (threaded_stream) {
+				stream = PTHREADS_FETCH_STREAMS_STREAM(threaded_stream);
+				stream->ops = &pthreads_stream_socket_ops;
+				return threaded_stream;
+			}
+		}
+	} while (0);
+#endif
+
+	if (file) {
+		threaded_stream = pthreads_stream_fopen_from_file(file, mode);
+	} else {
+		threaded_stream = pthreads_stream_fopen_from_fd(fd, mode);
+		if (threaded_stream == NULL) {
+			close(fd);
+		}
+	}
+
+#ifdef PHP_WIN32
+	if (pipe_requested && threaded_stream && threaded_context) {
+		zval *blocking_pipes = pthreads_stream_context_get_option(threaded_context, "pipe", "blocking");
+		if (blocking_pipes) {
+			pthreads_stream_set_option(threaded_stream, PTHREADS_STREAM_OPTION_PIPE_BLOCKING, zval_get_long(blocking_pipes), NULL);
+		}
+	}
+#endif
+	return threaded_stream;
+}
+/* }}} */
+
+const pthreads_stream_wrapper_ops pthreads_stdio_wops = {
+	pthreads_stream_url_wrap_php,
+	NULL, /* close */ NULL, /* fstat */
+	NULL, /* stat */ NULL, /* opendir */
+	"PHP",
+	NULL, /* unlink */ NULL, /* rename */
+	NULL, /* mkdir */ NULL, /* rmdir */
+	NULL
+};
+
+#endif

--- a/src/streams/wrappers/fopen_wrapper.h
+++ b/src/streams/wrappers/fopen_wrapper.h
@@ -1,0 +1,37 @@
+/*
+  +----------------------------------------------------------------------+
+  | pthreads                                                             |
+  +----------------------------------------------------------------------+
+  | Copyright (c) Joe Watkins 2018                                       |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | http://www.php.net/license/3_01.txt                                  |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors: Bastian Schneider <b.schneider@badnoob.com>                 |
+  | Borrowed code from php-src                                           |
+  +----------------------------------------------------------------------+
+ */
+#ifndef HAVE_PTHREADS_STREAMS_WRAPPERS_FOPEN_WRAPPER_H
+#define HAVE_PTHREADS_STREAMS_WRAPPERS_FOPEN_WRAPPER_H
+
+#ifndef HAVE_PTHREADS_URL_H
+#	include <src/url.h>
+#endif
+
+pthreads_stream_t *pthreads_stream_url_wrap_http(pthreads_stream_wrapper_t *threaded_wrapper, const char *path, const char *mode, int options,
+		zend_string **opened_path, pthreads_stream_context_t *threaded_context, zend_class_entry *ce);
+pthreads_stream_t *pthreads_stream_url_wrap_ftp(pthreads_stream_wrapper_t *threaded_wrapper, const char *path, const char *mode, int options,
+		zend_string **opened_path, pthreads_stream_context_t *threaded_context, zend_class_entry *ce);
+pthreads_stream_t *pthreads_stream_url_wrap_php(pthreads_stream_wrapper_t *threaded_wrapper, const char *path, const char *mode, int options,
+		zend_string **opened_path, pthreads_stream_context_t *threaded_context, zend_class_entry *ce);
+
+extern const pthreads_stream_wrapper_ops pthreads_stdio_wops;
+extern const pthreads_stream_wrapper_ops pthreads_http_stream_wops;
+extern const pthreads_stream_wrapper_ops pthreads_ftp_stream_wops;
+
+#endif

--- a/src/streams/wrappers/ftp_fopen_wrapper.c
+++ b/src/streams/wrappers/ftp_fopen_wrapper.c
@@ -1,0 +1,1160 @@
+/*
+  +----------------------------------------------------------------------+
+  | pthreads                                                             |
+  +----------------------------------------------------------------------+
+  | Copyright (c) Joe Watkins 2018                                       |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | http://www.php.net/license/3_01.txt                                  |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors: Bastian Schneider <b.schneider@badnoob.com>                 |
+  | Borrowed code from php-src                                           |
+  +----------------------------------------------------------------------+
+ */
+#ifndef HAVE_PTHREADS_STREAMS_WRAPPERS_FTP_FOPEN_WRAPPER
+#define HAVE_PTHREADS_STREAMS_WRAPPERS_FTP_FOPEN_WRAPPER
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#ifndef HAVE_PTHREADS_H
+#	include <src/pthreads.h>
+#endif
+
+#ifndef HAVE_PTHREADS_STREAM_H
+#	include <src/streams.h>
+#endif
+
+#ifndef HAVE_PTHREADS_STREAMS_WRAPPERS_FOPEN_WRAPPER_H
+#	include <src/streams/wrappers/fopen_wrapper.h>
+#endif
+
+#ifndef HAVE_PTHREADS_NETWORK_H
+#	include <src/network.h>
+#endif
+
+#ifndef PHP_STRING_H
+#	include <ext/standard/php_string.h>
+#endif
+
+
+#define PTHREADS_FTPS_ENCRYPT_DATA 1
+#define PTHREADS_GET_FTP_RESULT(threaded_stream)	pthreads_get_ftp_result((threaded_stream), tmp_line, sizeof(tmp_line))
+
+typedef struct _pthreads_ftp_dirstream_data {
+	pthreads_stream_t *datastream;
+	pthreads_stream_t *controlstream;
+	pthreads_stream_t *dirstream;
+} pthreads_ftp_dirstream_data;
+
+/* {{{ pthreads_get_ftp_result */
+static inline int pthreads_get_ftp_result(pthreads_stream_t *threaded_stream, char *buffer, size_t buffer_size) {
+	buffer[0] = '\0'; /* in case read fails to read anything */
+	while (pthreads_stream_gets(threaded_stream, buffer, buffer_size-1) &&
+		   !(isdigit((int) buffer[0]) && isdigit((int) buffer[1]) &&
+			 isdigit((int) buffer[2]) && buffer[3] == ' '));
+	return strtol(buffer, NULL, 10);
+}
+/* }}} */
+
+/* {{{ pthreads_stream_ftp_stream_stat */
+static int pthreads_stream_ftp_stream_stat(pthreads_stream_wrapper_t *threaded_wrapper, pthreads_stream_t *threaded_stream, pthreads_stream_statbuf *ssb) {
+	/* For now, we return with a failure code to prevent the underlying
+	 * file's details from being used instead. */
+	return -1;
+}
+/* }}} */
+
+/* {{{ pthreads_stream_ftp_stream_close */
+static int pthreads_stream_ftp_stream_close(pthreads_stream_wrapper_t *threaded_wrapper, pthreads_stream_t *threaded_stream) {
+	pthreads_stream *stream = PTHREADS_FETCH_STREAMS_STREAM(threaded_stream);
+	pthreads_stream_t *controlstream = stream->wrapperthis;
+	int ret = 0;
+
+	if (controlstream && stream_lock(threaded_stream)) {
+		if (strpbrk(stream->mode, "wa+")) {
+			char tmp_line[512];
+			int result;
+
+			/* For write modes close data stream first to signal EOF to server */
+			result = PTHREADS_GET_FTP_RESULT(controlstream);
+			if (result != 226 && result != 250) {
+				php_error_docref(NULL, E_WARNING, "FTP server error %d:%s", result, tmp_line);
+				ret = EOF;
+			}
+		}
+
+		pthreads_stream_write_string(controlstream, "QUIT\r\n");
+		pthreads_stream_close(controlstream, PTHREADS_STREAM_FREE_CLOSE);
+		stream->wrapperthis = NULL;
+
+		stream_unlock(threaded_stream);
+	}
+
+	return ret;
+}
+/* }}} */
+
+/* {{{ pthreads_ftp_fopen_connect */
+static pthreads_stream_t *pthreads_ftp_fopen_connect(pthreads_stream_wrapper_t *threaded_wrapper, const char *path, const char *mode, int options,
+										 zend_string **opened_path, pthreads_stream_context_t *threaded_context, pthreads_stream_t **preuseid,
+										 pthreads_url **presource, int *puse_ssl, int *puse_ssl_on_data)
+{
+	pthreads_stream_t *threaded_stream = NULL, *reuseid = NULL;
+	pthreads_url *resource = NULL;
+	int result, use_ssl, use_ssl_on_data = 0;
+	char tmp_line[512];
+	char *transport;
+	int transport_len;
+
+	resource = pthreads_url_parse(path);
+	if (resource == NULL || resource->path == NULL) {
+		if (resource && presource) {
+			*presource = resource;
+		}
+		return NULL;
+	}
+
+	use_ssl = resource->scheme && (ZSTR_LEN(resource->scheme) > 3) && ZSTR_VAL(resource->scheme)[3] == 's';
+
+	/* use port 21 if one wasn't specified */
+	if (resource->port == 0)
+		resource->port = 21;
+
+	transport_len = (int)spprintf(&transport, 0, "tcp://%s:%d", ZSTR_VAL(resource->host), resource->port);
+	threaded_stream = pthreads_stream_xport_create(transport, transport_len, PTHREADS_REPORT_ERRORS,
+							PTHREADS_STREAM_XPORT_CLIENT | PTHREADS_STREAM_XPORT_CONNECT, NULL, threaded_context, NULL, NULL);
+	efree(transport);
+	if (threaded_stream == NULL) {
+		result = 0; /* silence */
+		goto connect_errexit;
+	}
+
+	pthreads_stream_context_set(threaded_stream, threaded_context);
+	pthreads_stream_notify_info(threaded_context, PTHREADS_STREAM_NOTIFY_CONNECT, NULL, 0);
+
+	/* Start talking to ftp server */
+	result = PTHREADS_GET_FTP_RESULT(threaded_stream);
+	if (result > 299 || result < 200) {
+		pthreads_stream_notify_error(threaded_context, PTHREADS_STREAM_NOTIFY_FAILURE, tmp_line, result);
+		goto connect_errexit;
+	}
+
+	if (use_ssl) {
+		/* send the AUTH TLS request name */
+		pthreads_stream_write_string(threaded_stream, "AUTH TLS\r\n");
+
+		/* get the response */
+		result = PTHREADS_GET_FTP_RESULT(threaded_stream);
+		if (result != 234) {
+			/* AUTH TLS not supported try AUTH SSL */
+			pthreads_stream_write_string(threaded_stream, "AUTH SSL\r\n");
+
+			/* get the response */
+			result = PTHREADS_GET_FTP_RESULT(threaded_stream);
+			if (result != 334) {
+				pthreads_stream_wrapper_log_error(threaded_wrapper, options, "Server doesn't support FTPS.");
+				goto connect_errexit;
+			} else {
+				/* we must reuse the old SSL session id */
+				/* if we talk to an old ftpd-ssl */
+				reuseid = threaded_stream;
+			}
+		} else {
+			/* encrypt data etc */
+		}
+	}
+
+	if (use_ssl) {
+		if (pthreads_stream_xport_crypto_setup(threaded_stream, PTHREADS_STREAM_CRYPTO_METHOD_SSLv23_CLIENT, NULL) < 0
+				|| pthreads_stream_xport_crypto_enable(threaded_stream, 1) < 0) {
+			pthreads_stream_wrapper_log_error(threaded_wrapper, options, "Unable to activate SSL mode");
+			pthreads_stream_close(threaded_stream, PTHREADS_STREAM_FREE_CLOSE);
+			threaded_stream = NULL;
+			goto connect_errexit;
+		}
+
+		/* set PBSZ to 0 */
+		pthreads_stream_write_string(threaded_stream, "PBSZ 0\r\n");
+
+		/* ignore the response */
+		result = PTHREADS_GET_FTP_RESULT(threaded_stream);
+
+		/* set data connection protection level */
+#if PTHREADS_FTPS_ENCRYPT_DATA
+		pthreads_stream_write_string(threaded_stream, "PROT P\r\n");
+
+		/* get the response */
+		result = PTHREADS_GET_FTP_RESULT(threaded_stream);
+		use_ssl_on_data = (result >= 200 && result<=299) || reuseid;
+#else
+		pthreads_stream_write_string(threaded_stream, "PROT C\r\n");
+
+		/* get the response */
+		result = PTHREADS_GET_FTP_RESULT(threaded_stream);
+#endif
+	}
+
+#define PHP_FTP_CNTRL_CHK(val, val_len, err_msg) {	\
+	unsigned char *s = (unsigned char *) val, *e = (unsigned char *) s + val_len;	\
+	while (s < e) {	\
+		if (iscntrl(*s)) {	\
+			pthreads_stream_wrapper_log_error(threaded_wrapper, options, err_msg, val);	\
+			goto connect_errexit;	\
+		}	\
+		s++;	\
+	}	\
+}
+
+	/* send the user name */
+	if (resource->user != NULL) {
+		ZSTR_LEN(resource->user) = php_raw_url_decode(ZSTR_VAL(resource->user), ZSTR_LEN(resource->user));
+
+		PHP_FTP_CNTRL_CHK(ZSTR_VAL(resource->user), ZSTR_LEN(resource->user), "Invalid login %s")
+
+		pthreads_stream_printf(threaded_stream, "USER %s\r\n", ZSTR_VAL(resource->user));
+	} else {
+		pthreads_stream_write_string(threaded_stream, "USER anonymous\r\n");
+	}
+
+	/* get the response */
+	result = PTHREADS_GET_FTP_RESULT(threaded_stream);
+
+	/* if a password is required, send it */
+	if (result >= 300 && result <= 399) {
+		pthreads_stream_notify_info(threaded_context, PTHREADS_STREAM_NOTIFY_AUTH_REQUIRED, tmp_line, 0);
+
+		if (resource->pass != NULL) {
+			ZSTR_LEN(resource->pass) = php_raw_url_decode(ZSTR_VAL(resource->pass), ZSTR_LEN(resource->pass));
+
+			PHP_FTP_CNTRL_CHK(ZSTR_VAL(resource->pass), ZSTR_LEN(resource->pass), "Invalid password %s")
+
+			pthreads_stream_printf(threaded_stream, "PASS %s\r\n", ZSTR_VAL(resource->pass));
+		} else {
+			/* if the user has configured who they are,
+			   send that as the password */
+			if (FG(from_address)) {
+				pthreads_stream_printf(threaded_stream, "PASS %s\r\n", FG(from_address));
+			} else {
+				pthreads_stream_write_string(threaded_stream, "PASS anonymous\r\n");
+			}
+		}
+
+		/* read the response */
+		result = PTHREADS_GET_FTP_RESULT(threaded_stream);
+
+		if (result > 299 || result < 200) {
+			pthreads_stream_notify_error(threaded_context, PTHREADS_STREAM_NOTIFY_AUTH_RESULT, tmp_line, result);
+		} else {
+			pthreads_stream_notify_info(threaded_context, PTHREADS_STREAM_NOTIFY_AUTH_RESULT, tmp_line, result);
+		}
+	}
+	if (result > 299 || result < 200) {
+		goto connect_errexit;
+	}
+
+	if (puse_ssl) {
+		*puse_ssl = use_ssl;
+	}
+	if (puse_ssl_on_data) {
+		*puse_ssl_on_data = use_ssl_on_data;
+	}
+	if (preuseid) {
+		*preuseid = reuseid;
+	}
+	if (presource) {
+		*presource = resource;
+	}
+
+	return threaded_stream;
+
+connect_errexit:
+	if (resource) {
+		pthreads_url_free(resource);
+	}
+
+	if (threaded_stream) {
+		pthreads_stream_close(threaded_stream, PTHREADS_STREAM_FREE_CLOSE);
+	}
+
+	return NULL;
+}
+/* }}} */
+
+/* {{{ pthreads_fopen_do_pasv */
+static unsigned short pthreads_fopen_do_pasv(pthreads_stream_t *threaded_stream, char *ip, size_t ip_size, char **phoststart) {
+	char tmp_line[512];
+	int result, i;
+	unsigned short portno;
+	char *tpath, *ttpath, *hoststart=NULL;
+
+#ifdef HAVE_IPV6
+	/* We try EPSV first, needed for IPv6 and works on some IPv4 servers */
+	pthreads_stream_write_string(threaded_stream, "EPSV\r\n");
+	result = PTHREADS_GET_FTP_RESULT(threaded_stream);
+
+	/* check if we got a 229 response */
+	if (result != 229) {
+#endif
+		/* EPSV failed, let's try PASV */
+		pthreads_stream_write_string(threaded_stream, "PASV\r\n");
+		result = PTHREADS_GET_FTP_RESULT(threaded_stream);
+
+		/* make sure we got a 227 response */
+		if (result != 227) {
+			return 0;
+		}
+
+		/* parse pasv command (129, 80, 95, 25, 13, 221) */
+		tpath = tmp_line;
+		/* skip over the "227 Some message " part */
+		for (tpath += 4; *tpath && !isdigit((int) *tpath); tpath++);
+		if (!*tpath) {
+			return 0;
+		}
+		/* skip over the host ip, to get the port */
+		hoststart = tpath;
+		for (i = 0; i < 4; i++) {
+			for (; isdigit((int) *tpath); tpath++);
+			if (*tpath != ',') {
+				return 0;
+			}
+			*tpath='.';
+			tpath++;
+		}
+		tpath[-1] = '\0';
+		memcpy(ip, hoststart, ip_size);
+		ip[ip_size-1] = '\0';
+		hoststart = ip;
+
+		/* pull out the MSB of the port */
+		portno = (unsigned short) strtoul(tpath, &ttpath, 10) * 256;
+		if (ttpath == NULL) {
+			/* didn't get correct response from PASV */
+			return 0;
+		}
+		tpath = ttpath;
+		if (*tpath != ',') {
+			return 0;
+		}
+		tpath++;
+		/* pull out the LSB of the port */
+		portno += (unsigned short) strtoul(tpath, &ttpath, 10);
+#ifdef HAVE_IPV6
+	} else {
+		/* parse epsv command (|||6446|) */
+		for (i = 0, tpath = tmp_line + 4; *tpath; tpath++) {
+			if (*tpath == '|') {
+				i++;
+				if (i == 3)
+					break;
+			}
+		}
+		if (i < 3) {
+			return 0;
+		}
+		/* pull out the port */
+		portno = (unsigned short) strtoul(tpath + 1, &ttpath, 10);
+	}
+#endif
+	if (ttpath == NULL) {
+		/* didn't get correct response from EPSV/PASV */
+		return 0;
+	}
+
+	if (phoststart) {
+		*phoststart = hoststart;
+	}
+
+	return portno;
+}
+/* }}} */
+
+/* {{{ pthreads_fopen_url_wrap_ftp */
+pthreads_stream_t * pthreads_stream_url_wrap_ftp(pthreads_stream_wrapper_t *threaded_wrapper, const char *path, const char *mode,
+									 int options, zend_string **opened_path, pthreads_stream_context_t *threaded_context, zend_class_entry *ce) {
+	pthreads_stream_t *threaded_stream = NULL, *datastream = NULL;
+	pthreads_url *resource = NULL;
+	char tmp_line[512];
+	char ip[sizeof("123.123.123.123")];
+	unsigned short portno;
+	char *hoststart = NULL;
+	int result = 0, use_ssl, use_ssl_on_data=0;
+	pthreads_stream_t *reuseid=NULL;
+	size_t file_size = 0;
+	zval *tmpzval;
+	zend_bool allow_overwrite = 0;
+	int8_t read_write = 0;
+	char *transport;
+	int transport_len;
+	zend_string *error_message = NULL;
+
+	tmp_line[0] = '\0';
+
+	if (strpbrk(mode, "r+")) {
+		read_write = 1; /* Open for reading */
+	}
+	if (strpbrk(mode, "wa+")) {
+		if (read_write) {
+			pthreads_stream_wrapper_log_error(threaded_wrapper, options, "FTP does not support simultaneous read/write connections");
+			return NULL;
+		}
+		if (strchr(mode, 'a')) {
+			read_write = 3; /* Open for Appending */
+		} else {
+			read_write = 2; /* Open for writing */
+		}
+	}
+	if (!read_write) {
+		/* No mode specified? */
+		pthreads_stream_wrapper_log_error(threaded_wrapper, options, "Unknown file open mode");
+		return NULL;
+	}
+
+	if (threaded_context &&
+		(tmpzval = pthreads_stream_context_get_option(threaded_context, "ftp", "proxy")) != NULL) {
+		if (read_write == 1) {
+			/* Use http wrapper to proxy ftp request */
+			return pthreads_stream_url_wrap_http(threaded_wrapper, path, mode, options, opened_path, threaded_context, ce);
+		} else {
+			/* ftp proxy is read-only */
+			pthreads_stream_wrapper_log_error(threaded_wrapper, options, "FTP proxy may only be used in read mode");
+			return NULL;
+		}
+	}
+
+	threaded_stream = pthreads_ftp_fopen_connect(threaded_wrapper, path, mode, options, opened_path, threaded_context, &reuseid, &resource, &use_ssl, &use_ssl_on_data);
+	if (!threaded_stream) {
+		goto errexit;
+	}
+
+	/* set the connection to be binary */
+	pthreads_stream_write_string(threaded_stream, "TYPE I\r\n");
+	result = PTHREADS_GET_FTP_RESULT(threaded_stream);
+	if (result > 299 || result < 200)
+		goto errexit;
+
+	/* find out the size of the file (verifying it exists) */
+	pthreads_stream_printf(threaded_stream, "SIZE %s\r\n", ZSTR_VAL(resource->path));
+
+	/* read the response */
+	result = PTHREADS_GET_FTP_RESULT(threaded_stream);
+	if (read_write == 1) {
+		/* Read Mode */
+		char *sizestr;
+
+		/* when reading file, it must exist */
+		if (result > 299 || result < 200) {
+			errno = ENOENT;
+			goto errexit;
+		}
+
+		sizestr = strchr(tmp_line, ' ');
+		if (sizestr) {
+			sizestr++;
+			file_size = atoi(sizestr);
+			pthreads_stream_notify_file_size(threaded_context, file_size, tmp_line, result);
+		}
+	} else if (read_write == 2) {
+		/* when writing file (but not appending), it must NOT exist, unless a context option exists which allows it */
+		if (threaded_context && (tmpzval = pthreads_stream_context_get_option(threaded_context, "ftp", "overwrite")) != NULL) {
+			allow_overwrite = Z_LVAL_P(tmpzval) ? 1 : 0;
+		}
+		if (result <= 299 && result >= 200) {
+			if (allow_overwrite) {
+				/* Context permits overwriting file,
+				   so we just delete whatever's there in preparation */
+				pthreads_stream_printf(threaded_stream, "DELE %s\r\n", ZSTR_VAL(resource->path));
+				result = PTHREADS_GET_FTP_RESULT(threaded_stream);
+				if (result >= 300 || result <= 199) {
+					goto errexit;
+				}
+			} else {
+				pthreads_stream_wrapper_log_error(threaded_wrapper, options, "Remote file already exists and overwrite context option not specified");
+				errno = EEXIST;
+				goto errexit;
+			}
+		}
+	}
+
+	/* set up the passive connection */
+	portno = pthreads_fopen_do_pasv(threaded_stream, ip, sizeof(ip), &hoststart);
+
+	if (!portno) {
+		goto errexit;
+	}
+
+	/* Send RETR/STOR command */
+	if (read_write == 1) {
+		/* set resume position if applicable */
+		if (threaded_context &&
+			(tmpzval = pthreads_stream_context_get_option(threaded_context, "ftp", "resume_pos")) != NULL &&
+			Z_TYPE_P(tmpzval) == IS_LONG &&
+			Z_LVAL_P(tmpzval) > 0) {
+			pthreads_stream_printf(threaded_stream, "REST " ZEND_LONG_FMT "\r\n", Z_LVAL_P(tmpzval));
+			result = PTHREADS_GET_FTP_RESULT(threaded_stream);
+			if (result < 300 || result > 399) {
+				pthreads_stream_wrapper_log_error(threaded_wrapper, options, "Unable to resume from offset " ZEND_LONG_FMT, Z_LVAL_P(tmpzval));
+				goto errexit;
+			}
+		}
+
+		/* retrieve file */
+		memcpy(tmp_line, "RETR", sizeof("RETR"));
+	} else if (read_write == 2) {
+		/* Write new file */
+		memcpy(tmp_line, "STOR", sizeof("STOR"));
+	} else {
+		/* Append */
+		memcpy(tmp_line, "APPE", sizeof("APPE"));
+	}
+	pthreads_stream_printf(threaded_stream, "%s %s\r\n", tmp_line, (resource->path != NULL ? ZSTR_VAL(resource->path) : "/"));
+
+	/* open the data channel */
+	if (hoststart == NULL) {
+		hoststart = ZSTR_VAL(resource->host);
+	}
+	transport_len = (int)spprintf(&transport, 0, "tcp://%s:%d", hoststart, portno);
+	datastream = pthreads_stream_xport_create(transport, transport_len, PTHREADS_REPORT_ERRORS,
+			PTHREADS_STREAM_XPORT_CLIENT | PTHREADS_STREAM_XPORT_CONNECT, NULL, threaded_context, &error_message, NULL);
+	efree(transport);
+	if (datastream == NULL) {
+		tmp_line[0]='\0';
+		goto errexit;
+	}
+
+	result = PTHREADS_GET_FTP_RESULT(threaded_stream);
+	if (result != 150 && result != 125) {
+		/* Could not retrieve or send the file
+		 * this data will only be sent to us after connection on the data port was initiated.
+		 */
+		pthreads_stream_close(datastream, PTHREADS_STREAM_FREE_CLOSE);
+		datastream = NULL;
+		goto errexit;
+	}
+
+	pthreads_stream_context_set(datastream, threaded_context);
+	pthreads_stream_notify_progress_init(threaded_context, 0, file_size);
+
+	if (use_ssl_on_data && (pthreads_stream_xport_crypto_setup(datastream,
+			PTHREADS_STREAM_CRYPTO_METHOD_SSLv23_CLIENT, NULL) < 0 ||
+			pthreads_stream_xport_crypto_enable(datastream, 1) < 0)) {
+
+		pthreads_stream_wrapper_log_error(threaded_wrapper, options, "Unable to activate SSL mode");
+		pthreads_stream_close(datastream, PTHREADS_STREAM_FREE_CLOSE);
+		datastream = NULL;
+		tmp_line[0]='\0';
+		goto errexit;
+	}
+
+	/* remember control stream */
+	PTHREADS_FETCH_STREAMS_STREAM(datastream)->wrapperthis = threaded_stream;
+
+	pthreads_url_free(resource);
+	return datastream;
+
+errexit:
+	if (resource) {
+		pthreads_url_free(resource);
+	}
+	if (threaded_stream) {
+		pthreads_stream_notify_error(threaded_context, PTHREADS_STREAM_NOTIFY_FAILURE, tmp_line, result);
+		pthreads_stream_close(threaded_stream, PTHREADS_STREAM_FREE_CLOSE);
+	}
+	if (tmp_line[0] != '\0')
+		pthreads_stream_wrapper_log_error(threaded_wrapper, options, "FTP server reports %s", tmp_line);
+
+	if (error_message) {
+		pthreads_stream_wrapper_log_error(threaded_wrapper, options, "Failed to set up data channel: %s", ZSTR_VAL(error_message));
+		zend_string_release(error_message);
+	}
+	return NULL;
+}
+/* }}} */
+
+/* {{{ pthreads_ftp_dirsteam_read */
+static size_t pthreads_ftp_dirstream_read(pthreads_stream_t *threaded_stream, char *buf, size_t count) {
+	pthreads_stream_dirent *ent = (pthreads_stream_dirent *)buf;
+	pthreads_stream_t *innerstream;
+	size_t tmp_len;
+	zend_string *basename;
+
+	if(stream_lock(threaded_stream)) {
+		innerstream = ((pthreads_ftp_dirstream_data *)PTHREADS_FETCH_STREAMS_STREAM(threaded_stream)->abstract)->datastream;
+
+		if (count != sizeof(pthreads_stream_dirent)) {
+			stream_unlock(threaded_stream);
+			return 0;
+		}
+
+		if (pthreads_stream_eof(innerstream)) {
+			stream_unlock(threaded_stream);
+			return 0;
+		}
+
+		if (!pthreads_stream_get_line(innerstream, ent->d_name, sizeof(ent->d_name), &tmp_len)) {
+			stream_unlock(threaded_stream);
+			return 0;
+		}
+
+		basename = php_basename(ent->d_name, tmp_len, NULL, 0);
+
+		tmp_len = MIN(sizeof(ent->d_name), ZSTR_LEN(basename) - 1);
+		memcpy(ent->d_name, ZSTR_VAL(basename), tmp_len);
+		ent->d_name[tmp_len - 1] = '\0';
+		zend_string_release(basename);
+
+		/* Trim off trailing whitespace characters */
+		while (tmp_len > 0 &&
+				(ent->d_name[tmp_len - 1] == '\n' || ent->d_name[tmp_len - 1] == '\r' ||
+				 ent->d_name[tmp_len - 1] == '\t' || ent->d_name[tmp_len - 1] == ' ')) {
+			ent->d_name[--tmp_len] = '\0';
+		}
+		stream_unlock(threaded_stream);
+	}
+	return sizeof(pthreads_stream_dirent);
+}
+/* }}} */
+
+/* {{{ pthreads_ftp_dirstream_close */
+static int pthreads_ftp_dirstream_close(pthreads_stream_t *threaded_stream, int close_handle) {
+	pthreads_stream *stream = PTHREADS_FETCH_STREAMS_STREAM(threaded_stream);
+	pthreads_ftp_dirstream_data *data = stream->abstract;
+
+	/* close control connection */
+	if (data->controlstream) {
+		pthreads_stream_close(data->controlstream, PTHREADS_STREAM_FREE_CLOSE);
+		data->controlstream = NULL;
+	}
+	/* close data connection */
+	pthreads_stream_close(data->datastream, PTHREADS_STREAM_FREE_CLOSE);
+	data->datastream = NULL;
+
+	return 0;
+}
+/* }}} */
+
+/* {{{ pthreads_ftp_dirstream_close */
+static void pthreads_ftp_dirstream_free(pthreads_stream_t *threaded_stream, int close_handle) {
+	pthreads_stream *stream = PTHREADS_FETCH_STREAMS_STREAM(threaded_stream);
+	pthreads_ftp_dirstream_data *data = stream->abstract;
+
+	efree(data);
+	stream->abstract = NULL;
+}
+/* }}} */
+/* ftp dirstreams only need to support read and close operations,
+   They can't be rewound because the underlying ftp stream can't be rewound. */
+static const pthreads_stream_ops pthreads_ftp_dirstream_ops = {
+	NULL, /* write */
+	pthreads_ftp_dirstream_read, /* read */
+	pthreads_ftp_dirstream_close, /* close */
+	pthreads_ftp_dirstream_free, /* free */
+	NULL, /* flush */
+	"ftpdir",
+	NULL, /* rewind */
+	NULL, /* cast */
+	NULL, /* stat */
+	NULL  /* set option */
+};
+
+/* {{{ pthreads_stream_ftp_opendir */
+pthreads_stream_t * pthreads_stream_ftp_opendir(pthreads_stream_wrapper_t *threaded_wrapper, const char *path, const char *mode, int options,
+									zend_string **opened_path, pthreads_stream_context_t *threaded_context, zend_class_entry *ce) {
+	pthreads_stream_t *threaded_stream, *reuseid, *datastream = NULL;
+	pthreads_ftp_dirstream_data *dirsdata;
+	pthreads_url *resource = NULL;
+	int result = 0, use_ssl, use_ssl_on_data = 0;
+	char *hoststart = NULL, tmp_line[512];
+	char ip[sizeof("123.123.123.123")];
+	unsigned short portno;
+
+	tmp_line[0] = '\0';
+
+	threaded_stream = pthreads_ftp_fopen_connect(threaded_wrapper, path, mode, options, opened_path, threaded_context, &reuseid, &resource, &use_ssl, &use_ssl_on_data);
+	if (!threaded_stream) {
+		goto opendir_errexit;
+	}
+
+	/* set the connection to be ascii */
+	pthreads_stream_write_string(threaded_stream, "TYPE A\r\n");
+	result = PTHREADS_GET_FTP_RESULT(threaded_stream);
+	if (result > 299 || result < 200)
+		goto opendir_errexit;
+
+	// tmp_line isn't relevant after the php_fopen_do_pasv().
+	tmp_line[0] = '\0';
+
+	/* set up the passive connection */
+	portno = pthreads_fopen_do_pasv(threaded_stream, ip, sizeof(ip), &hoststart);
+
+	if (!portno) {
+		goto opendir_errexit;
+	}
+
+	/* open the data channel */
+	if (hoststart == NULL) {
+		hoststart = ZSTR_VAL(resource->host);
+	}
+
+	datastream = pthreads_stream_sock_open_host(hoststart, portno, SOCK_STREAM, 0);
+	if (datastream == NULL) {
+		goto opendir_errexit;
+	}
+
+	pthreads_stream_printf(threaded_stream, "NLST %s\r\n", (resource->path != NULL ? ZSTR_VAL(resource->path) : "/"));
+
+	result = PTHREADS_GET_FTP_RESULT(threaded_stream);
+	if (result != 150 && result != 125) {
+		/* Could not retrieve or send the file
+		 * this data will only be sent to us after connection on the data port was initiated.
+		 */
+		pthreads_stream_close(datastream, PTHREADS_STREAM_FREE_CLOSE);
+		datastream = NULL;
+		goto opendir_errexit;
+	}
+
+	pthreads_stream_context_set(datastream, threaded_context);
+	if (use_ssl_on_data && (pthreads_stream_xport_crypto_setup(datastream,
+			PTHREADS_STREAM_CRYPTO_METHOD_SSLv23_CLIENT, NULL) < 0 ||
+			pthreads_stream_xport_crypto_enable(datastream, 1) < 0)) {
+
+		pthreads_stream_wrapper_log_error(threaded_wrapper, options, "Unable to activate SSL mode");
+		pthreads_stream_close(datastream, PTHREADS_STREAM_FREE_CLOSE);
+		datastream = NULL;
+		goto opendir_errexit;
+	}
+
+	pthreads_url_free(resource);
+
+	dirsdata = emalloc(sizeof *dirsdata);
+	dirsdata->datastream = datastream;
+	dirsdata->controlstream = threaded_stream;
+	dirsdata->dirstream = PTHREADS_STREAM_CLASS_NEW(&pthreads_ftp_dirstream_ops, dirsdata, mode, ce);
+
+	return dirsdata->dirstream;
+
+opendir_errexit:
+	if (resource) {
+		pthreads_url_free(resource);
+	}
+	if (threaded_stream) {
+		pthreads_stream_notify_error(threaded_context, PTHREADS_STREAM_NOTIFY_FAILURE, tmp_line, result);
+		pthreads_stream_close(threaded_stream, PTHREADS_STREAM_FREE_CLOSE);
+	}
+	if (tmp_line[0] != '\0') {
+		pthreads_stream_wrapper_log_error(threaded_wrapper, options, "FTP server reports %s", tmp_line);
+	}
+	return NULL;
+}
+/* }}} */
+
+/* {{{ pthreads_stream_ftp_url_stat */
+static int pthreads_stream_ftp_url_stat(pthreads_stream_wrapper_t *threaded_wrapper, const char *url, int flags, pthreads_stream_statbuf *ssb, pthreads_stream_context_t *threaded_context) {
+	pthreads_stream_t *threaded_stream = NULL;
+	pthreads_url *resource = NULL;
+	int result;
+	char tmp_line[512];
+
+	/* If ssb is NULL then someone is misbehaving */
+	if (!ssb) return -1;
+
+	threaded_stream = pthreads_ftp_fopen_connect(threaded_wrapper, url, "r", 0, NULL, threaded_context, NULL, &resource, NULL, NULL);
+	if (!threaded_stream) {
+		goto stat_errexit;
+	}
+
+	ssb->sb.st_mode = 0644;									/* FTP won't give us a valid mode, so approximate one based on being readable */
+	pthreads_stream_printf(threaded_stream, "CWD %s\r\n", (resource->path != NULL ? ZSTR_VAL(resource->path) : "/")); /* If we can CWD to it, it's a directory (maybe a link, but we can't tell) */
+	result = PTHREADS_GET_FTP_RESULT(threaded_stream);
+	if (result < 200 || result > 299) {
+		ssb->sb.st_mode |= S_IFREG;
+	} else {
+		ssb->sb.st_mode |= S_IFDIR;
+	}
+
+	pthreads_stream_write_string(threaded_stream, "TYPE I\r\n"); /* we need this since some servers refuse to accept SIZE command in ASCII mode */
+
+	result = PTHREADS_GET_FTP_RESULT(threaded_stream);
+
+	if(result < 200 || result > 299) {
+		goto stat_errexit;
+	}
+
+	pthreads_stream_printf(threaded_stream, "SIZE %s\r\n", (resource->path != NULL ? ZSTR_VAL(resource->path) : "/"));
+	result = PTHREADS_GET_FTP_RESULT(threaded_stream);
+	if (result < 200 || result > 299) {
+		/* Failure either means it doesn't exist
+		   or it's a directory and this server
+		   fails on listing directory sizes */
+		if (ssb->sb.st_mode & S_IFDIR) {
+			ssb->sb.st_size = 0;
+		} else {
+			goto stat_errexit;
+		}
+	} else {
+		ssb->sb.st_size = atoi(tmp_line + 4);
+	}
+
+	pthreads_stream_printf(threaded_stream, "MDTM %s\r\n", (resource->path != NULL ? ZSTR_VAL(resource->path) : "/"));
+	result = PTHREADS_GET_FTP_RESULT(threaded_stream);
+	if (result == 213) {
+		char *p = tmp_line + 4;
+		int n;
+		struct tm tm, tmbuf, *gmt;
+		time_t stamp;
+
+		while ((size_t)(p - tmp_line) < sizeof(tmp_line) && !isdigit(*p)) {
+			p++;
+		}
+
+		if ((size_t)(p - tmp_line) > sizeof(tmp_line)) {
+			goto mdtm_error;
+		}
+
+		n = sscanf(p, "%4u%2u%2u%2u%2u%2u", &tm.tm_year, &tm.tm_mon, &tm.tm_mday, &tm.tm_hour, &tm.tm_min, &tm.tm_sec);
+		if (n != 6) {
+			goto mdtm_error;
+		}
+
+		tm.tm_year -= 1900;
+		tm.tm_mon--;
+		tm.tm_isdst = -1;
+
+		/* figure out the GMT offset */
+		stamp = time(NULL);
+		gmt = php_gmtime_r(&stamp, &tmbuf);
+		if (!gmt) {
+			goto mdtm_error;
+		}
+		gmt->tm_isdst = -1;
+
+		/* apply the GMT offset */
+		tm.tm_sec += (long)(stamp - mktime(gmt));
+		tm.tm_isdst = gmt->tm_isdst;
+
+		ssb->sb.st_mtime = mktime(&tm);
+	} else {
+		/* error or unsupported command */
+mdtm_error:
+		ssb->sb.st_mtime = -1;
+	}
+
+	ssb->sb.st_ino = 0;						/* Unknown values */
+	ssb->sb.st_dev = 0;
+	ssb->sb.st_uid = 0;
+	ssb->sb.st_gid = 0;
+	ssb->sb.st_atime = -1;
+	ssb->sb.st_ctime = -1;
+
+	ssb->sb.st_nlink = 1;
+	ssb->sb.st_rdev = -1;
+#ifdef HAVE_STRUCT_STAT_ST_BLKSIZE
+	ssb->sb.st_blksize = 4096;				/* Guess since FTP won't expose this information */
+#ifdef HAVE_ST_BLOCKS
+	ssb->sb.st_blocks = (int)((4095 + ssb->sb.st_size) / ssb->sb.st_blksize); /* emulate ceil */
+#endif
+#endif
+	pthreads_stream_close(threaded_stream, PTHREADS_STREAM_FREE_CLOSE);
+	pthreads_url_free(resource);
+	return 0;
+
+stat_errexit:
+	if (resource) {
+		pthreads_url_free(resource);
+	}
+	if (threaded_stream) {
+		pthreads_stream_close(threaded_stream, PTHREADS_STREAM_FREE_CLOSE);
+	}
+	return -1;
+}
+/* }}} */
+
+/* {{{ pthreads_stream_ftp_unlink */
+static int pthreads_stream_ftp_unlink(pthreads_stream_wrapper_t *threaded_wrapper, const char *url, int options, pthreads_stream_context_t *threaded_context) {
+	pthreads_stream_t *threaded_stream = NULL;
+	pthreads_url *resource = NULL;
+	int result;
+	char tmp_line[512];
+
+	threaded_stream = pthreads_ftp_fopen_connect(threaded_wrapper, url, "r", 0, NULL, threaded_context, NULL, &resource, NULL, NULL);
+	if (!threaded_stream) {
+		if (options & PTHREADS_REPORT_ERRORS) {
+			php_error_docref(NULL, E_WARNING, "Unable to connect to %s", url);
+		}
+		goto unlink_errexit;
+	}
+
+	if (resource->path == NULL) {
+		if (options & PTHREADS_REPORT_ERRORS) {
+			php_error_docref(NULL, E_WARNING, "Invalid path provided in %s", url);
+		}
+		goto unlink_errexit;
+	}
+
+	/* Attempt to delete the file */
+	pthreads_stream_printf(threaded_stream, "DELE %s\r\n", (resource->path != NULL ? ZSTR_VAL(resource->path) : "/"));
+
+	result = PTHREADS_GET_FTP_RESULT(threaded_stream);
+	if (result < 200 || result > 299) {
+		if (options & PTHREADS_REPORT_ERRORS) {
+			php_error_docref(NULL, E_WARNING, "Error Deleting file: %s", tmp_line);
+		}
+		goto unlink_errexit;
+	}
+
+	pthreads_url_free(resource);
+	pthreads_stream_close(threaded_stream, PTHREADS_STREAM_FREE_CLOSE);
+	return 1;
+
+unlink_errexit:
+	if (resource) {
+		pthreads_url_free(resource);
+	}
+	if (threaded_stream) {
+		pthreads_stream_close(threaded_stream, PTHREADS_STREAM_FREE_CLOSE);
+	}
+	return 0;
+}
+/* }}} */
+
+/* {{{ pthreads_stream_ftp_rename */
+static int pthreads_stream_ftp_rename(pthreads_stream_wrapper_t *threaded_wrapper, const char *url_from, const char *url_to, int options, pthreads_stream_context_t *threaded_context)
+{
+	pthreads_stream_t *threaded_stream = NULL;
+	pthreads_url *resource_from = NULL, *resource_to = NULL;
+	int result;
+	char tmp_line[512];
+
+	resource_from = pthreads_url_parse(url_from);
+	resource_to = pthreads_url_parse(url_to);
+	/* Must be same scheme (ftp/ftp or ftps/ftps), same host, and same port
+		(or a 21/0 0/21 combination which is also "same")
+	   Also require paths to/from */
+	if (!resource_from ||
+		!resource_to ||
+		!resource_from->scheme ||
+		!resource_to->scheme ||
+		!zend_string_equals(resource_from->scheme, resource_to->scheme) ||
+		!resource_from->host ||
+		!resource_to->host ||
+		!zend_string_equals(resource_from->host, resource_to->host) ||
+		(resource_from->port != resource_to->port &&
+		 resource_from->port * resource_to->port != 0 &&
+		 resource_from->port + resource_to->port != 21) ||
+		!resource_from->path ||
+		!resource_to->path) {
+		goto rename_errexit;
+	}
+
+	threaded_stream = pthreads_ftp_fopen_connect(threaded_wrapper, url_from, "r", 0, NULL, threaded_context, NULL, NULL, NULL, NULL);
+	if (!threaded_stream) {
+		if (options & PTHREADS_REPORT_ERRORS) {
+			php_error_docref(NULL, E_WARNING, "Unable to connect to %s", ZSTR_VAL(resource_from->host));
+		}
+		goto rename_errexit;
+	}
+
+	/* Rename FROM */
+	pthreads_stream_printf(threaded_stream, "RNFR %s\r\n", (resource_from->path != NULL ? ZSTR_VAL(resource_from->path) : "/"));
+
+	result = PTHREADS_GET_FTP_RESULT(threaded_stream);
+	if (result < 300 || result > 399) {
+		if (options & PTHREADS_REPORT_ERRORS) {
+			php_error_docref(NULL, E_WARNING, "Error Renaming file: %s", tmp_line);
+		}
+		goto rename_errexit;
+	}
+
+	/* Rename TO */
+	pthreads_stream_printf(threaded_stream, "RNTO %s\r\n", (resource_to->path != NULL ? ZSTR_VAL(resource_to->path) : "/"));
+
+	result = PTHREADS_GET_FTP_RESULT(threaded_stream);
+	if (result < 200 || result > 299) {
+		if (options & PTHREADS_REPORT_ERRORS) {
+			php_error_docref(NULL, E_WARNING, "Error Renaming file: %s", tmp_line);
+		}
+		goto rename_errexit;
+	}
+
+	pthreads_url_free(resource_from);
+	pthreads_url_free(resource_to);
+	pthreads_stream_close(threaded_stream, PTHREADS_STREAM_FREE_CLOSE);
+	return 1;
+
+rename_errexit:
+	if (resource_from) {
+		pthreads_url_free(resource_from);
+	}
+	if (resource_to) {
+		pthreads_url_free(resource_to);
+	}
+	if (threaded_stream) {
+		pthreads_stream_close(threaded_stream, PTHREADS_STREAM_FREE_CLOSE);
+	}
+	return 0;
+}
+/* }}} */
+
+/* {{{ pthreads_stream_ftp_mkdir */
+static int pthreads_stream_ftp_mkdir(pthreads_stream_wrapper_t *threaded_wrapper, const char *url, int mode, int options, pthreads_stream_context_t *threaded_context) {
+	pthreads_stream_t *threaded_stream = NULL;
+	pthreads_url *resource = NULL;
+	int result, recursive = options & PTHREADS_STREAM_MKDIR_RECURSIVE;
+	char tmp_line[512];
+
+	threaded_stream = pthreads_ftp_fopen_connect(threaded_wrapper, url, "r", 0, NULL, threaded_context, NULL, &resource, NULL, NULL);
+	if (!threaded_stream) {
+		if (options & PTHREADS_REPORT_ERRORS) {
+			php_error_docref(NULL, E_WARNING, "Unable to connect to %s", url);
+		}
+		goto mkdir_errexit;
+	}
+
+	if (resource->path == NULL) {
+		if (options & PTHREADS_REPORT_ERRORS) {
+			php_error_docref(NULL, E_WARNING, "Invalid path provided in %s", url);
+		}
+		goto mkdir_errexit;
+	}
+
+	if (!recursive) {
+		pthreads_stream_printf(threaded_stream, "MKD %s\r\n", ZSTR_VAL(resource->path));
+		result = PTHREADS_GET_FTP_RESULT(threaded_stream);
+    } else {
+        /* we look for directory separator from the end of string, thus hopefuly reducing our work load */
+        char *p, *e, *buf;
+
+        buf = estrndup(ZSTR_VAL(resource->path), ZSTR_LEN(resource->path));
+        e = buf + ZSTR_LEN(resource->path);
+
+        /* find a top level directory we need to create */
+        while ((p = strrchr(buf, '/'))) {
+            *p = '\0';
+			pthreads_stream_printf(threaded_stream, "CWD %s\r\n", buf);
+			result = PTHREADS_GET_FTP_RESULT(threaded_stream);
+			if (result >= 200 && result <= 299) {
+				*p = '/';
+				break;
+			}
+        }
+        if (p == buf) {
+			pthreads_stream_printf(threaded_stream, "MKD %s\r\n", ZSTR_VAL(resource->path));
+			result = PTHREADS_GET_FTP_RESULT(threaded_stream);
+        } else {
+			pthreads_stream_printf(threaded_stream, "MKD %s\r\n", buf);
+			result = PTHREADS_GET_FTP_RESULT(threaded_stream);
+			if (result >= 200 && result <= 299) {
+				if (!p) {
+					p = buf;
+				}
+				/* create any needed directories if the creation of the 1st directory worked */
+				while (++p != e) {
+					if (*p == '\0' && *(p + 1) != '\0') {
+						*p = '/';
+						pthreads_stream_printf(threaded_stream, "MKD %s\r\n", buf);
+						result = PTHREADS_GET_FTP_RESULT(threaded_stream);
+						if (result < 200 || result > 299) {
+							if (options & PTHREADS_REPORT_ERRORS) {
+								php_error_docref(NULL, E_WARNING, "%s", tmp_line);
+							}
+							break;
+						}
+					}
+				}
+			}
+		}
+        efree(buf);
+    }
+
+	pthreads_url_free(resource);
+	pthreads_stream_close(threaded_stream, PTHREADS_STREAM_FREE_CLOSE);
+
+	if (result < 200 || result > 299) {
+		/* Failure */
+		return 0;
+	}
+
+	return 1;
+
+mkdir_errexit:
+	if (resource) {
+		pthreads_url_free(resource);
+	}
+	if (threaded_stream) {
+		pthreads_stream_close(threaded_stream, PTHREADS_STREAM_FREE_CLOSE);
+	}
+	return 0;
+}
+/* }}} */
+
+/* {{{ pthreads_stream_ftp_rmdir */
+static int pthreads_stream_ftp_rmdir(pthreads_stream_wrapper_t *threaded_wrapper, const char *url, int options, pthreads_stream_context_t *threaded_context) {
+	pthreads_stream_t *threaded_stream = NULL;
+	pthreads_url *resource = NULL;
+	int result;
+	char tmp_line[512];
+
+	threaded_stream = pthreads_ftp_fopen_connect(threaded_wrapper, url, "r", 0, NULL, threaded_context, NULL, &resource, NULL, NULL);
+	if (!threaded_stream) {
+		if (options & PTHREADS_REPORT_ERRORS) {
+			php_error_docref(NULL, E_WARNING, "Unable to connect to %s", url);
+		}
+		goto rmdir_errexit;
+	}
+
+	if (resource->path == NULL) {
+		if (options & PTHREADS_REPORT_ERRORS) {
+			php_error_docref(NULL, E_WARNING, "Invalid path provided in %s", url);
+		}
+		goto rmdir_errexit;
+	}
+
+	pthreads_stream_printf(threaded_stream, "RMD %s\r\n", ZSTR_VAL(resource->path));
+	result = PTHREADS_GET_FTP_RESULT(threaded_stream);
+
+	if (result < 200 || result > 299) {
+		if (options & PTHREADS_REPORT_ERRORS) {
+			php_error_docref(NULL, E_WARNING, "%s", tmp_line);
+		}
+		goto rmdir_errexit;
+	}
+
+	pthreads_url_free(resource);
+	pthreads_stream_close(threaded_stream, PTHREADS_STREAM_FREE_CLOSE);
+
+	return 1;
+
+rmdir_errexit:
+	if (resource) {
+		pthreads_url_free(resource);
+	}
+
+	if (threaded_stream) {
+		pthreads_stream_close(threaded_stream, PTHREADS_STREAM_FREE_CLOSE);
+	}
+	return 0;
+}
+/* }}} */
+
+const pthreads_stream_wrapper_ops pthreads_ftp_stream_wops = {
+	pthreads_stream_url_wrap_ftp,
+	pthreads_stream_ftp_stream_close, /* stream_close */
+	pthreads_stream_ftp_stream_stat,
+	pthreads_stream_ftp_url_stat, /* stat_url */
+	pthreads_stream_ftp_opendir, /* opendir */
+	"ftp",
+	pthreads_stream_ftp_unlink, /* unlink */
+	pthreads_stream_ftp_rename, /* rename */
+	pthreads_stream_ftp_mkdir,  /* mkdir */
+	pthreads_stream_ftp_rmdir,  /* rmdir */
+	NULL
+};
+
+#endif

--- a/src/streams/wrappers/glob_wrapper.c
+++ b/src/streams/wrappers/glob_wrapper.c
@@ -1,0 +1,329 @@
+/*
+  +----------------------------------------------------------------------+
+  | pthreads                                                             |
+  +----------------------------------------------------------------------+
+  | Copyright (c) Joe Watkins 2018                                       |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | http://www.php.net/license/3_01.txt                                  |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors: Bastian Schneider <b.schneider@badnoob.com>                 |
+  | Borrowed code from php-src                                           |
+  +----------------------------------------------------------------------+
+ */
+#ifndef HAVE_PTHREADS_STREAMS_WRAPPERS_GLOB_WRAPPER
+#define HAVE_PTHREADS_STREAMS_WRAPPERS_GLOB_WRAPPER
+
+#ifndef HAVE_PTHREADS_H
+#	include <src/pthreads.h>
+#endif
+
+#ifndef HAVE_PTHREADS_STREAM_H
+#	include <src/streams.h>
+#endif
+
+#ifndef HAVE_PTHREADS_STREAMS_INTERNAL_H
+#	include <src/streams/internal.h>
+#endif
+
+#ifdef HAVE_GLOB
+# ifndef PHP_WIN32
+#  include <glob.h>
+# else
+#  include "win32/glob.h"
+# endif
+
+#ifndef PTHREADS_GLOB_ONLYDIR
+#define PTHREADS_GLOB_ONLYDIR (1<<30)
+#define PTHREADS_GLOB_FLAGMASK (~PTHREADS_GLOB_ONLYDIR)
+#else
+#define PTHREADS_GLOB_FLAGMASK (~0)
+#endif
+
+typedef struct {
+	glob_t   glob;
+	size_t   index;
+	int      flags;
+	char     *path;
+	size_t   path_len;
+	char     *pattern;
+	size_t   pattern_len;
+} pthreads_glob_s_t;
+
+/* {{{ */
+char* _pthreads_glob_stream_get_path(pthreads_stream_t *threaded_stream, int copy, size_t *plen) {
+	pthreads_stream *stream = PTHREADS_FETCH_STREAMS_STREAM(threaded_stream);
+	pthreads_glob_s_t *pglob = (pthreads_glob_s_t *)stream->abstract;
+	char *ret = NULL;
+
+	if(stream_lock(threaded_stream)) {
+		if (pglob && pglob->path) {
+			if (plen) {
+				*plen = pglob->path_len;
+			}
+			if (copy) {
+				ret = strndup(pglob->path, pglob->path_len);
+			} else {
+				ret = pglob->path;
+			}
+			stream_unlock(threaded_stream);
+			return ret;
+		} else {
+			if (plen) {
+				*plen = 0;
+			}
+			stream_unlock(threaded_stream);
+			return NULL;
+		}
+	}
+	return ret;
+}
+/* }}} */
+
+/* {{{ */
+char* _pthreads_glob_stream_get_pattern(pthreads_stream_t *threaded_stream, int copy, size_t *plen) {
+	pthreads_stream *stream = PTHREADS_FETCH_STREAMS_STREAM(threaded_stream);
+	pthreads_glob_s_t *pglob = (pthreads_glob_s_t *)stream->abstract;
+	char *ret = NULL;
+
+	if(stream_lock(threaded_stream)) {
+		if (pglob && pglob->pattern) {
+			if (plen) {
+				*plen = pglob->pattern_len;
+			}
+			if (copy) {
+				ret = strndup(pglob->pattern, pglob->pattern_len);
+			} else {
+				ret = pglob->pattern;
+			}
+			stream_unlock(threaded_stream);
+			return ret;
+		} else {
+			if (plen) {
+				*plen = 0;
+			}
+			stream_unlock(threaded_stream);
+			return NULL;
+		}
+	}
+	return ret;
+}
+/* }}} */
+
+/* {{{ */
+int _pthreads_glob_stream_get_count(pthreads_stream_t *threaded_stream, int *pflags) {
+	pthreads_stream *stream = PTHREADS_FETCH_STREAMS_STREAM(threaded_stream);
+	pthreads_glob_s_t *pglob = (pthreads_glob_s_t *)stream->abstract;
+
+	if(stream_lock(threaded_stream)) {
+		if (pglob) {
+			if (pflags) {
+				*pflags = pglob->flags;
+			}
+			int ret = pglob->glob.gl_pathc;
+			stream_unlock(threaded_stream);
+			return ret;
+		} else {
+			if (pflags) {
+				*pflags = 0;
+			}
+			stream_unlock(threaded_stream);
+			return 0;
+		}
+	}
+	return 0;
+}
+/* }}} */
+
+/* {{{ */
+static void pthreads_glob_stream_path_split(pthreads_glob_s_t *pglob, const char *path, int get_path, const char **p_file) {
+	const char *pos, *gpath = path;
+
+	if ((pos = strrchr(path, '/')) != NULL) {
+		path = pos+1;
+	}
+#ifdef PHP_WIN32
+	if ((pos = strrchr(path, '\\')) != NULL) {
+		path = pos+1;
+	}
+#endif
+
+	*p_file = path;
+
+	if (get_path) {
+		if (pglob->path) {
+			free(pglob->path);
+		}
+		if (path != gpath) {
+			path--;
+		}
+		pglob->path_len = path - gpath;
+		pglob->path = strndup(gpath, pglob->path_len);
+	}
+}
+/* }}} */
+
+/* {{{ */
+static size_t pthreads_glob_stream_read(pthreads_stream_t *threaded_stream, char *buf, size_t count) {
+	pthreads_stream *stream = PTHREADS_FETCH_STREAMS_STREAM(threaded_stream);
+	pthreads_glob_s_t *pglob = (pthreads_glob_s_t *)stream->abstract;
+	pthreads_stream_dirent *ent = (pthreads_stream_dirent*)buf;
+	const char *path;
+
+	/* avoid problems if someone mis-uses the stream */
+	if (count == sizeof(pthreads_stream_dirent) && pglob) {
+		if(stream_lock(threaded_stream)) {
+			if (pglob->index < (size_t)pglob->glob.gl_pathc) {
+				pthreads_glob_stream_path_split(pglob, pglob->glob.gl_pathv[pglob->index++], pglob->flags & GLOB_APPEND, &path);
+				PHP_STRLCPY(ent->d_name, path, sizeof(ent->d_name), strlen(path));
+				stream_unlock(threaded_stream);
+				return sizeof(pthreads_stream_dirent);
+			}
+			pglob->index = pglob->glob.gl_pathc;
+
+			if (pglob->path) {
+				free(pglob->path);
+				pglob->path = NULL;
+			}
+			stream_unlock(threaded_stream);
+		}
+	}
+
+	return 0;
+}
+/* }}} */
+
+/* {{{ */
+static int pthreads_glob_stream_close(pthreads_stream_t *threaded_stream, int close_handle) {
+	return 0;
+}
+/* }}} */
+
+/* {{{ */
+static void pthreads_glob_stream_free(pthreads_stream_t *threaded_stream, int close_handle) {
+	pthreads_stream *stream = PTHREADS_FETCH_STREAMS_STREAM(threaded_stream);
+	pthreads_glob_s_t *pglob = (pthreads_glob_s_t *)stream->abstract;
+
+	if (pglob) {
+		pglob->index = 0;
+		globfree(&pglob->glob);
+		if (pglob->path) {
+			free(pglob->path);
+		}
+		if (pglob->pattern) {
+			free(pglob->pattern);
+		}
+	}
+	free(stream->abstract);
+}
+/* }}} */
+
+/* {{{ */
+static int pthreads_glob_stream_rewind(pthreads_stream_t *threaded_stream, zend_off_t offset, int whence, zend_off_t *newoffs) {
+	pthreads_stream *stream = PTHREADS_FETCH_STREAMS_STREAM(threaded_stream);
+	pthreads_glob_s_t *pglob = (pthreads_glob_s_t *)stream->abstract;
+
+	if (pglob) {
+		if(stream_lock(threaded_stream)) {
+			pglob->index = 0;
+			if (pglob->path) {
+				free(pglob->path);
+				pglob->path = NULL;
+			}
+			stream_unlock(threaded_stream);
+		}
+	}
+	return 0;
+}
+/* }}} */
+
+const pthreads_stream_ops pthreads_glob_stream_ops = {
+	NULL, pthreads_glob_stream_read,
+	pthreads_glob_stream_close,
+	pthreads_glob_stream_free,
+	NULL,
+	"glob",
+	pthreads_glob_stream_rewind,
+	NULL, /* cast */
+	NULL, /* stat */
+	NULL  /* set_option */
+};
+
+ /* {{{ pthreads_glob_stream_opener */
+static pthreads_stream_t *pthreads_glob_stream_opener(pthreads_stream_wrapper_t *threaded_wrapper, const char *path, const char *mode,
+		int options, zend_string **opened_path, pthreads_stream_context_t *threaded_context, zend_class_entry *ce)
+{
+	pthreads_glob_s_t *pglob;
+	int ret;
+	const char *tmp, *pos;
+
+	if (!strncmp(path, "glob://", sizeof("glob://")-1)) {
+		path += sizeof("glob://")-1;
+		if (opened_path) {
+			*opened_path = zend_string_init(path, strlen(path), 1);
+		}
+	}
+
+	if (((options & PTHREADS_STREAM_DISABLE_OPEN_BASEDIR) == 0) && php_check_open_basedir(path)) {
+		return NULL;
+	}
+
+	pglob = calloc(sizeof(*pglob), 1);
+
+	if (0 != (ret = glob(path, pglob->flags & PTHREADS_GLOB_FLAGMASK, NULL, &pglob->glob))) {
+#ifdef GLOB_NOMATCH
+		if (GLOB_NOMATCH != ret)
+#endif
+		{
+			free(pglob);
+			return NULL;
+		}
+	}
+
+	pos = path;
+	if ((tmp = strrchr(pos, '/')) != NULL) {
+		pos = tmp+1;
+	}
+#ifdef PHP_WIN32
+	if ((tmp = strrchr(pos, '\\')) != NULL) {
+		pos = tmp+1;
+	}
+#endif
+
+	pglob->pattern_len = strlen(pos);
+	pglob->pattern = strndup(pos, pglob->pattern_len);
+
+	pglob->flags |= GLOB_APPEND;
+
+	if (pglob->glob.gl_pathc) {
+		pthreads_glob_stream_path_split(pglob, pglob->glob.gl_pathv[0], 1, &tmp);
+	} else {
+		pthreads_glob_stream_path_split(pglob, path, 1, &tmp);
+	}
+
+	return PTHREADS_STREAM_CLASS_NEW(&pthreads_glob_stream_ops, pglob, mode, ce);
+}
+/* }}} */
+
+const pthreads_stream_wrapper_ops  pthreads_glob_stream_wrapper_ops = {
+	NULL,
+	NULL,
+	NULL,
+	NULL,
+	pthreads_glob_stream_opener,
+	"glob",
+	NULL,
+	NULL,
+	NULL,
+	NULL,
+	NULL
+};
+
+#endif /* HAVE_GLOB */
+
+#endif

--- a/src/streams/wrappers/glob_wrapper.h
+++ b/src/streams/wrappers/glob_wrapper.h
@@ -1,0 +1,34 @@
+/*
+  +----------------------------------------------------------------------+
+  | pthreads                                                             |
+  +----------------------------------------------------------------------+
+  | Copyright (c) Joe Watkins 2018                                       |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | http://www.php.net/license/3_01.txt                                  |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors: Bastian Schneider <b.schneider@badnoob.com>                 |
+  | Borrowed code from php-src                                           |
+  +----------------------------------------------------------------------+
+ */
+#ifndef HAVE_PTHREADS_STREAMS_WRAPPERS_GLOB_WRAPPER_H
+#define HAVE_PTHREADS_STREAMS_WRAPPERS_GLOB_WRAPPER_H
+
+extern const pthreads_stream_ops pthreads_glob_stream_ops;
+extern const pthreads_stream_wrapper_ops  pthreads_glob_stream_wrapper_ops;
+
+char* _pthreads_glob_stream_get_path(pthreads_stream_t *threaded_stream, int copy, size_t *plen);
+#define pthreads_glob_stream_get_path(threaded_stream, copy, plen)	_pthreads_glob_stream_get_path((threaded_stream), (copy), (plen))
+
+char* _pthreads_glob_stream_get_pattern(pthreads_stream_t *threaded_stream, int copy, size_t *plen);
+#define pthreads_glob_stream_get_pattern(threaded_stream, copy, plen)	_pthreads_glob_stream_get_pattern((threaded_stream), (copy), (plen))
+
+int   _pthreads_glob_stream_get_count(pthreads_stream_t *threaded_stream, int *pflags);
+#define pthreads_glob_stream_get_count(threaded_stream, pflags)	_pthreads_glob_stream_get_count((threaded_stream), (pflags))
+
+#endif

--- a/src/streams/wrappers/http_fopen_wrapper.c
+++ b/src/streams/wrappers/http_fopen_wrapper.c
@@ -1,0 +1,1002 @@
+/*
+  +----------------------------------------------------------------------+
+  | pthreads                                                             |
+  +----------------------------------------------------------------------+
+  | Copyright (c) Joe Watkins 2018                                       |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | http://www.php.net/license/3_01.txt                                  |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors: Bastian Schneider <b.schneider@badnoob.com>                 |
+  | Borrowed code from php-src                                           |
+  +----------------------------------------------------------------------+
+ */
+#ifndef HAVE_PTHREADS_STREAMS_WRAPPERS_HTTP_FOPEN_WRAPPER
+#define HAVE_PTHREADS_STREAMS_WRAPPERS_HTTP_FOPEN_WRAPPER
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#ifndef HAVE_PTHREADS_H
+#	include <src/pthreads.h>
+#endif
+
+#ifndef HAVE_PTHREADS_STREAM_H
+#	include <src/streams.h>
+#endif
+
+#ifndef HAVE_PTHREADS_STREAMS_WRAPPERS_FOPEN_WRAPPER_H
+#	include <src/streams/wrappers/fopen_wrapper.h>
+#endif
+
+#ifndef PHP_STRING_H
+#	include <ext/standard/php_string.h>
+#endif
+
+#ifndef BASE64_H
+#	include <ext/standard/base64.h>
+#endif
+
+#define HTTP_HEADER_BLOCK_SIZE		1024
+#define PHP_URL_REDIRECT_MAX		20
+#define HTTP_HEADER_USER_AGENT		1
+#define HTTP_HEADER_HOST			2
+#define HTTP_HEADER_AUTH			4
+#define HTTP_HEADER_FROM			8
+#define HTTP_HEADER_CONTENT_LENGTH	16
+#define HTTP_HEADER_TYPE			32
+#define HTTP_HEADER_CONNECTION		64
+
+#define HTTP_WRAPPER_HEADER_INIT    1
+#define HTTP_WRAPPER_REDIRECTED     2
+
+static inline void strip_header(char *header_bag, char *lc_header_bag,
+		const char *lc_header_name)
+{
+	char *lc_header_start = strstr(lc_header_bag, lc_header_name);
+	char *header_start = header_bag + (lc_header_start - lc_header_bag);
+
+	if (lc_header_start
+	&& (lc_header_start == lc_header_bag || *(lc_header_start-1) == '\n')
+	) {
+		char *lc_eol = strchr(lc_header_start, '\n');
+		char *eol = header_start + (lc_eol - lc_header_start);
+
+		if (lc_eol) {
+			size_t eollen = strlen(lc_eol);
+
+			memmove(lc_header_start, lc_eol+1, eollen);
+			memmove(header_start, eol+1, eollen);
+		} else {
+			*lc_header_start = '\0';
+			*header_start = '\0';
+		}
+	}
+}
+
+
+/* {{{ */
+static pthreads_stream_t *pthreads_stream_url_wrap_http_ex(pthreads_stream_wrapper_t *threaded_wrapper,
+		const char *path, const char *mode, int options, zend_string **opened_path,
+		pthreads_stream_context_t *threaded_context, int redirect_max, int flags,
+		zval *response_header, zend_class_entry *ce) {
+	pthreads_stream_wrapper *wrapper = PTHREADS_FETCH_STREAMS_WRAPPER(threaded_wrapper);
+	pthreads_stream_t *threaded_stream = NULL;
+	pthreads_stream *stream;
+	pthreads_url *resource = NULL;
+	int use_ssl;
+	int use_proxy = 0;
+	zend_string *tmp = NULL;
+	char *ua_str = NULL;
+	zval *ua_zval = NULL, *tmpzval = NULL, ssl_proxy_peer_name;
+	char location[HTTP_HEADER_BLOCK_SIZE];
+	int reqok = 0;
+	char *http_header_line = NULL;
+	char tmp_line[128];
+	size_t chunk_size = 0, file_size = 0;
+	int eol_detect = 0;
+	char *transport_string;
+	zend_string *errstr = NULL;
+	size_t transport_len;
+	int have_header = 0;
+	zend_bool request_fulluri = 0, ignore_errors = 0;
+	struct timeval timeout;
+	char *user_headers = NULL;
+	int header_init = ((flags & HTTP_WRAPPER_HEADER_INIT) != 0);
+	int redirected = ((flags & HTTP_WRAPPER_REDIRECTED) != 0);
+	zend_bool follow_location = 1;
+	pthreads_stream_filter_t *threaded_transfer_encoding = NULL;
+	int response_code;
+	smart_str req_buf = {0};
+	zend_bool custom_request_method;
+
+	tmp_line[0] = '\0';
+
+	if (redirect_max < 1) {
+		pthreads_stream_wrapper_log_error(threaded_wrapper, options, "Redirection limit reached, aborting");
+		return NULL;
+	}
+
+	resource = pthreads_url_parse(path);
+	if (resource == NULL) {
+		return NULL;
+	}
+
+	if (!zend_string_equals_literal_ci(resource->scheme, "http") &&
+		!zend_string_equals_literal_ci(resource->scheme, "https")) {
+		if (!threaded_context ||
+			(tmpzval = pthreads_stream_context_get_option(threaded_context, wrapper->wops->label, "proxy")) == NULL ||
+			Z_TYPE_P(tmpzval) != IS_STRING ||
+			Z_STRLEN_P(tmpzval) == 0) {
+			pthreads_url_free(resource);
+			return pthreads_stream_open_wrapper_ex(path, mode, PTHREADS_REPORT_ERRORS, NULL, threaded_context, ce);
+		}
+		/* Called from a non-http wrapper with http proxying requested (i.e. ftp) */
+		request_fulluri = 1;
+		use_ssl = 0;
+		use_proxy = 1;
+
+		transport_len = Z_STRLEN_P(tmpzval);
+		transport_string = estrndup(Z_STRVAL_P(tmpzval), Z_STRLEN_P(tmpzval));
+	} else {
+		/* Normal http request (possibly with proxy) */
+
+		if (strpbrk(mode, "awx+")) {
+			pthreads_stream_wrapper_log_error(threaded_wrapper, options, "HTTP wrapper does not support writeable connections");
+			pthreads_url_free(resource);
+			return NULL;
+		}
+
+		use_ssl = resource->scheme && (ZSTR_LEN(resource->scheme) > 4) && ZSTR_VAL(resource->scheme)[4] == 's';
+		/* choose default ports */
+		if (use_ssl && resource->port == 0)
+			resource->port = 443;
+		else if (resource->port == 0)
+			resource->port = 80;
+
+		if (threaded_context &&
+			(tmpzval = pthreads_stream_context_get_option(threaded_context, wrapper->wops->label, "proxy")) != NULL &&
+			Z_TYPE_P(tmpzval) == IS_STRING &&
+			Z_STRLEN_P(tmpzval) > 0) {
+			use_proxy = 1;
+			transport_len = Z_STRLEN_P(tmpzval);
+			transport_string = estrndup(Z_STRVAL_P(tmpzval), Z_STRLEN_P(tmpzval));
+		} else {
+			transport_len = spprintf(&transport_string, 0, "%s://%s:%d", use_ssl ? "ssl" : "tcp", ZSTR_VAL(resource->host), resource->port);
+		}
+	}
+
+	if (threaded_context && (tmpzval = pthreads_stream_context_get_option(threaded_context, wrapper->wops->label, "timeout")) != NULL) {
+		double d = zval_get_double(tmpzval);
+#ifndef PHP_WIN32
+		timeout.tv_sec = (time_t) d;
+		timeout.tv_usec = (size_t) ((d - timeout.tv_sec) * 1000000);
+#else
+		timeout.tv_sec = (long) d;
+		timeout.tv_usec = (long) ((d - timeout.tv_sec) * 1000000);
+#endif
+	} else {
+#ifndef PHP_WIN32
+		timeout.tv_sec = FG(default_socket_timeout);
+#else
+		timeout.tv_sec = (long)FG(default_socket_timeout);
+#endif
+		timeout.tv_usec = 0;
+	}
+
+	threaded_stream = pthreads_stream_xport_create(transport_string, transport_len, options,
+			PTHREADS_STREAM_XPORT_CLIENT | PTHREADS_STREAM_XPORT_CONNECT,
+			&timeout, threaded_context, &errstr, NULL);
+
+	if (threaded_stream) {
+		pthreads_stream_set_option(threaded_stream, PTHREADS_STREAM_OPTION_READ_TIMEOUT, 0, &timeout);
+		stream = PTHREADS_FETCH_STREAMS_STREAM(threaded_stream);
+	}
+
+	if (errstr) {
+		pthreads_stream_wrapper_log_error(threaded_wrapper, options, "%s", ZSTR_VAL(errstr));
+		zend_string_release(errstr);
+		errstr = NULL;
+	}
+
+	efree(transport_string);
+
+	if (threaded_stream && use_proxy && use_ssl) {
+		smart_str header = {0};
+
+		/* Set peer_name or name verification will try to use the proxy server name */
+		if (!threaded_context || (tmpzval = pthreads_stream_context_get_option(threaded_context, "ssl", "peer_name")) == NULL) {
+			ZVAL_STR_COPY(&ssl_proxy_peer_name, resource->host);
+			pthreads_stream_context_set_option(pthreads_stream_get_context(threaded_stream), "ssl", "peer_name", &ssl_proxy_peer_name);
+			zval_ptr_dtor(&ssl_proxy_peer_name);
+		}
+
+		smart_str_appendl(&header, "CONNECT ", sizeof("CONNECT ")-1);
+		smart_str_appends(&header, ZSTR_VAL(resource->host));
+		smart_str_appendc(&header, ':');
+		smart_str_append_unsigned(&header, resource->port);
+		smart_str_appendl(&header, " HTTP/1.0\r\n", sizeof(" HTTP/1.0\r\n")-1);
+
+	    /* check if we have Proxy-Authorization header */
+		if (threaded_context && (tmpzval = pthreads_stream_context_get_option(threaded_context, "http", "header")) != NULL) {
+			char *s, *p;
+
+			if (Z_TYPE_P(tmpzval) == IS_ARRAY) {
+				zval *tmpheader = NULL;
+
+				ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(tmpzval), tmpheader) {
+					if (Z_TYPE_P(tmpheader) == IS_STRING) {
+						s = Z_STRVAL_P(tmpheader);
+						do {
+							while (*s == ' ' || *s == '\t') s++;
+							p = s;
+							while (*p != 0 && *p != ':' && *p != '\r' && *p !='\n') p++;
+							if (*p == ':') {
+								p++;
+								if (p - s == sizeof("Proxy-Authorization:") - 1 &&
+								    zend_binary_strcasecmp(s, sizeof("Proxy-Authorization:") - 1,
+								        "Proxy-Authorization:", sizeof("Proxy-Authorization:") - 1) == 0) {
+									while (*p != 0 && *p != '\r' && *p !='\n') p++;
+									smart_str_appendl(&header, s, p - s);
+									smart_str_appendl(&header, "\r\n", sizeof("\r\n")-1);
+									goto finish;
+								} else {
+									while (*p != 0 && *p != '\r' && *p !='\n') p++;
+								}
+							}
+							s = p;
+							while (*s == '\r' || *s == '\n') s++;
+						} while (*s != 0);
+					}
+				} ZEND_HASH_FOREACH_END();
+			} else if (Z_TYPE_P(tmpzval) == IS_STRING && Z_STRLEN_P(tmpzval)) {
+				s = Z_STRVAL_P(tmpzval);
+				do {
+					while (*s == ' ' || *s == '\t') s++;
+					p = s;
+					while (*p != 0 && *p != ':' && *p != '\r' && *p !='\n') p++;
+					if (*p == ':') {
+						p++;
+						if (p - s == sizeof("Proxy-Authorization:") - 1 &&
+						    zend_binary_strcasecmp(s, sizeof("Proxy-Authorization:") - 1,
+						        "Proxy-Authorization:", sizeof("Proxy-Authorization:") - 1) == 0) {
+							while (*p != 0 && *p != '\r' && *p !='\n') p++;
+							smart_str_appendl(&header, s, p - s);
+							smart_str_appendl(&header, "\r\n", sizeof("\r\n")-1);
+							goto finish;
+						} else {
+							while (*p != 0 && *p != '\r' && *p !='\n') p++;
+						}
+					}
+					s = p;
+					while (*s == '\r' || *s == '\n') s++;
+				} while (*s != 0);
+			}
+		}
+finish:
+		smart_str_appendl(&header, "\r\n", sizeof("\r\n")-1);
+
+		if (pthreads_stream_write(threaded_stream, ZSTR_VAL(header.s), ZSTR_LEN(header.s)) != ZSTR_LEN(header.s)) {
+			pthreads_stream_wrapper_log_error(threaded_wrapper, options, "Cannot connect to HTTPS server through proxy");
+			pthreads_stream_close(threaded_stream, PTHREADS_STREAM_FREE_CLOSE);
+			threaded_stream = NULL;
+		}
+ 	 	smart_str_free(&header);
+
+ 	 	if (threaded_stream) {
+ 	 		char header_line[HTTP_HEADER_BLOCK_SIZE];
+
+			/* get response header */
+			while (pthreads_stream_gets(threaded_stream, header_line, HTTP_HEADER_BLOCK_SIZE-1) != NULL) {
+				if (header_line[0] == '\n' ||
+				    header_line[0] == '\r' ||
+				    header_line[0] == '\0') {
+				  break;
+				}
+			}
+		}
+
+		/* enable SSL transport layer */
+		if (threaded_stream) {
+			if (pthreads_stream_xport_crypto_setup(threaded_stream, PTHREADS_STREAM_CRYPTO_METHOD_SSLv23_CLIENT, NULL) < 0 ||
+				pthreads_stream_xport_crypto_enable(threaded_stream, 1) < 0) {
+				pthreads_stream_wrapper_log_error(threaded_wrapper, options, "Cannot connect to HTTPS server through proxy");
+				pthreads_stream_close(threaded_stream, PTHREADS_STREAM_FREE_CLOSE);
+				threaded_stream = NULL;
+			}
+		}
+	}
+
+	if (threaded_stream == NULL)
+		goto out;
+
+	/* avoid buffering issues while reading header */
+	if (options & PTHREADS_STREAM_WILL_CAST)
+		chunk_size = pthreads_stream_set_chunk_size(threaded_stream, 1);
+
+	stream = PTHREADS_FETCH_STREAMS_STREAM(threaded_stream);
+
+	/* avoid problems with auto-detecting when reading the headers -> the headers
+	 * are always in canonical \r\n format */
+	eol_detect = stream->flags & (PTHREADS_STREAM_FLAG_DETECT_EOL | PTHREADS_STREAM_FLAG_EOL_MAC);
+	stream->flags &= ~(PTHREADS_STREAM_FLAG_DETECT_EOL | PTHREADS_STREAM_FLAG_EOL_MAC);
+
+	pthreads_stream_context_set(threaded_stream, threaded_context);
+
+	pthreads_stream_notify_info(threaded_context, PTHREADS_STREAM_NOTIFY_CONNECT, NULL, 0);
+
+	if (header_init && threaded_context && (tmpzval = pthreads_stream_context_get_option(threaded_context, "http", "max_redirects")) != NULL) {
+		redirect_max = (int)zval_get_long(tmpzval);
+	}
+
+	custom_request_method = 0;
+	if (threaded_context && (tmpzval = pthreads_stream_context_get_option(threaded_context, "http", "method")) != NULL) {
+		if (Z_TYPE_P(tmpzval) == IS_STRING && Z_STRLEN_P(tmpzval) > 0) {
+			/* As per the RFC, automatically redirected requests MUST NOT use other methods than
+			 * GET and HEAD unless it can be confirmed by the user */
+			if (!redirected
+				|| (Z_STRLEN_P(tmpzval) == 3 && memcmp("GET", Z_STRVAL_P(tmpzval), 3) == 0)
+				|| (Z_STRLEN_P(tmpzval) == 4 && memcmp("HEAD",Z_STRVAL_P(tmpzval), 4) == 0)
+			) {
+				custom_request_method = 1;
+				smart_str_append(&req_buf, Z_STR_P(tmpzval));
+				smart_str_appendc(&req_buf, ' ');
+			}
+		}
+	}
+
+	if (!custom_request_method) {
+		smart_str_appends(&req_buf, "GET ");
+	}
+
+	/* Should we send the entire path in the request line, default to no. */
+	if (!request_fulluri && threaded_context &&
+		(tmpzval = pthreads_stream_context_get_option(threaded_context, "http", "request_fulluri")) != NULL) {
+		request_fulluri = zend_is_true(tmpzval);
+	}
+
+	if (request_fulluri) {
+		/* Ask for everything */
+		smart_str_appends(&req_buf, path);
+	} else {
+		/* Send the traditional /path/to/file?query_string */
+
+		/* file */
+		if (resource->path && ZSTR_LEN(resource->path)) {
+			smart_str_appends(&req_buf, ZSTR_VAL(resource->path));
+		} else {
+			smart_str_appendc(&req_buf, '/');
+		}
+
+		/* query string */
+		if (resource->query) {
+			smart_str_appendc(&req_buf, '?');
+			smart_str_appends(&req_buf, ZSTR_VAL(resource->query));
+		}
+	}
+
+	/* protocol version we are speaking */
+	if (threaded_context && (tmpzval = pthreads_stream_context_get_option(threaded_context, "http", "protocol_version")) != NULL) {
+		char *protocol_version;
+		spprintf(&protocol_version, 0, "%.1F", zval_get_double(tmpzval));
+
+		smart_str_appends(&req_buf, " HTTP/");
+		smart_str_appends(&req_buf, protocol_version);
+		smart_str_appends(&req_buf, "\r\n");
+		efree(protocol_version);
+	} else {
+		smart_str_appends(&req_buf, " HTTP/1.0\r\n");
+	}
+
+	if (threaded_context && (tmpzval = pthreads_stream_context_get_option(threaded_context, "http", "header")) != NULL) {
+		tmp = NULL;
+
+		if (Z_TYPE_P(tmpzval) == IS_ARRAY) {
+			zval *tmpheader = NULL;
+			smart_str tmpstr = {0};
+
+			ZEND_HASH_FOREACH_VAL(Z_ARRVAL_P(tmpzval), tmpheader) {
+				if (Z_TYPE_P(tmpheader) == IS_STRING) {
+					smart_str_append(&tmpstr, Z_STR_P(tmpheader));
+					smart_str_appendl(&tmpstr, "\r\n", sizeof("\r\n") - 1);
+				}
+			} ZEND_HASH_FOREACH_END();
+			smart_str_0(&tmpstr);
+			/* Remove newlines and spaces from start and end. there's at least one extra \r\n at the end that needs to go. */
+			if (tmpstr.s) {
+				tmp = php_trim(tmpstr.s, NULL, 0, 3);
+				smart_str_free(&tmpstr);
+			}
+		} else if (Z_TYPE_P(tmpzval) == IS_STRING && Z_STRLEN_P(tmpzval)) {
+			/* Remove newlines and spaces from start and end php_trim will estrndup() */
+			tmp = php_trim(Z_STR_P(tmpzval), NULL, 0, 3);
+		}
+		if (tmp && ZSTR_LEN(tmp)) {
+			char *s;
+			char *t;
+
+			user_headers = estrndup(ZSTR_VAL(tmp), ZSTR_LEN(tmp));
+
+			if (ZSTR_IS_INTERNED(tmp)) {
+				tmp = zend_string_init(ZSTR_VAL(tmp), ZSTR_LEN(tmp), 0);
+			} else if (GC_REFCOUNT(tmp) > 1) {
+				GC_DELREF(tmp);
+				tmp = zend_string_init(ZSTR_VAL(tmp), ZSTR_LEN(tmp), 0);
+			}
+
+			/* Make lowercase for easy comparison against 'standard' headers */
+			php_strtolower(ZSTR_VAL(tmp), ZSTR_LEN(tmp));
+			t = ZSTR_VAL(tmp);
+
+			if (!header_init) {
+				/* strip POST headers on redirect */
+				strip_header(user_headers, t, "content-length:");
+				strip_header(user_headers, t, "content-type:");
+			}
+
+			if ((s = strstr(t, "user-agent:")) &&
+			    (s == t || *(s-1) == '\r' || *(s-1) == '\n' ||
+			                 *(s-1) == '\t' || *(s-1) == ' ')) {
+				 have_header |= HTTP_HEADER_USER_AGENT;
+			}
+			if ((s = strstr(t, "host:")) &&
+			    (s == t || *(s-1) == '\r' || *(s-1) == '\n' ||
+			                 *(s-1) == '\t' || *(s-1) == ' ')) {
+				 have_header |= HTTP_HEADER_HOST;
+			}
+			if ((s = strstr(t, "from:")) &&
+			    (s == t || *(s-1) == '\r' || *(s-1) == '\n' ||
+			                 *(s-1) == '\t' || *(s-1) == ' ')) {
+				 have_header |= HTTP_HEADER_FROM;
+				}
+			if ((s = strstr(t, "authorization:")) &&
+			    (s == t || *(s-1) == '\r' || *(s-1) == '\n' ||
+			                 *(s-1) == '\t' || *(s-1) == ' ')) {
+				 have_header |= HTTP_HEADER_AUTH;
+			}
+			if ((s = strstr(t, "content-length:")) &&
+			    (s == t || *(s-1) == '\r' || *(s-1) == '\n' ||
+			                 *(s-1) == '\t' || *(s-1) == ' ')) {
+				 have_header |= HTTP_HEADER_CONTENT_LENGTH;
+			}
+			if ((s = strstr(t, "content-type:")) &&
+			    (s == t || *(s-1) == '\r' || *(s-1) == '\n' ||
+			                 *(s-1) == '\t' || *(s-1) == ' ')) {
+				 have_header |= HTTP_HEADER_TYPE;
+			}
+			if ((s = strstr(t, "connection:")) &&
+			    (s == t || *(s-1) == '\r' || *(s-1) == '\n' ||
+			                 *(s-1) == '\t' || *(s-1) == ' ')) {
+				 have_header |= HTTP_HEADER_CONNECTION;
+			}
+			/* remove Proxy-Authorization header */
+			if (use_proxy && use_ssl && (s = strstr(t, "proxy-authorization:")) &&
+			    (s == t || *(s-1) == '\r' || *(s-1) == '\n' ||
+			                 *(s-1) == '\t' || *(s-1) == ' ')) {
+				char *p = s + sizeof("proxy-authorization:") - 1;
+
+				while (s > t && (*(s-1) == ' ' || *(s-1) == '\t')) s--;
+				while (*p != 0 && *p != '\r' && *p != '\n') p++;
+				while (*p == '\r' || *p == '\n') p++;
+				if (*p == 0) {
+					if (s == t) {
+						efree(user_headers);
+						user_headers = NULL;
+					} else {
+						while (s > t && (*(s-1) == '\r' || *(s-1) == '\n')) s--;
+						user_headers[s - t] = 0;
+					}
+				} else {
+					memmove(user_headers + (s - t), user_headers + (p - t), strlen(p) + 1);
+				}
+			}
+
+		}
+		if (tmp) {
+			zend_string_release(tmp);
+		}
+	}
+
+	/* auth header if it was specified */
+	if (((have_header & HTTP_HEADER_AUTH) == 0) && resource->user) {
+		/* make scratch large enough to hold the whole URL (over-estimate) */
+		size_t scratch_len = strlen(path) + 1;
+		char *scratch = emalloc(scratch_len);
+		zend_string *stmp;
+
+		/* decode the strings first */
+		php_url_decode(ZSTR_VAL(resource->user), ZSTR_LEN(resource->user));
+
+		strcpy(scratch, ZSTR_VAL(resource->user));
+		strcat(scratch, ":");
+
+		/* Note: password is optional! */
+		if (resource->pass) {
+			php_url_decode(ZSTR_VAL(resource->pass), ZSTR_LEN(resource->pass));
+			strcat(scratch, ZSTR_VAL(resource->pass));
+		}
+
+		stmp = php_base64_encode((unsigned char*)scratch, strlen(scratch));
+
+		smart_str_appends(&req_buf, "Authorization: Basic ");
+		smart_str_appends(&req_buf, ZSTR_VAL(stmp));
+		smart_str_appends(&req_buf, "\r\n");
+
+		pthreads_stream_notify_info(threaded_context, PTHREADS_STREAM_NOTIFY_AUTH_REQUIRED, NULL, 0);
+
+		zend_string_free(stmp);
+		efree(scratch);
+	}
+
+	/* if the user has configured who they are, send a From: line */
+	if (!(have_header & HTTP_HEADER_FROM) && FG(from_address)) {
+		smart_str_appends(&req_buf, "From: ");
+		smart_str_appends(&req_buf, FG(from_address));
+		smart_str_appends(&req_buf, "\r\n");
+	}
+
+	/* Send Host: header so name-based virtual hosts work */
+	if ((have_header & HTTP_HEADER_HOST) == 0) {
+		smart_str_appends(&req_buf, "Host: ");
+		smart_str_appends(&req_buf, ZSTR_VAL(resource->host));
+		if ((use_ssl && resource->port != 443 && resource->port != 0) ||
+			(!use_ssl && resource->port != 80 && resource->port != 0)) {
+			smart_str_appendc(&req_buf, ':');
+			smart_str_append_unsigned(&req_buf, resource->port);
+		}
+		smart_str_appends(&req_buf, "\r\n");
+	}
+
+	/* Send a Connection: close header to avoid hanging when the server
+	 * interprets the RFC literally and establishes a keep-alive connection,
+	 * unless the user specifically requests something else by specifying a
+	 * Connection header in the context options. Send that header even for
+	 * HTTP/1.0 to avoid issues when the server respond with a HTTP/1.1
+	 * keep-alive response, which is the preferred response type. */
+	if ((have_header & HTTP_HEADER_CONNECTION) == 0) {
+		smart_str_appends(&req_buf, "Connection: close\r\n");
+	}
+
+	if (threaded_context &&
+	    (ua_zval = pthreads_stream_context_get_option(threaded_context, "http", "user_agent")) != NULL &&
+		Z_TYPE_P(ua_zval) == IS_STRING) {
+		ua_str = Z_STRVAL_P(ua_zval);
+	} else if (FG(user_agent)) {
+		ua_str = FG(user_agent);
+	}
+
+	if (((have_header & HTTP_HEADER_USER_AGENT) == 0) && ua_str) {
+#define _UA_HEADER "User-Agent: %s\r\n"
+		char *ua;
+		size_t ua_len;
+
+		ua_len = sizeof(_UA_HEADER) + strlen(ua_str);
+
+		/* ensure the header is only sent if user_agent is not blank */
+		if (ua_len > sizeof(_UA_HEADER)) {
+			ua = emalloc(ua_len + 1);
+			if ((ua_len = slprintf(ua, ua_len, _UA_HEADER, ua_str)) > 0) {
+				ua[ua_len] = 0;
+				smart_str_appendl(&req_buf, ua, ua_len);
+			} else {
+				php_error_docref(NULL, E_WARNING, "Cannot construct User-agent header");
+			}
+			efree(ua);
+		}
+	}
+
+	if (user_headers) {
+		/* A bit weird, but some servers require that Content-Length be sent prior to Content-Type for POST
+		 * see bug #44603 for details. Since Content-Type maybe part of user's headers we need to do this check first.
+		 */
+		if (
+				header_init &&
+				threaded_context &&
+				!(have_header & HTTP_HEADER_CONTENT_LENGTH) &&
+				(tmpzval = pthreads_stream_context_get_option(threaded_context, "http", "content")) != NULL &&
+				Z_TYPE_P(tmpzval) == IS_STRING && Z_STRLEN_P(tmpzval) > 0
+		) {
+			smart_str_appends(&req_buf, "Content-Length: ");
+			smart_str_append_unsigned(&req_buf, Z_STRLEN_P(tmpzval));
+			smart_str_appends(&req_buf, "\r\n");
+			have_header |= HTTP_HEADER_CONTENT_LENGTH;
+		}
+
+		smart_str_appends(&req_buf, user_headers);
+		smart_str_appends(&req_buf, "\r\n");
+		efree(user_headers);
+	}
+
+	/* Request content, such as for POST requests */
+	if (header_init && threaded_context &&
+		(tmpzval = pthreads_stream_context_get_option(threaded_context, "http", "content")) != NULL &&
+		Z_TYPE_P(tmpzval) == IS_STRING && Z_STRLEN_P(tmpzval) > 0) {
+		if (!(have_header & HTTP_HEADER_CONTENT_LENGTH)) {
+			smart_str_appends(&req_buf, "Content-Length: ");
+			smart_str_append_unsigned(&req_buf, Z_STRLEN_P(tmpzval));
+			smart_str_appends(&req_buf, "\r\n");
+		}
+		if (!(have_header & HTTP_HEADER_TYPE)) {
+			smart_str_appends(&req_buf, "Content-Type: application/x-www-form-urlencoded\r\n");
+			php_error_docref(NULL, E_NOTICE, "Content-type not specified assuming application/x-www-form-urlencoded");
+		}
+		smart_str_appends(&req_buf, "\r\n");
+		smart_str_appendl(&req_buf, Z_STRVAL_P(tmpzval), Z_STRLEN_P(tmpzval));
+	} else {
+		smart_str_appends(&req_buf, "\r\n");
+	}
+
+	/* send it */
+	pthreads_stream_write(threaded_stream, ZSTR_VAL(req_buf.s), ZSTR_LEN(req_buf.s));
+
+	location[0] = '\0';
+
+	if (Z_ISUNDEF_P(response_header)) {
+		array_init(response_header);
+	}
+
+	if (!pthreads_stream_eof(threaded_stream)) {
+		size_t tmp_line_len;
+		/* get response header */
+
+		if (pthreads_stream_get_line(threaded_stream, tmp_line, sizeof(tmp_line) - 1, &tmp_line_len) != NULL) {
+			zval http_response;
+
+			if (tmp_line_len > 9) {
+				response_code = atoi(tmp_line + 9);
+			} else {
+				response_code = 0;
+			}
+			if (threaded_context && NULL != (tmpzval = pthreads_stream_context_get_option(threaded_context, "http", "ignore_errors"))) {
+				ignore_errors = zend_is_true(tmpzval);
+			}
+			/* when we request only the header, don't fail even on error codes */
+			if ((options & PTHREADS_STREAM_ONLY_GET_HEADERS) || ignore_errors) {
+				reqok = 1;
+			}
+
+			/* status codes of 1xx are "informational", and will be followed by a real response
+			 * e.g "100 Continue". RFC 7231 states that unexpected 1xx status MUST be parsed,
+			 * and MAY be ignored. As such, we need to skip ahead to the "real" status*/
+			if (response_code >= 100 && response_code < 200) {
+				/* consume lines until we find a line starting 'HTTP/1' */
+				while (
+					!pthreads_stream_eof(threaded_stream)
+					&& pthreads_stream_get_line(threaded_stream, tmp_line, sizeof(tmp_line) - 1, &tmp_line_len) != NULL
+					&& ( tmp_line_len < sizeof("HTTP/1") - 1 || strncasecmp(tmp_line, "HTTP/1", sizeof("HTTP/1") - 1) )
+				);
+
+				if (tmp_line_len > 9) {
+					response_code = atoi(tmp_line + 9);
+				} else {
+					response_code = 0;
+				}
+			}
+			/* all status codes in the 2xx range are defined by the specification as successful;
+			 * all status codes in the 3xx range are for redirection, and so also should never
+			 * fail */
+			if (response_code >= 200 && response_code < 400) {
+				reqok = 1;
+			} else {
+				switch(response_code) {
+					case 403:
+						pthreads_stream_notify_error(threaded_context, PTHREADS_STREAM_NOTIFY_AUTH_RESULT,
+								tmp_line, response_code);
+						break;
+					default:
+						/* safety net in the event tmp_line == NULL */
+						if (!tmp_line_len) {
+							tmp_line[0] = '\0';
+						}
+						pthreads_stream_notify_error(threaded_context, PTHREADS_STREAM_NOTIFY_FAILURE,
+								tmp_line, response_code);
+				}
+			}
+			if (tmp_line_len >= 1 && tmp_line[tmp_line_len - 1] == '\n') {
+				--tmp_line_len;
+				if (tmp_line_len >= 1 &&tmp_line[tmp_line_len - 1] == '\r') {
+					--tmp_line_len;
+				}
+			}
+			ZVAL_STRINGL(&http_response, tmp_line, tmp_line_len);
+			zend_hash_next_index_insert(Z_ARRVAL_P(response_header), &http_response);
+		}
+	} else {
+		pthreads_stream_wrapper_log_error(threaded_wrapper, options, "HTTP request failed, unexpected end of socket!");
+		goto out;
+	}
+
+	/* read past HTTP headers */
+
+	http_header_line = emalloc(HTTP_HEADER_BLOCK_SIZE);
+
+	while (!pthreads_stream_eof(threaded_stream)) {
+		size_t http_header_line_length;
+
+		if (pthreads_stream_get_line(threaded_stream, http_header_line, HTTP_HEADER_BLOCK_SIZE, &http_header_line_length) && *http_header_line != '\n' && *http_header_line != '\r') {
+			char *e = http_header_line + http_header_line_length - 1;
+			char *http_header_value;
+			if (*e != '\n') {
+				do { /* partial header */
+					if (pthreads_stream_get_line(threaded_stream, http_header_line, HTTP_HEADER_BLOCK_SIZE, &http_header_line_length) == NULL) {
+						pthreads_stream_wrapper_log_error(threaded_wrapper, options, "Failed to read HTTP headers");
+						goto out;
+					}
+					e = http_header_line + http_header_line_length - 1;
+				} while (*e != '\n');
+				continue;
+			}
+			while (e >= http_header_line && (*e == '\n' || *e == '\r')) {
+				e--;
+			}
+
+			/* The primary definition of an HTTP header in RFC 7230 states:
+			 * > Each header field consists of a case-insensitive field name followed
+			 * > by a colon (":"), optional leading whitespace, the field value, and
+			 * > optional trailing whitespace. */
+
+			/* Strip trailing whitespace */
+			while (e >= http_header_line && (*e == ' ' || *e == '\t')) {
+				e--;
+			}
+
+			/* Terminate header line */
+			e++;
+			*e = '\0';
+			http_header_line_length = e - http_header_line;
+
+			http_header_value = memchr(http_header_line, ':', http_header_line_length);
+			if (http_header_value) {
+				http_header_value++; /* Skip ':' */
+
+				/* Strip leading whitespace */
+				while (http_header_value < e
+						&& (*http_header_value == ' ' || *http_header_value == '\t')) {
+					http_header_value++;
+				}
+			} else {
+				/* There is no colon. Set the value to the end of the header line, which is
+				 * effectively an empty string. */
+				http_header_value = e;
+			}
+
+			if (!strncasecmp(http_header_line, "Location:", sizeof("Location:")-1)) {
+				if (threaded_context && (tmpzval = pthreads_stream_context_get_option(threaded_context, "http", "follow_location")) != NULL) {
+					follow_location = zval_is_true(tmpzval);
+				} else if (!((response_code >= 300 && response_code < 304)
+						|| 307 == response_code || 308 == response_code)) {
+					/* we shouldn't redirect automatically
+					if follow_location isn't set and response_code not in (300, 301, 302, 303 and 307)
+					see http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.3.1
+					RFC 7238 defines 308: http://tools.ietf.org/html/rfc7238 */
+					follow_location = 0;
+				}
+				strlcpy(location, http_header_value, sizeof(location));
+			} else if (!strncasecmp(http_header_line, "Content-Type:", sizeof("Content-Type:")-1)) {
+				pthreads_stream_notify_info(threaded_context, PTHREADS_STREAM_NOTIFY_MIME_TYPE_IS, http_header_value, 0);
+			} else if (!strncasecmp(http_header_line, "Content-Length:", sizeof("Content-Length:")-1)) {
+				file_size = atoi(http_header_value);
+				pthreads_stream_notify_file_size(threaded_context, file_size, http_header_line, 0);
+			} else if (
+				!strncasecmp(http_header_line, "Transfer-Encoding:", sizeof("Transfer-Encoding:")-1)
+				&& !strncasecmp(http_header_value, "Chunked", sizeof("Chunked")-1)
+			) {
+
+				/* create filter to decode response body */
+				if (!(options & PTHREADS_STREAM_ONLY_GET_HEADERS)) {
+					zend_long decode = 1;
+
+					if (threaded_context && (tmpzval = pthreads_stream_context_get_option(threaded_context, "http", "auto_decode")) != NULL) {
+						decode = zend_is_true(tmpzval);
+					}
+					if (decode) {
+						threaded_transfer_encoding = pthreads_stream_filter_create("dechunk", NULL);
+						if (threaded_transfer_encoding) {
+							/* don't store transfer-encodeing header */
+							continue;
+						}
+					}
+				}
+			}
+
+			{
+				zval http_header;
+				ZVAL_STRINGL(&http_header, http_header_line, http_header_line_length);
+				zend_hash_next_index_insert(Z_ARRVAL_P(response_header), &http_header);
+			}
+		} else {
+			break;
+		}
+	}
+
+	if (!reqok || (location[0] != '\0' && follow_location)) {
+		if (!follow_location || (((options & PTHREADS_STREAM_ONLY_GET_HEADERS) || ignore_errors) && redirect_max <= 1)) {
+			goto out;
+		}
+
+		if (location[0] != '\0')
+			pthreads_stream_notify_info(threaded_context, PTHREADS_STREAM_NOTIFY_REDIRECTED, location, 0);
+
+		pthreads_stream_close(threaded_stream, PTHREADS_STREAM_FREE_CLOSE);
+		threaded_stream = NULL;
+
+		if (location[0] != '\0') {
+
+			char new_path[HTTP_HEADER_BLOCK_SIZE];
+			char loc_path[HTTP_HEADER_BLOCK_SIZE];
+
+			*new_path='\0';
+			if (strlen(location)<8 || (strncasecmp(location, "http://", sizeof("http://")-1) &&
+							strncasecmp(location, "https://", sizeof("https://")-1) &&
+							strncasecmp(location, "ftp://", sizeof("ftp://")-1) &&
+							strncasecmp(location, "ftps://", sizeof("ftps://")-1)))
+			{
+				if (*location != '/') {
+					if (*(location+1) != '\0' && resource->path) {
+						char *s = strrchr(ZSTR_VAL(resource->path), '/');
+						if (!s) {
+							s = ZSTR_VAL(resource->path);
+							if (!ZSTR_LEN(resource->path)) {
+								zend_string_release(resource->path);
+								resource->path = zend_string_init("/", 1, 0);
+								s = ZSTR_VAL(resource->path);
+							} else {
+								*s = '/';
+							}
+						}
+						s[1] = '\0';
+						if (resource->path &&
+							ZSTR_VAL(resource->path)[0] == '/' &&
+							ZSTR_VAL(resource->path)[1] == '\0') {
+							snprintf(loc_path, sizeof(loc_path) - 1, "%s%s", ZSTR_VAL(resource->path), location);
+						} else {
+							snprintf(loc_path, sizeof(loc_path) - 1, "%s/%s", ZSTR_VAL(resource->path), location);
+						}
+					} else {
+						snprintf(loc_path, sizeof(loc_path) - 1, "/%s", location);
+					}
+				} else {
+					strlcpy(loc_path, location, sizeof(loc_path));
+				}
+				if ((use_ssl && resource->port != 443) || (!use_ssl && resource->port != 80)) {
+					snprintf(new_path, sizeof(new_path) - 1, "%s://%s:%d%s", ZSTR_VAL(resource->scheme), ZSTR_VAL(resource->host), resource->port, loc_path);
+				} else {
+					snprintf(new_path, sizeof(new_path) - 1, "%s://%s%s", ZSTR_VAL(resource->scheme), ZSTR_VAL(resource->host), loc_path);
+				}
+			} else {
+				strlcpy(new_path, location, sizeof(new_path));
+			}
+
+			pthreads_url_free(resource);
+			/* check for invalid redirection URLs */
+			if ((resource = pthreads_url_parse(new_path)) == NULL) {
+				pthreads_stream_wrapper_log_error(threaded_wrapper, options, "Invalid redirect URL! %s", new_path);
+				goto out;
+			}
+
+#define CHECK_FOR_CNTRL_CHARS(val) { \
+	if (val) { \
+		unsigned char *s, *e; \
+		ZSTR_LEN(val) = php_url_decode(ZSTR_VAL(val), ZSTR_LEN(val)); \
+		s = (unsigned char*)ZSTR_VAL(val); e = s + ZSTR_LEN(val); \
+		while (s < e) { \
+			if (iscntrl(*s)) { \
+				pthreads_stream_wrapper_log_error(threaded_wrapper, options, "Invalid redirect URL! %s", new_path); \
+				goto out; \
+			} \
+			s++; \
+		} \
+	} \
+}
+			/* check for control characters in login, password & path */
+			if (strncasecmp(new_path, "http://", sizeof("http://") - 1) || strncasecmp(new_path, "https://", sizeof("https://") - 1)) {
+				CHECK_FOR_CNTRL_CHARS(resource->user);
+				CHECK_FOR_CNTRL_CHARS(resource->pass);
+				CHECK_FOR_CNTRL_CHARS(resource->path);
+			}
+			threaded_stream = pthreads_stream_url_wrap_http_ex(
+				threaded_wrapper, new_path, mode, options, opened_path, threaded_context,
+				--redirect_max, HTTP_WRAPPER_REDIRECTED, response_header, ce);
+		} else {
+			pthreads_stream_wrapper_log_error(threaded_wrapper, options, "HTTP request failed! %s", tmp_line);
+		}
+	}
+out:
+
+	smart_str_free(&req_buf);
+
+	if (http_header_line) {
+		efree(http_header_line);
+	}
+
+	if (resource) {
+		pthreads_url_free(resource);
+	}
+
+	if (threaded_stream) {
+		stream = PTHREADS_FETCH_STREAMS_STREAM(threaded_stream);
+
+		if (header_init) {
+			pthreads_stream_set_wrapperdata(threaded_stream, pthreads_array_to_volatile_map(response_header));
+		}
+		pthreads_stream_notify_progress_init(threaded_context, 0, file_size);
+
+		/* Restore original chunk size now that we're done with headers */
+		if (options & PTHREADS_STREAM_WILL_CAST)
+			pthreads_stream_set_chunk_size(threaded_stream, (int)chunk_size);
+
+		/* restore the users auto-detect-line-endings setting */
+		stream->flags |= eol_detect;
+
+		/* as far as streams are concerned, we are now at the start of
+		 * the stream */
+		stream->position = 0;
+
+		/* restore mode */
+		strlcpy(stream->mode, mode, sizeof(stream->mode));
+
+		if (threaded_transfer_encoding) {
+			pthreads_stream_filter_append(pthreads_stream_get_readfilters(threaded_stream), threaded_transfer_encoding);
+		}
+	} else {
+		if (threaded_transfer_encoding) {
+			pthreads_ptr_dtor(threaded_transfer_encoding);
+		}
+	}
+
+	return threaded_stream;
+}
+/* }}} */
+
+pthreads_stream_t *pthreads_stream_url_wrap_http(pthreads_stream_wrapper_t *threaded_wrapper, const char *path,
+		const char *mode, int options, zend_string **opened_path, pthreads_stream_context_t *threaded_context, zend_class_entry *ce) /* {{{ */
+{
+	pthreads_stream_t *threaded_stream;
+	zval headers;
+	ZVAL_UNDEF(&headers);
+
+	threaded_stream = pthreads_stream_url_wrap_http_ex(
+		threaded_wrapper, path, mode, options, opened_path, threaded_context,
+		PHP_URL_REDIRECT_MAX, HTTP_WRAPPER_HEADER_INIT, &headers, ce);
+
+	if (!Z_ISUNDEF(headers)) {
+		if (FAILURE == zend_set_local_var_str(
+				"http_response_header", sizeof("http_response_header")-1, &headers, 1)) {
+			zval_ptr_dtor(&headers);
+		}
+	}
+
+	return threaded_stream;
+}
+/* }}} */
+
+static int pthreads_stream_http_stream_stat(pthreads_stream_wrapper_t *threaded_wrapper, pthreads_stream_t *threaded_stream, pthreads_stream_statbuf *ssb) /* {{{ */
+{
+	/* one day, we could fill in the details based on Date: and Content-Length:
+	 * headers.  For now, we return with a failure code to prevent the underlying
+	 * file's details from being used instead. */
+	return -1;
+}
+/* }}} */
+
+const pthreads_stream_wrapper_ops pthreads_http_stream_wops = {
+	pthreads_stream_url_wrap_http,
+	NULL, /* stream_close */
+	pthreads_stream_http_stream_stat,
+	NULL, /* stat_url */
+	NULL, /* opendir */
+	"http",
+	NULL, /* unlink */
+	NULL, /* rename */
+	NULL, /* mkdir */
+	NULL, /* rmdir */
+	NULL
+};
+
+#endif

--- a/src/streams/wrappers/plain_wrapper.c
+++ b/src/streams/wrappers/plain_wrapper.c
@@ -1,0 +1,1738 @@
+/*
+  +----------------------------------------------------------------------+
+  | pthreads                                                             |
+  +----------------------------------------------------------------------+
+  | Copyright (c) Joe Watkins 2018                                       |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | http://www.php.net/license/3_01.txt                                  |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors: Bastian Schneider <b.schneider@badnoob.com>                 |
+  | Borrowed code from php-src                                           |
+  +----------------------------------------------------------------------+
+ */
+#ifndef HAVE_PTHREADS_STREAMS_WRAPPERS_PLAIN_WRAPPER
+#define HAVE_PTHREADS_STREAMS_WRAPPERS_PLAIN_WRAPPER
+
+#ifndef HAVE_PTHREADS_H
+#	include <src/pthreads.h>
+#endif
+
+#ifndef HAVE_PTHREADS_STREAM_H
+#	include <src/streams.h>
+#endif
+
+#include "php_open_temporary_file.h" // ok
+#include "ext/standard/file.h"
+#include <stddef.h>
+#include <fcntl.h>
+#if HAVE_SYS_WAIT_H
+#include <sys/wait.h>
+#endif
+#if HAVE_SYS_FILE_H
+#include <sys/file.h>
+#endif
+#ifdef HAVE_SYS_MMAN_H
+#include <sys/mman.h>
+#endif
+
+#ifndef HAVE_PTHREADS_STREAMS_INTERNAL_H
+#	include <src/streams/internal.h>
+#endif
+
+#ifdef PHP_WIN32
+# include "win32/winutil.h"
+# include "win32/time.h"
+# include "win32/ioutil.h"
+# include "win32/readdir.h"
+#endif
+
+#ifndef HAVE_PTHREADS_SOCKET
+#	include <src/socket.h>
+#endif
+
+#define pthreads_stream_fopen_from_fd_int(fd, mode)	_pthreads_stream_fopen_from_fd_int((fd), (mode))
+#define pthreads_stream_fopen_from_file_int(file, mode)	_pthreads_stream_fopen_from_file_int((file), (mode))
+
+#ifndef PHP_WIN32
+extern int php_get_uid_by_name(const char *name, uid_t *uid);
+extern int php_get_gid_by_name(const char *name, gid_t *gid);
+#endif
+
+#if defined(PHP_WIN32)
+# define PTHREADS_PLAIN_WRAP_BUF_SIZE(st) (((st) > UINT_MAX) ? UINT_MAX : (unsigned int)(st))
+#else
+# define PTHREADS_PLAIN_WRAP_BUF_SIZE(st) (st)
+#endif
+
+/* parse standard "fopen" modes into open() flags */
+int pthreads_stream_parse_fopen_modes(const char *mode, int *open_flags)
+{
+	int flags;
+
+	switch (mode[0]) {
+		case 'r':
+			flags = 0;
+			break;
+		case 'w':
+			flags = O_TRUNC|O_CREAT;
+			break;
+		case 'a':
+			flags = O_CREAT|O_APPEND;
+			break;
+		case 'x':
+			flags = O_CREAT|O_EXCL;
+			break;
+		case 'c':
+			flags = O_CREAT;
+			break;
+		default:
+			/* unknown mode */
+			return FAILURE;
+	}
+
+	if (strchr(mode, '+')) {
+		flags |= O_RDWR;
+	} else if (flags) {
+		flags |= O_WRONLY;
+	} else {
+		flags |= O_RDONLY;
+	}
+
+#if defined(O_CLOEXEC)
+	if (strchr(mode, 'e')) {
+		flags |= O_CLOEXEC;
+	}
+#endif
+
+#if defined(O_NONBLOCK)
+	if (strchr(mode, 'n')) {
+		flags |= O_NONBLOCK;
+	}
+#endif
+
+#if defined(_O_TEXT) && defined(O_BINARY)
+	if (strchr(mode, 't')) {
+		flags |= _O_TEXT;
+	} else {
+		flags |= O_BINARY;
+	}
+#endif
+
+	*open_flags = flags;
+	return SUCCESS;
+}
+
+
+/* {{{ ------- STDIO stream implementation -------*/
+
+typedef struct {
+	FILE *file;
+	int fd;					/* underlying file descriptor */
+	unsigned is_process_pipe:1;	/* use pclose instead of fclose */
+	unsigned is_pipe:1;			/* don't try and seek */
+	unsigned cached_fstat:1;	/* sb is valid */
+	unsigned is_pipe_blocking:1; /* allow blocking read() on pipes, currently Windows only */
+	unsigned _reserved:28;
+
+	int lock_flag;			/* stores the lock state */
+	zend_string *temp_name;	/* if non-null, this is the path to a temporary file that
+							 * is to be deleted when the stream is closed */
+#if HAVE_FLUSHIO
+	char last_op;
+#endif
+
+#if HAVE_MMAP
+	char *last_mapped_addr;
+	size_t last_mapped_len;
+#endif
+#ifdef PHP_WIN32
+	char *last_mapped_addr;
+	HANDLE file_mapping;
+#endif
+
+	zend_stat_t sb;
+} pthreads_stdio_stream_data;
+#define PTHREADS_STDIOP_GET_FD(anfd, data)	anfd = (data)->file ? fileno((data)->file) : (data)->fd
+
+static int do_fstat(pthreads_stdio_stream_data *d, int force)
+{
+	if (!d->cached_fstat || force) {
+		int fd;
+		int r;
+
+		PTHREADS_STDIOP_GET_FD(fd, d);
+		r = zend_fstat(fd, &d->sb);
+		d->cached_fstat = r == 0;
+
+		return r;
+	}
+	return 0;
+}
+
+static pthreads_stream_t *_pthreads_stream_fopen_from_fd_int(int fd, const char *mode) {
+	pthreads_stdio_stream_data *self;
+
+	self = malloc(sizeof(*self));
+	memset(self, 0, sizeof(*self));
+	self->file = NULL;
+	self->is_pipe = 0;
+	self->lock_flag = LOCK_UN;
+	self->is_process_pipe = 0;
+	self->temp_name = NULL;
+	self->fd = fd;
+#ifdef PHP_WIN32
+	self->is_pipe_blocking = 0;
+#endif
+
+	return PTHREADS_STREAM_CLASS_NEW(&pthreads_stream_stdio_ops, self, mode, pthreads_file_stream_entry);
+}
+
+static pthreads_stream_t *_pthreads_stream_fopen_from_file_int(FILE *file, const char *mode) {
+	pthreads_stdio_stream_data *self;
+
+	self = malloc(sizeof(*self));
+	memset(self, 0, sizeof(*self));
+	self->file = file;
+	self->is_pipe = 0;
+	self->lock_flag = LOCK_UN;
+	self->is_process_pipe = 0;
+	self->temp_name = NULL;
+	self->fd = fileno(file);
+#ifdef PHP_WIN32
+	self->is_pipe_blocking = 0;
+#endif
+
+	return PTHREADS_STREAM_CLASS_NEW(&pthreads_stream_stdio_ops, self, mode, pthreads_file_stream_entry);
+}
+
+pthreads_stream_t *_pthreads_stream_fopen_temporary_file(const char *dir, const char *pfx, zend_string **opened_path_ptr) {
+	zend_string *opened_path, *tmp = NULL;
+	int fd;
+
+	fd = php_open_temporary_fd(dir, pfx, &opened_path);
+	if (fd != -1)	{
+		pthreads_stream_t *threaded_stream;
+
+		if(opened_path) {
+			tmp = zend_string_init(ZSTR_VAL(opened_path), ZSTR_LEN(opened_path), 1);
+			zend_string_release(opened_path);
+			opened_path = tmp;
+		}
+
+		if (opened_path_ptr) {
+			*opened_path_ptr = opened_path;
+		}
+
+		threaded_stream = pthreads_stream_fopen_from_fd_int(fd, "r+b");
+		if (threaded_stream) {
+			pthreads_stream *stream = PTHREADS_FETCH_STREAMS_STREAM(threaded_stream);
+			pthreads_stdio_stream_data *self = (pthreads_stdio_stream_data*)stream->abstract;
+
+			stream->wrapper = PTHREADS_STREAMG(plain_files_wrapper);
+			stream->orig_path = strndup(ZSTR_VAL(opened_path), ZSTR_LEN(opened_path));
+
+			self->temp_name = opened_path;
+			self->lock_flag = LOCK_UN;
+
+			return threaded_stream;
+		}
+		close(fd);
+
+		php_error_docref(NULL, E_WARNING, "unable to allocate stream");
+
+		return NULL;
+	}
+	return NULL;
+}
+
+pthreads_stream_t *_pthreads_stream_fopen_tmpfile(int dummy) {
+	return pthreads_stream_fopen_temporary_file(NULL, "php", NULL);
+}
+
+pthreads_stream_t *_pthreads_stream_fopen_from_fd(int fd, const char *mode) {
+	pthreads_stream_t *threaded_stream = pthreads_stream_fopen_from_fd_int(fd, mode);
+
+	if (threaded_stream) {
+		pthreads_stream *stream = PTHREADS_FETCH_STREAMS_STREAM(threaded_stream);
+		pthreads_stdio_stream_data *self = (pthreads_stdio_stream_data*)stream->abstract;
+
+#ifdef S_ISFIFO
+		/* detect if this is a pipe */
+		if (self->fd >= 0) {
+			self->is_pipe = (do_fstat(self, 0) == 0 && S_ISFIFO(self->sb.st_mode)) ? 1 : 0;
+		}
+#elif defined(PHP_WIN32)
+		{
+			zend_uintptr_t handle = _get_osfhandle(self->fd);
+
+			if (handle != (zend_uintptr_t)INVALID_HANDLE_VALUE) {
+				self->is_pipe = GetFileType((HANDLE)handle) == FILE_TYPE_PIPE;
+			}
+		}
+#endif
+
+		if (self->is_pipe) {
+			stream->flags |= PTHREADS_STREAM_FLAG_NO_SEEK;
+		} else {
+			stream->position = zend_lseek(self->fd, 0, SEEK_CUR);
+#ifdef ESPIPE
+			if (stream->position == (zend_off_t)-1 && errno == ESPIPE) {
+				stream->position = 0;
+				stream->flags |= PTHREADS_STREAM_FLAG_NO_SEEK;
+				self->is_pipe = 1;
+			}
+#endif
+		}
+	}
+
+	return threaded_stream;
+}
+
+pthreads_stream_t *_pthreads_stream_fopen_from_file(FILE *file, const char *mode) {
+	pthreads_stream_t *threaded_stream = pthreads_stream_fopen_from_file_int(file, mode);
+
+	if (threaded_stream) {
+		pthreads_stream *stream = PTHREADS_FETCH_STREAMS_STREAM(threaded_stream);
+		pthreads_stdio_stream_data *self = (pthreads_stdio_stream_data*)stream->abstract;
+
+#ifdef S_ISFIFO
+		/* detect if this is a pipe */
+		if (self->fd >= 0) {
+			self->is_pipe = (do_fstat(self, 0) == 0 && S_ISFIFO(self->sb.st_mode)) ? 1 : 0;
+		}
+#elif defined(PHP_WIN32)
+		{
+			zend_uintptr_t handle = _get_osfhandle(self->fd);
+
+			if (handle != (zend_uintptr_t)INVALID_HANDLE_VALUE) {
+				self->is_pipe = GetFileType((HANDLE)handle) == FILE_TYPE_PIPE;
+			}
+		}
+#endif
+
+		if (self->is_pipe) {
+			stream->flags |= PTHREADS_STREAM_FLAG_NO_SEEK;
+		} else {
+			stream->position = zend_ftell(file);
+		}
+	}
+
+	return threaded_stream;
+}
+
+pthreads_stream_t *_pthreads_stream_fopen_from_pipe(FILE *file, const char *mode, zend_class_entry *ce)
+{
+	pthreads_stdio_stream_data *self;
+	pthreads_stream_t *threaded_stream;
+	pthreads_stream *stream;
+
+	self = malloc(sizeof(*self));
+	memset(self, 0, sizeof(*self));
+	self->file = file;
+	self->is_pipe = 1;
+	self->lock_flag = LOCK_UN;
+	self->is_process_pipe = 1;
+	self->fd = fileno(file);
+	self->temp_name = NULL;
+#ifdef PHP_WIN32
+	self->is_pipe_blocking = 0;
+#endif
+
+	threaded_stream = PTHREADS_STREAM_CLASS_NEW(&pthreads_stream_stdio_ops, self, mode, ce);
+
+	stream = PTHREADS_FETCH_STREAMS_STREAM(threaded_stream);
+	stream->flags |= PTHREADS_STREAM_FLAG_NO_SEEK;
+
+	return threaded_stream;
+}
+
+static size_t pthreads_stdiop_write(pthreads_stream_t *threaded_stream, const char *buf, size_t count) {
+	pthreads_stream *stream = PTHREADS_FETCH_STREAMS_STREAM(threaded_stream);
+	pthreads_stdio_stream_data *data = NULL;
+
+	if(stream_lock(threaded_stream)) {
+		data = (pthreads_stdio_stream_data*)stream->abstract;
+
+		assert(data != NULL);
+
+		if (data->fd >= 0) {
+#ifdef PHP_WIN32
+			int bytes_written;
+			if (ZEND_SIZE_T_UINT_OVFL(count)) {
+				count = UINT_MAX;
+			}
+			bytes_written = _write(data->fd, buf, (unsigned int)count);
+#else
+			int bytes_written = write(data->fd, buf, count);
+#endif
+			stream_unlock(threaded_stream);
+
+			if (bytes_written < 0) {
+				return 0;
+			}
+			return (size_t) bytes_written;
+		} else {
+
+#if HAVE_FLUSHIO
+			if (!data->is_pipe && data->last_op == 'r') {
+				zend_fseek(data->file, 0, SEEK_CUR);
+			}
+			data->last_op = 'w';
+#endif
+			int bytes_written = fwrite(buf, 1, count, data->file);
+
+			stream_unlock(threaded_stream);
+
+			return bytes_written;
+		}
+	}
+}
+
+static size_t pthreads_stdiop_read(pthreads_stream_t *threaded_stream, char *buf, size_t count) {
+	pthreads_stream *stream = PTHREADS_FETCH_STREAMS_STREAM(threaded_stream);
+	pthreads_stdio_stream_data *data = NULL;
+	size_t ret;
+
+	if(stream_lock(threaded_stream)) {
+		data = (pthreads_stdio_stream_data*)stream->abstract;
+
+		assert(data != NULL);
+
+		if (data->fd >= 0) {
+#ifdef PHP_WIN32
+			php_stdio_stream_data *self = (php_stdio_stream_data*)stream->abstract;
+
+			if ((self->is_pipe || self->is_process_pipe) && !self->is_pipe_blocking) {
+				HANDLE ph = (HANDLE)_get_osfhandle(data->fd);
+				int retry = 0;
+				DWORD avail_read = 0;
+
+				do {
+					/* Look ahead to get the available data amount to read. Do the same
+						as read() does, however not blocking forever. In case it failed,
+						no data will be read (better than block). */
+					if (!PeekNamedPipe(ph, NULL, 0, NULL, &avail_read, NULL)) {
+						break;
+					}
+					/* If there's nothing to read, wait in 10ms periods. */
+					if (0 == avail_read) {
+						usleep(10);
+					}
+				} while (0 == avail_read && retry++ < 3200000);
+
+				/* Reduce the required data amount to what is available, otherwise read()
+					will block.*/
+				if (avail_read < count) {
+					count = avail_read;
+				}
+			}
+#endif
+			ret = read(data->fd, buf, PTHREADS_PLAIN_WRAP_BUF_SIZE(count));
+
+			if (ret == (size_t)-1 && errno == EINTR) {
+				/* Read was interrupted, retry once,
+				   If read still fails, giveup with feof==0
+				   so script can retry if desired */
+				ret = read(data->fd, buf,  PTHREADS_PLAIN_WRAP_BUF_SIZE(count));
+			}
+
+			stream->eof = (ret == 0 || (ret == (size_t)-1 && errno != EWOULDBLOCK && errno != EINTR && errno != EBADF));
+
+		} else {
+#if HAVE_FLUSHIO
+			if (!data->is_pipe && data->last_op == 'w')
+				zend_fseek(data->file, 0, SEEK_CUR);
+			data->last_op = 'r';
+#endif
+
+			ret = fread(buf, 1, count, data->file);
+
+			stream->eof = feof(data->file);
+		}
+		stream_unlock(threaded_stream);
+	}
+	return ret;
+}
+
+static int pthreads_stdiop_close(pthreads_stream_t *threaded_stream, int close_handle) {
+	int ret;
+	pthreads_stream *stream = PTHREADS_FETCH_STREAMS_STREAM(threaded_stream);
+	pthreads_stdio_stream_data *data = (pthreads_stdio_stream_data*)stream->abstract;
+
+	assert(data != NULL);
+
+#if HAVE_MMAP
+	if (data->last_mapped_addr) {
+		munmap(data->last_mapped_addr, data->last_mapped_len);
+		data->last_mapped_addr = NULL;
+	}
+#elif defined(PHP_WIN32)
+	if (data->last_mapped_addr) {
+		UnmapViewOfFile(data->last_mapped_addr);
+		data->last_mapped_addr = NULL;
+	}
+	if (data->file_mapping) {
+		CloseHandle(data->file_mapping);
+		data->file_mapping = NULL;
+	}
+#endif
+
+	if (close_handle) {
+		if (data->file) {
+			if (data->is_process_pipe) {
+				errno = 0;
+				ret = pclose(data->file);
+
+#if HAVE_SYS_WAIT_H
+				if (WIFEXITED(ret)) {
+					ret = WEXITSTATUS(ret);
+				}
+#endif
+			} else {
+				ret = fclose(data->file);
+				data->file = NULL;
+			}
+		} else if (data->fd != -1) {
+			ret = close(data->fd);
+			data->fd = -1;
+		} else {
+			stream_unlock(threaded_stream);
+			return 0; /* everything should be closed already -> success */
+		}
+
+		if (data->temp_name) {
+#ifdef PHP_WIN32
+			php_win32_ioutil_unlink(ZSTR_VAL(data->temp_name));
+#else
+			unlink(ZSTR_VAL(data->temp_name));
+#endif
+		}
+	} else {
+		ret = 0;
+		data->file = NULL;
+		data->fd = -1;
+	}
+
+	return ret;
+}
+
+static void pthreads_stdiop_free(pthreads_stream_t *threaded_stream, int close_handle) {
+	pthreads_stream *stream = PTHREADS_FETCH_STREAMS_STREAM(threaded_stream);
+	pthreads_stdio_stream_data *data = (pthreads_stdio_stream_data*)stream->abstract;
+
+	assert(data != NULL);
+
+	if (close_handle) {
+
+		if (data->temp_name) {
+			zend_string_release(data->temp_name);
+			data->temp_name = NULL;
+		}
+	}
+	free(data);
+
+	stream->abstract = NULL;
+}
+
+static int pthreads_stdiop_flush(pthreads_stream_t *threaded_stream) {
+	pthreads_stream *stream = PTHREADS_FETCH_STREAMS_STREAM(threaded_stream);
+	pthreads_stdio_stream_data *data = NULL;
+
+	if(stream_lock(threaded_stream)) {
+		data = (pthreads_stdio_stream_data*)stream->abstract;
+
+		assert(data != NULL);
+
+		/*
+		 * stdio buffers data in user land. By calling fflush(3), this
+		 * data is send to the kernel using write(2). fsync'ing is
+		 * something completely different.
+		 */
+		if (data->file) {
+			int result = fflush(data->file);
+
+			stream_unlock(threaded_stream);
+
+			return result;
+		}
+		stream_unlock(threaded_stream);
+	}
+	return 0;
+}
+
+static int pthreads_stdiop_seek(pthreads_stream_t *threaded_stream, zend_off_t offset, int whence, zend_off_t *newoffset) {
+	pthreads_stream *stream = PTHREADS_FETCH_STREAMS_STREAM(threaded_stream);
+	pthreads_stdio_stream_data *data = NULL;
+	int ret;
+
+	if(stream_lock(threaded_stream)) {
+		data = (pthreads_stdio_stream_data*)stream->abstract;
+
+		assert(data != NULL);
+
+		if (data->is_pipe) {
+			stream_unlock(threaded_stream);
+			php_error_docref(NULL, E_WARNING, "cannot seek on a pipe");
+			return -1;
+		}
+
+		if (data->fd >= 0) {
+			zend_off_t result;
+
+			result = zend_lseek(data->fd, offset, whence);
+			if (result == (zend_off_t)-1) {
+				stream_unlock(threaded_stream);
+				return -1;
+			}
+			*newoffset = result;
+			stream_unlock(threaded_stream);
+			return 0;
+
+		} else {
+			ret = zend_fseek(data->file, offset, whence);
+			*newoffset = zend_ftell(data->file);
+			stream_unlock(threaded_stream);
+			return ret;
+		}
+	}
+}
+
+static int pthreads_stdiop_cast(pthreads_stream_t *threaded_stream, int castas, void **ret) {
+	php_socket_t fd;
+	pthreads_stream *stream = PTHREADS_FETCH_STREAMS_STREAM(threaded_stream);
+	pthreads_stdio_stream_data *data = NULL;
+
+	if(stream_lock(threaded_stream)) {
+		data = (pthreads_stdio_stream_data*)stream->abstract;
+
+		assert(data != NULL);
+
+		/* as soon as someone touches the stdio layer, buffering may ensue,
+		 * so we need to stop using the fd directly in that case */
+
+		switch (castas)	{
+			case PTHREADS_STREAM_AS_STDIO:
+				if (ret) {
+					if (data->file == NULL) {
+						/* we were opened as a plain file descriptor, so we
+						 * need fdopen now */
+						char fixed_mode[5];
+						pthreads_stream_mode_sanitize_fdopen_fopencookie(threaded_stream, fixed_mode);
+						data->file = fdopen(data->fd, fixed_mode);
+						if (data->file == NULL) {
+							stream_unlock(threaded_stream);
+							return FAILURE;
+						}
+					}
+
+					*(FILE**)ret = data->file;
+					data->fd = SOCK_ERR;
+				}
+				stream_unlock(threaded_stream);
+
+				return SUCCESS;
+
+			case PTHREADS_STREAM_AS_FD_FOR_SELECT:
+				PTHREADS_STDIOP_GET_FD(fd, data);
+				if (PTHREADS_INVALID_SOCKET == fd) {
+					stream_unlock(threaded_stream);
+
+					return FAILURE;
+				}
+				if (ret) {
+					*(php_socket_t *)ret = fd;
+				}
+				stream_unlock(threaded_stream);
+
+				return SUCCESS;
+
+			case PTHREADS_STREAM_AS_FD:
+				PTHREADS_STDIOP_GET_FD(fd, data);
+
+				if (PTHREADS_INVALID_SOCKET == fd) {
+					stream_unlock(threaded_stream);
+
+					return FAILURE;
+				}
+				if (data->file) {
+					fflush(data->file);
+				}
+				if (ret) {
+					*(php_socket_t *)ret = fd;
+				}
+				stream_unlock(threaded_stream);
+
+				return SUCCESS;
+			default:
+				stream_unlock(threaded_stream);
+				return FAILURE;
+		}
+	}
+}
+
+static int pthreads_stdiop_stat(pthreads_stream_t *threaded_stream, pthreads_stream_statbuf *ssb) {
+	int ret;
+	pthreads_stream *stream = PTHREADS_FETCH_STREAMS_STREAM(threaded_stream);
+	pthreads_stdio_stream_data *data = NULL;
+
+	if(stream_lock(threaded_stream)) {
+		data = (pthreads_stdio_stream_data*)stream->abstract;
+
+		assert(data != NULL);
+		if((ret = do_fstat(data, 1)) == 0) {
+			memcpy(&ssb->sb, &data->sb, sizeof(ssb->sb));
+		}
+		stream_unlock(threaded_stream);
+	}
+	return ret;
+}
+
+static int pthreads_stdiop_set_option(pthreads_stream_t *threaded_stream, int option, int value, void *ptrparam) {
+
+	pthreads_stream *stream = PTHREADS_FETCH_STREAMS_STREAM(threaded_stream);
+	pthreads_stdio_stream_data *data = NULL;
+
+	if(stream_lock(threaded_stream)) {
+		data = (pthreads_stdio_stream_data*) stream->abstract;
+		size_t size;
+		int fd;
+		int result = -1;
+#ifdef O_NONBLOCK
+		/* FIXME: make this work for win32 */
+		int flags;
+		int oldval;
+#endif
+
+		PTHREADS_STDIOP_GET_FD(fd, data);
+
+		switch(option) {
+			case PTHREADS_STREAM_OPTION_BLOCKING:
+				if (fd == -1) {
+					stream_unlock(threaded_stream);
+					return -1;
+				}
+#ifdef O_NONBLOCK
+				flags = fcntl(fd, F_GETFL, 0);
+				oldval = (flags & O_NONBLOCK) ? 0 : 1;
+				if (value)
+					flags &= ~O_NONBLOCK;
+				else
+					flags |= O_NONBLOCK;
+
+				if (-1 == fcntl(fd, F_SETFL, flags)) {
+					stream_unlock(threaded_stream);
+					return -1;
+				}
+				stream_unlock(threaded_stream);
+				return oldval;
+#else
+				stream_unlock(threaded_stream);
+				return -1; /* not yet implemented */
+#endif
+
+			case PTHREADS_STREAM_OPTION_WRITE_BUFFER:
+
+				if (data->file == NULL) {
+					stream_unlock(threaded_stream);
+					return -1;
+				}
+
+				if (ptrparam)
+					size = *(size_t *)ptrparam;
+				else
+					size = BUFSIZ;
+
+				switch(value) {
+					case PTHREADS_STREAM_BUFFER_NONE:
+						result = setvbuf(data->file, NULL, _IONBF, 0);
+						break;
+
+					case PTHREADS_STREAM_BUFFER_LINE:
+						result = setvbuf(data->file, NULL, _IOLBF, size);
+						break;
+
+					case PTHREADS_STREAM_BUFFER_FULL:
+						result = setvbuf(data->file, NULL, _IOFBF, size);
+						break;
+				}
+				stream_unlock(threaded_stream);
+
+				return result;
+
+			case PTHREADS_STREAM_OPTION_LOCKING:
+				if (fd == -1) {
+					stream_unlock(threaded_stream);
+					return -1;
+				}
+
+				if ((zend_uintptr_t) ptrparam == PTHREADS_STREAM_LOCK_SUPPORTED) {
+					stream_unlock(threaded_stream);
+					return 0;
+				}
+
+				if (!flock(fd, value)) {
+					data->lock_flag = value;
+					stream_unlock(threaded_stream);
+					return 0;
+				} else {
+					stream_unlock(threaded_stream);
+					return -1;
+				}
+				break;
+
+			case PTHREADS_STREAM_OPTION_MMAP_API:
+#if HAVE_MMAP
+				{
+					pthreads_stream_mmap_range *range = (pthreads_stream_mmap_range*)ptrparam;
+					int prot, flags;
+
+					switch (value) {
+						case PTHREADS_STREAM_MMAP_SUPPORTED:
+							stream_unlock(threaded_stream);
+							return fd == -1 ? PTHREADS_STREAM_OPTION_RETURN_ERR : PTHREADS_STREAM_OPTION_RETURN_OK;
+
+						case PTHREADS_STREAM_MMAP_MAP_RANGE:
+							if(do_fstat(data, 1) != 0) {
+								stream_unlock(threaded_stream);
+								return PTHREADS_STREAM_OPTION_RETURN_ERR;
+							}
+							if (range->length == 0 && range->offset > 0 && range->offset < data->sb.st_size) {
+								range->length = data->sb.st_size - range->offset;
+							}
+							if (range->length == 0 || range->length > data->sb.st_size) {
+								range->length = data->sb.st_size;
+							}
+							if (range->offset >= data->sb.st_size) {
+								range->offset = data->sb.st_size;
+								range->length = 0;
+							}
+							switch (range->mode) {
+								case PTHREADS_STREAM_MAP_MODE_READONLY:
+									prot = PROT_READ;
+									flags = MAP_PRIVATE;
+									break;
+								case PTHREADS_STREAM_MAP_MODE_READWRITE:
+									prot = PROT_READ | PROT_WRITE;
+									flags = MAP_PRIVATE;
+									break;
+								case PTHREADS_STREAM_MAP_MODE_SHARED_READONLY:
+									prot = PROT_READ;
+									flags = MAP_SHARED;
+									break;
+								case PTHREADS_STREAM_MAP_MODE_SHARED_READWRITE:
+									prot = PROT_READ | PROT_WRITE;
+									flags = MAP_SHARED;
+									break;
+								default:
+									stream_unlock(threaded_stream);
+									return PTHREADS_STREAM_OPTION_RETURN_ERR;
+							}
+							range->mapped = (char*)mmap(NULL, range->length, prot, flags, fd, range->offset);
+							if (range->mapped == (char*)MAP_FAILED) {
+								range->mapped = NULL;
+								stream_unlock(threaded_stream);
+								return PTHREADS_STREAM_OPTION_RETURN_ERR;
+							}
+							/* remember the mapping */
+							data->last_mapped_addr = range->mapped;
+							data->last_mapped_len = range->length;
+							stream_unlock(threaded_stream);
+
+							return PTHREADS_STREAM_OPTION_RETURN_OK;
+
+						case PTHREADS_STREAM_MMAP_UNMAP:
+							if (data->last_mapped_addr) {
+								munmap(data->last_mapped_addr, data->last_mapped_len);
+								data->last_mapped_addr = NULL;
+								stream_unlock(threaded_stream);
+
+								return PTHREADS_STREAM_OPTION_RETURN_OK;
+							}
+							return PTHREADS_STREAM_OPTION_RETURN_ERR;
+					}
+				}
+#elif defined(PHP_WIN32)
+				{
+					pthreads_stream_mmap_range *range = (pthreads_stream_mmap_range*)ptrparam;
+					HANDLE hfile = (HANDLE)_get_osfhandle(fd);
+					DWORD prot, acc, loffs = 0, delta = 0;
+
+					switch (value) {
+						case PTHREADS_STREAM_MMAP_SUPPORTED:
+							stream_unlock(threaded_stream);
+							return hfile == INVALID_HANDLE_VALUE ? PTHREADS_STREAM_OPTION_RETURN_ERR : PTHREADS_STREAM_OPTION_RETURN_OK;
+
+						case PTHREADS_STREAM_MMAP_MAP_RANGE:
+							switch (range->mode) {
+								case PTHREADS_STREAM_MAP_MODE_READONLY:
+									prot = PAGE_READONLY;
+									acc = FILE_MAP_READ;
+									break;
+								case PTHREADS_STREAM_MAP_MODE_READWRITE:
+									prot = PAGE_READWRITE;
+									acc = FILE_MAP_READ | FILE_MAP_WRITE;
+									break;
+								case PTHREADS_STREAM_MAP_MODE_SHARED_READONLY:
+									prot = PAGE_READONLY;
+									acc = FILE_MAP_READ;
+									/* TODO: we should assign a name for the mapping */
+									break;
+								case PTHREADS_STREAM_MAP_MODE_SHARED_READWRITE:
+									prot = PAGE_READWRITE;
+									acc = FILE_MAP_READ | FILE_MAP_WRITE;
+									/* TODO: we should assign a name for the mapping */
+									break;
+								default:
+									stream_unlock(threaded_stream);
+									return PTHREADS_STREAM_OPTION_RETURN_ERR;
+							}
+
+							/* create a mapping capable of viewing the whole file (this costs no real resources) */
+							data->file_mapping = CreateFileMapping(hfile, NULL, prot, 0, 0, NULL);
+
+							if (data->file_mapping == NULL) {
+								return PTHREADS_STREAM_OPTION_RETURN_ERR;
+							}
+
+							size = GetFileSize(hfile, NULL);
+							if (range->length == 0 && range->offset > 0 && range->offset < size) {
+								range->length = size - range->offset;
+							}
+							if (range->length == 0 || range->length > size) {
+								range->length = size;
+							}
+							if (range->offset >= size) {
+								range->offset = size;
+								range->length = 0;
+							}
+
+							/* figure out how big a chunk to map to be able to view the part that we need */
+							if (range->offset != 0) {
+								SYSTEM_INFO info;
+								DWORD gran;
+
+								GetSystemInfo(&info);
+								gran = info.dwAllocationGranularity;
+								loffs = ((DWORD)range->offset / gran) * gran;
+								delta = (DWORD)range->offset - loffs;
+							}
+
+							data->last_mapped_addr = MapViewOfFile(data->file_mapping, acc, 0, loffs, range->length + delta);
+
+							if (data->last_mapped_addr) {
+								/* give them back the address of the start offset they requested */
+								range->mapped = data->last_mapped_addr + delta;
+								stream_unlock(threaded_stream);
+
+								return PTHREADS_STREAM_OPTION_RETURN_OK;
+							}
+
+							CloseHandle(data->file_mapping);
+							data->file_mapping = NULL;
+							stream_unlock(threaded_stream);
+
+							return PTHREADS_STREAM_OPTION_RETURN_ERR;
+
+						case PTHREADS_STREAM_MMAP_UNMAP:
+							if (data->last_mapped_addr) {
+								UnmapViewOfFile(data->last_mapped_addr);
+								data->last_mapped_addr = NULL;
+								CloseHandle(data->file_mapping);
+								data->file_mapping = NULL;
+								stream_unlock(threaded_stream);
+
+								return PTHREADS_STREAM_OPTION_RETURN_OK;
+							}
+							stream_unlock(threaded_stream);
+
+							return PTHREADS_STREAM_OPTION_RETURN_ERR;
+
+						default:
+							return PTHREADS_STREAM_OPTION_RETURN_ERR;
+					}
+				}
+
+#endif
+				stream_unlock(threaded_stream);
+
+				return PTHREADS_STREAM_OPTION_RETURN_NOTIMPL;
+
+			case PTHREADS_STREAM_OPTION_TRUNCATE_API:
+				switch (value) {
+					case PTHREADS_STREAM_TRUNCATE_SUPPORTED:
+						stream_unlock(threaded_stream);
+
+						return fd == -1 ? PTHREADS_STREAM_OPTION_RETURN_ERR : PTHREADS_STREAM_OPTION_RETURN_OK;
+
+					case PTHREADS_STREAM_TRUNCATE_SET_SIZE: {
+						ptrdiff_t new_size = *(ptrdiff_t*)ptrparam;
+						if (new_size < 0) {
+							stream_unlock(threaded_stream);
+
+							return PTHREADS_STREAM_OPTION_RETURN_ERR;
+						}
+#ifdef PHP_WIN32
+						HANDLE h = (HANDLE) _get_osfhandle(fd);
+						if (INVALID_HANDLE_VALUE == h) {
+							stream_unlock(threaded_stream);
+
+							return PTHREADS_STREAM_OPTION_RETURN_ERR;
+						}
+
+						LARGE_INTEGER sz, old_sz;
+						sz.QuadPart = 0;
+
+						if (!SetFilePointerEx(h, sz, &old_sz, FILE_CURRENT)) {
+							stream_unlock(threaded_stream);
+
+							return PTHREADS_STREAM_OPTION_RETURN_ERR;
+						}
+
+#if defined(_WIN64)
+						sz.HighPart = (new_size >> 32);
+						sz.LowPart = (new_size & 0xffffffff);
+#else
+						sz.HighPart = 0;
+						sz.LowPart = new_size;
+#endif
+						if (INVALID_SET_FILE_POINTER == SetFilePointerEx(h, sz, NULL, FILE_BEGIN) && NO_ERROR != GetLastError()) {
+							stream_unlock(threaded_stream);
+
+							return PTHREADS_STREAM_OPTION_RETURN_ERR;
+						}
+						if (0 == SetEndOfFile(h)) {
+							stream_unlock(threaded_stream);
+
+							return PTHREADS_STREAM_OPTION_RETURN_ERR;
+						}
+						if (INVALID_SET_FILE_POINTER == SetFilePointerEx(h, old_sz, NULL, FILE_BEGIN) && NO_ERROR != GetLastError()) {
+							stream_unlock(threaded_stream);
+
+							return PTHREADS_STREAM_OPTION_RETURN_ERR;
+						}
+						stream_unlock(threaded_stream);
+
+						return PTHREADS_STREAM_OPTION_RETURN_OK;
+#else
+						stream_unlock(threaded_stream);
+
+						return ftruncate(fd, new_size) == 0 ? PTHREADS_STREAM_OPTION_RETURN_OK : PTHREADS_STREAM_OPTION_RETURN_ERR;
+#endif
+					}
+				}
+
+#ifdef PHP_WIN32
+			case PTHREADS_STREAM_OPTION_PIPE_BLOCKING:
+				data->is_pipe_blocking = value;
+				stream_unlock(threaded_stream);
+
+				return PTHREADS_STREAM_OPTION_RETURN_OK;
+#endif
+			case PTHREADS_STREAM_OPTION_META_DATA_API:
+				if (fd == -1) {
+					stream_unlock(threaded_stream);
+
+					return -1;
+				}
+#ifdef O_NONBLOCK
+				flags = fcntl(fd, F_GETFL, 0);
+
+				add_assoc_bool((zval*)ptrparam, "timed_out", 0);
+				add_assoc_bool((zval*)ptrparam, "blocked", (flags & O_NONBLOCK)? 0 : 1);
+				add_assoc_bool((zval*)ptrparam, "eof", stream->eof);
+				stream_unlock(threaded_stream);
+
+				return PTHREADS_STREAM_OPTION_RETURN_OK;
+#endif
+				return -1;
+			default:
+				stream_unlock(threaded_stream);
+				return PTHREADS_STREAM_OPTION_RETURN_NOTIMPL;
+		}
+	}
+}
+
+/* This should be "const", but phpdbg overwrite it */
+pthreads_stream_ops pthreads_stream_stdio_ops = {
+	pthreads_stdiop_write, pthreads_stdiop_read,
+	pthreads_stdiop_close, pthreads_stdiop_free,
+	pthreads_stdiop_flush,
+	"STDIO",
+	pthreads_stdiop_seek,
+	pthreads_stdiop_cast,
+	pthreads_stdiop_stat,
+	pthreads_stdiop_set_option
+};
+/* }}} */
+
+/* {{{ plain files opendir/readdir implementation */
+static size_t pthreads_plain_files_dirstream_read(pthreads_stream_t *threaded_stream, char *buf, size_t count) {
+	pthreads_stream *stream = PTHREADS_FETCH_STREAMS_STREAM(threaded_stream);
+
+	if(stream_lock(threaded_stream)) {
+		DIR *dir = (DIR*)stream->abstract;
+		/* avoid libc5 readdir problems */
+		char entry[sizeof(struct dirent)+MAXPATHLEN];
+		struct dirent *result = (struct dirent *)&entry;
+		pthreads_stream_dirent *ent = (pthreads_stream_dirent*)buf;
+
+		/* avoid problems if someone mis-uses the stream */
+		if (count != sizeof(pthreads_stream_dirent)) {
+			stream_unlock(threaded_stream);
+			return 0;
+		}
+
+		if (php_readdir_r(dir, (struct dirent *)entry, &result) == 0 && result) {
+			PHP_STRLCPY(ent->d_name, result->d_name, sizeof(ent->d_name), strlen(result->d_name));
+			stream_unlock(threaded_stream);
+			return sizeof(pthreads_stream_dirent);
+		}
+		stream_unlock(threaded_stream);
+	}
+	return 0;
+}
+
+static int pthreads_plain_files_dirstream_close(pthreads_stream_t *threaded_stream, int close_handle) {
+	return closedir((DIR *)PTHREADS_FETCH_STREAMS_STREAM(threaded_stream)->abstract);
+}
+
+static void pthreads_plain_files_dirstream_free(pthreads_stream_t *threaded_stream, int close_handle) {}
+
+static int pthreads_plain_files_dirstream_rewind(pthreads_stream_t *threaded_stream, zend_off_t offset, int whence, zend_off_t *newoffs) {
+	if(stream_lock(threaded_stream)) {
+		rewinddir((DIR *)PTHREADS_FETCH_STREAMS_STREAM(threaded_stream)->abstract);
+		stream_unlock(threaded_stream);
+	}
+	return 0;
+}
+
+pthreads_stream_ops pthreads_plain_files_dirstream_ops = {
+	NULL, pthreads_plain_files_dirstream_read,
+	pthreads_plain_files_dirstream_close,
+	pthreads_plain_files_dirstream_free,
+	NULL,
+	"dir",
+	pthreads_plain_files_dirstream_rewind,
+	NULL, /* cast */
+	NULL, /* stat */
+	NULL  /* set_option */
+};
+
+static pthreads_stream_t *pthreads_plain_files_dir_opener(pthreads_stream_wrapper_t *threaded_wrapper, const char *path, const char *mode,
+		int options, zend_string **opened_path, pthreads_stream_context_t *threaded_context, zend_class_entry *ce) {
+
+	DIR *dir = NULL;
+	pthreads_stream_t *threaded_stream = NULL;
+
+#ifdef HAVE_GLOB
+	if (options & PTHREADS_STREAM_USE_GLOB_DIR_OPEN) {
+		pthreads_stream_wrapper_t *threaded_wrapper = PTHREADS_STREAMG(glob_stream_wrapper);
+
+		return PTHREADS_FETCH_STREAMS_WRAPPER(threaded_wrapper)->wops->dir_opener(threaded_wrapper, path, mode, options, opened_path, threaded_context, ce);
+	}
+#endif
+
+	if (((options & PTHREADS_STREAM_DISABLE_OPEN_BASEDIR) == 0) && php_check_open_basedir(path)) {
+		return NULL;
+	}
+
+	dir = VCWD_OPENDIR(path);
+
+#ifdef PHP_WIN32
+	if (!dir) {
+		php_win32_docref2_from_error(GetLastError(), path, path);
+	}
+
+	if (dir && dir->finished) {
+		closedir(dir);
+		dir = NULL;
+	}
+#endif
+	if (dir) {
+		threaded_stream = PTHREADS_STREAM_CLASS_NEW(&pthreads_plain_files_dirstream_ops, dir, mode, ce);
+		if (threaded_stream == NULL)
+			closedir(dir);
+	}
+
+	return threaded_stream;
+}
+/* }}} */
+
+/* {{{ pthreads_stream_fopen */
+pthreads_stream_t *_pthreads_stream_fopen(const char *filename, const char *mode, zend_string **opened_path, int options, zend_class_entry *ce) {
+	char realpath[MAXPATHLEN];
+	int open_flags;
+	int fd;
+	pthreads_stream *stream = NULL;
+	pthreads_stream_t *threaded_stream = NULL;
+	int persistent = options & PTHREADS_STREAM_OPEN_PERSISTENT;
+
+	if (FAILURE == pthreads_stream_parse_fopen_modes(mode, &open_flags)) {
+		if (options & PTHREADS_REPORT_ERRORS) {
+			php_error_docref(NULL, E_WARNING, "`%s' is not a valid mode for fopen", mode);
+		}
+		return NULL;
+	}
+
+	if (options & PTHREADS_STREAM_ASSUME_REALPATH) {
+		strlcpy(realpath, filename, sizeof(realpath));
+	} else {
+		if (expand_filepath(filename, realpath) == NULL) {
+			return NULL;
+		}
+	}
+
+#ifdef PHP_WIN32
+	fd = php_win32_ioutil_open(realpath, open_flags, 0666);
+#else
+	fd = open(realpath, open_flags, 0666);
+#endif
+	if (fd != -1)	{
+
+		if (options & PTHREADS_STREAM_OPEN_FOR_INCLUDE) {
+			threaded_stream = pthreads_stream_fopen_from_fd_int(fd, mode);
+		} else {
+			threaded_stream = pthreads_stream_fopen_from_fd(fd, mode);
+		}
+
+		if (threaded_stream)	{
+			if (opened_path) {
+				*opened_path = zend_string_init(realpath, strlen(realpath), 1);
+			}
+			stream = PTHREADS_FETCH_STREAMS_STREAM(threaded_stream);
+
+			/* WIN32 always set ISREG flag */
+#ifndef PHP_WIN32
+			/* sanity checks for include/require.
+			 * We check these after opening the stream, so that we save
+			 * on fstat() syscalls */
+			if (options & PTHREADS_STREAM_OPEN_FOR_INCLUDE) {
+				pthreads_stdio_stream_data *self = (pthreads_stdio_stream_data*)stream->abstract;
+				int r;
+
+				r = do_fstat(self, 0);
+				if ((r == 0 && !S_ISREG(self->sb.st_mode))) {
+					if (opened_path) {
+						zend_string_release(*opened_path);
+						*opened_path = NULL;
+					}
+					pthreads_stream_close(threaded_stream, PTHREADS_STREAM_FREE_CLOSE);
+					return NULL;
+				}
+			}
+
+			if (options & PTHREADS_STREAM_USE_BLOCKING_PIPE) {
+				pthreads_stdio_stream_data *self = (pthreads_stdio_stream_data*)stream->abstract;
+				self->is_pipe_blocking = 1;
+			}
+#endif
+
+			return threaded_stream;
+		}
+		close(fd);
+	}
+	return NULL;
+}
+/* }}} */
+
+
+static pthreads_stream_t *pthreads_plain_files_stream_opener(pthreads_stream_wrapper_t *threaded_wrapper, const char *path, const char *mode,
+		int options, zend_string **opened_path, pthreads_stream_context_t *threaded_context, zend_class_entry *ce)
+{
+	if (((options & PTHREADS_STREAM_DISABLE_OPEN_BASEDIR) == 0) && php_check_open_basedir(path)) {
+		return NULL;
+	}
+
+	return _pthreads_stream_fopen(path, mode, opened_path, options, ce);
+}
+
+static int pthreads_plain_files_url_stater(pthreads_stream_wrapper_t *threaded_wrapper, const char *url, int flags, pthreads_stream_statbuf *ssb, pthreads_stream_context_t *threaded_context)
+{
+	if (strncasecmp(url, "file://", sizeof("file://") - 1) == 0) {
+		url += sizeof("file://") - 1;
+	}
+
+	if (php_check_open_basedir_ex(url, (flags & PTHREADS_STREAM_URL_STAT_QUIET) ? 0 : 1)) {
+		return -1;
+	}
+
+#ifdef PHP_WIN32
+	if (flags & PTHREADS_STREAM_URL_STAT_LINK) {
+		return VCWD_LSTAT(url, &ssb->sb);
+	}
+#else
+# ifdef HAVE_SYMLINK
+	if (flags & PTHREADS_STREAM_URL_STAT_LINK) {
+		return VCWD_LSTAT(url, &ssb->sb);
+	} else
+# endif
+#endif
+		return VCWD_STAT(url, &ssb->sb);
+}
+
+static int pthreads_plain_files_unlink(pthreads_stream_wrapper_t *threaded_wrapper, const char *url, int options, pthreads_stream_context_t *threaded_context)
+{
+	int ret;
+
+	if (strncasecmp(url, "file://", sizeof("file://") - 1) == 0) {
+		url += sizeof("file://") - 1;
+	}
+
+	if (php_check_open_basedir(url)) {
+		return 0;
+	}
+
+	ret = VCWD_UNLINK(url);
+	if (ret == -1) {
+		if (options & PTHREADS_REPORT_ERRORS) {
+			php_error_docref1(NULL, url, E_WARNING, "%s", strerror(errno));
+		}
+		return 0;
+	}
+
+	/* Clear stat cache (and realpath cache) */
+	php_clear_stat_cache(1, NULL, 0);
+
+	return 1;
+}
+
+static int pthreads_plain_files_rename(pthreads_stream_wrapper_t *threaded_wrapper, const char *url_from, const char *url_to, int options, pthreads_stream_context_t *threaded_context)
+{
+	int ret;
+
+	if (!url_from || !url_to) {
+		return 0;
+	}
+
+#ifdef PHP_WIN32
+	if (!php_win32_check_trailing_space(url_from, strlen(url_from))) {
+		php_win32_docref2_from_error(ERROR_INVALID_NAME, url_from, url_to);
+		return 0;
+	}
+	if (!php_win32_check_trailing_space(url_to, strlen(url_to))) {
+		php_win32_docref2_from_error(ERROR_INVALID_NAME, url_from, url_to);
+		return 0;
+	}
+#endif
+
+	if (strncasecmp(url_from, "file://", sizeof("file://") - 1) == 0) {
+		url_from += sizeof("file://") - 1;
+	}
+
+	if (strncasecmp(url_to, "file://", sizeof("file://") - 1) == 0) {
+		url_to += sizeof("file://") - 1;
+	}
+
+	if (php_check_open_basedir(url_from) || php_check_open_basedir(url_to)) {
+		return 0;
+	}
+
+	ret = VCWD_RENAME(url_from, url_to);
+
+	if (ret == -1) {
+#ifndef PHP_WIN32
+# ifdef EXDEV
+		if (errno == EXDEV) {
+			zend_stat_t sb;
+			if (php_copy_file(url_from, url_to) == SUCCESS) {
+				if (VCWD_STAT(url_from, &sb) == 0) {
+#  ifndef TSRM_WIN32
+					if (VCWD_CHMOD(url_to, sb.st_mode)) {
+						if (errno == EPERM) {
+							php_error_docref2(NULL, url_from, url_to, E_WARNING, "%s", strerror(errno));
+							VCWD_UNLINK(url_from);
+							return 1;
+						}
+						php_error_docref2(NULL, url_from, url_to, E_WARNING, "%s", strerror(errno));
+						return 0;
+					}
+					if (VCWD_CHOWN(url_to, sb.st_uid, sb.st_gid)) {
+						if (errno == EPERM) {
+							php_error_docref2(NULL, url_from, url_to, E_WARNING, "%s", strerror(errno));
+							VCWD_UNLINK(url_from);
+							return 1;
+						}
+						php_error_docref2(NULL, url_from, url_to, E_WARNING, "%s", strerror(errno));
+						return 0;
+					}
+#  endif
+					VCWD_UNLINK(url_from);
+					return 1;
+				}
+			}
+			php_error_docref2(NULL, url_from, url_to, E_WARNING, "%s", strerror(errno));
+			return 0;
+		}
+# endif
+#endif
+
+#ifdef PHP_WIN32
+		php_win32_docref2_from_error(GetLastError(), url_from, url_to);
+#else
+		php_error_docref2(NULL, url_from, url_to, E_WARNING, "%s", strerror(errno));
+#endif
+		return 0;
+	}
+
+	/* Clear stat cache (and realpath cache) */
+	php_clear_stat_cache(1, NULL, 0);
+
+	return 1;
+}
+
+static int pthreads_plain_files_mkdir(pthreads_stream_wrapper_t *threaded_wrapper, const char *dir, int mode, int options, pthreads_stream_context_t *threaded_context)
+{
+	int ret, recursive = options & PTHREADS_STREAM_MKDIR_RECURSIVE;
+	char *p;
+
+	if (strncasecmp(dir, "file://", sizeof("file://") - 1) == 0) {
+		dir += sizeof("file://") - 1;
+	}
+
+	if (!recursive) {
+		ret = php_mkdir(dir, mode);
+	} else {
+		/* we look for directory separator from the end of string, thus hopefuly reducing our work load */
+		char *e;
+		zend_stat_t sb;
+		size_t dir_len = strlen(dir), offset = 0;
+		char buf[MAXPATHLEN];
+
+		if (!expand_filepath_with_mode(dir, buf, NULL, 0, CWD_EXPAND )) {
+			php_error_docref(NULL, E_WARNING, "Invalid path");
+			return 0;
+		}
+
+		e = buf +  strlen(buf);
+
+		if ((p = memchr(buf, DEFAULT_SLASH, dir_len))) {
+			offset = p - buf + 1;
+		}
+
+		if (p && dir_len == 1) {
+			/* buf == "DEFAULT_SLASH" */
+		}
+		else {
+			/* find a top level directory we need to create */
+			while ( (p = strrchr(buf + offset, DEFAULT_SLASH)) || (offset != 1 && (p = strrchr(buf, DEFAULT_SLASH))) ) {
+				int n = 0;
+
+				*p = '\0';
+				while (p > buf && *(p-1) == DEFAULT_SLASH) {
+					++n;
+					--p;
+					*p = '\0';
+				}
+				if (VCWD_STAT(buf, &sb) == 0) {
+					while (1) {
+						*p = DEFAULT_SLASH;
+						if (!n) break;
+						--n;
+						++p;
+					}
+					break;
+				}
+			}
+		}
+
+		if (p == buf) {
+			ret = php_mkdir(dir, mode);
+		} else if (!(ret = php_mkdir(buf, mode))) {
+			if (!p) {
+				p = buf;
+			}
+			/* create any needed directories if the creation of the 1st directory worked */
+			while (++p != e) {
+				if (*p == '\0') {
+					*p = DEFAULT_SLASH;
+					if ((*(p+1) != '\0') &&
+						(ret = VCWD_MKDIR(buf, (mode_t)mode)) < 0) {
+						if (options & REPORT_ERRORS) {
+							php_error_docref(NULL, E_WARNING, "%s", strerror(errno));
+						}
+						break;
+					}
+				}
+			}
+		}
+	}
+	if (ret < 0) {
+		/* Failure */
+		return 0;
+	} else {
+		/* Success */
+		return 1;
+	}
+}
+
+static int pthreads_plain_files_rmdir(pthreads_stream_wrapper_t *threaded_wrapper, const char *url, int options, pthreads_stream_context_t *threaded_context)
+{
+	if (strncasecmp(url, "file://", sizeof("file://") - 1) == 0) {
+		url += sizeof("file://") - 1;
+	}
+
+	if (php_check_open_basedir(url)) {
+		return 0;
+	}
+
+#ifdef PHP_WIN32
+	if (!php_win32_check_trailing_space(url, strlen(url))) {
+		php_error_docref1(NULL, url, E_WARNING, "%s", strerror(ENOENT));
+		return 0;
+	}
+#endif
+
+	if (VCWD_RMDIR(url) < 0) {
+		php_error_docref1(NULL, url, E_WARNING, "%s", strerror(errno));
+		return 0;
+	}
+
+	/* Clear stat cache (and realpath cache) */
+	php_clear_stat_cache(1, NULL, 0);
+
+	return 1;
+}
+
+static int pthreads_plain_files_metadata(pthreads_stream_wrapper_t *threaded_wrapper, const char *url, int option, void *value, pthreads_stream_context_t *threaded_context)
+{
+	struct utimbuf *newtime;
+#ifndef PHP_WIN32
+	uid_t uid;
+	gid_t gid;
+#endif
+	mode_t mode;
+	int ret = 0;
+
+#ifdef PHP_WIN32
+	if (!php_win32_check_trailing_space(url, strlen(url))) {
+		php_error_docref1(NULL, url, E_WARNING, "%s", strerror(ENOENT));
+		return 0;
+	}
+#endif
+
+	if (strncasecmp(url, "file://", sizeof("file://") - 1) == 0) {
+		url += sizeof("file://") - 1;
+	}
+
+	if (php_check_open_basedir(url)) {
+		return 0;
+	}
+
+	switch(option) {
+		case PTHREADS_STREAM_META_TOUCH:
+			newtime = (struct utimbuf *)value;
+			if (VCWD_ACCESS(url, F_OK) != 0) {
+				FILE *file = VCWD_FOPEN(url, "w");
+				if (file == NULL) {
+					php_error_docref1(NULL, url, E_WARNING, "Unable to create file %s because %s", url, strerror(errno));
+					return 0;
+				}
+				fclose(file);
+			}
+
+			ret = VCWD_UTIME(url, newtime);
+			break;
+#ifndef PHP_WIN32
+		case PTHREADS_STREAM_META_OWNER_NAME:
+		case PTHREADS_STREAM_META_OWNER:
+			if(option == PTHREADS_STREAM_META_OWNER_NAME) {
+				if(php_get_uid_by_name((char *)value, &uid) != SUCCESS) {
+					php_error_docref1(NULL, url, E_WARNING, "Unable to find uid for %s", (char *)value);
+					return 0;
+				}
+			} else {
+				uid = (uid_t)*(long *)value;
+			}
+			ret = VCWD_CHOWN(url, uid, -1);
+			break;
+		case PTHREADS_STREAM_META_GROUP:
+		case PTHREADS_STREAM_META_GROUP_NAME:
+			if(option == PTHREADS_STREAM_META_GROUP_NAME) {
+				if(php_get_gid_by_name((char *)value, &gid) != SUCCESS) {
+					php_error_docref1(NULL, url, E_WARNING, "Unable to find gid for %s", (char *)value);
+					return 0;
+				}
+			} else {
+				gid = (gid_t)*(long *)value;
+			}
+			ret = VCWD_CHOWN(url, -1, gid);
+			break;
+#endif
+		case PTHREADS_STREAM_META_ACCESS:
+			mode = (mode_t)*(zend_long *)value;
+			ret = VCWD_CHMOD(url, mode);
+			break;
+		default:
+			php_error_docref1(NULL, url, E_WARNING, "Unknown option %d for stream_metadata", option);
+			return 0;
+	}
+	if (ret == -1) {
+		php_error_docref1(NULL, url, E_WARNING, "Operation failed: %s", strerror(errno));
+		return 0;
+	}
+	php_clear_stat_cache(0, NULL, 0);
+	return 1;
+}
+
+const pthreads_stream_wrapper_ops pthreads_plain_files_wrapper_ops = {
+	pthreads_plain_files_stream_opener,
+	NULL,
+	NULL,
+	pthreads_plain_files_url_stater,
+	pthreads_plain_files_dir_opener,
+	"plainfile",
+	pthreads_plain_files_unlink,
+	pthreads_plain_files_rename,
+	pthreads_plain_files_mkdir,
+	pthreads_plain_files_rmdir,
+	pthreads_plain_files_metadata
+};
+
+/* {{{ pthreads_stream_fopen_with_path */
+pthreads_stream_t *_pthreads_stream_fopen_with_path(const char *filename, const char *mode, const char *path, zend_string **opened_path, int options) {
+	/* code ripped off from fopen_wrappers.c */
+	char *pathbuf, *end;
+	const char *ptr;
+	char trypath[MAXPATHLEN];
+	pthreads_stream_t *threaded_stream;
+	size_t filename_length;
+	zend_string *exec_filename;
+
+	if (opened_path) {
+		*opened_path = NULL;
+	}
+
+	if(!filename) {
+		return NULL;
+	}
+
+	filename_length = strlen(filename);
+#ifndef PHP_WIN32
+	(void) filename_length;
+#endif
+
+	/* Relative path open */
+	if (*filename == '.' && (IS_SLASH(filename[1]) || filename[1] == '.')) {
+		/* further checks, we could have ....... filenames */
+		ptr = filename + 1;
+		if (*ptr == '.') {
+			while (*(++ptr) == '.');
+			if (!IS_SLASH(*ptr)) { /* not a relative path after all */
+				goto not_relative_path;
+			}
+		}
+
+
+		if (((options & PTHREADS_STREAM_DISABLE_OPEN_BASEDIR) == 0) && php_check_open_basedir(filename)) {
+			return NULL;
+		}
+
+		return pthreads_stream_fopen(filename, mode, opened_path, options);
+	}
+
+not_relative_path:
+
+	/* Absolute path open */
+	if (IS_ABSOLUTE_PATH(filename, filename_length)) {
+
+		if (((options & PTHREADS_STREAM_DISABLE_OPEN_BASEDIR) == 0) && php_check_open_basedir(filename)) {
+			return NULL;
+		}
+
+		return pthreads_stream_fopen(filename, mode, opened_path, options);
+	}
+
+#ifdef PHP_WIN32
+	if (IS_SLASH(filename[0])) {
+		size_t cwd_len;
+		char *cwd;
+		cwd = virtual_getcwd_ex(&cwd_len);
+		/* getcwd() will return always return [DRIVE_LETTER]:/) on windows. */
+		*(cwd+3) = '\0';
+
+		if (snprintf(trypath, MAXPATHLEN, "%s%s", cwd, filename) >= MAXPATHLEN) {
+			php_error_docref(NULL, E_NOTICE, "%s/%s path was truncated to %d", cwd, filename, MAXPATHLEN);
+		}
+
+		efree(cwd);
+
+		if (((options & PTHREADS_STREAM_DISABLE_OPEN_BASEDIR) == 0) && php_check_open_basedir(trypath)) {
+			return NULL;
+		}
+
+		return pthreads_stream_fopen(trypath, mode, opened_path, options);
+	}
+#endif
+
+	if (!path || !*path) {
+		return pthreads_stream_fopen(filename, mode, opened_path, options);
+	}
+
+	/* check in provided path */
+	/* append the calling scripts' current working directory
+	 * as a fall back case
+	 */
+	if (zend_is_executing() &&
+	    (exec_filename = zend_get_executed_filename_ex()) != NULL) {
+		const char *exec_fname = ZSTR_VAL(exec_filename);
+		size_t exec_fname_length = ZSTR_LEN(exec_filename);
+
+		while ((--exec_fname_length < SIZE_MAX) && !IS_SLASH(exec_fname[exec_fname_length]));
+		if (exec_fname_length<=0) {
+			/* no path */
+			pathbuf = estrdup(path);
+		} else {
+			size_t path_length = strlen(path);
+
+			pathbuf = (char *) emalloc(exec_fname_length + path_length +1 +1);
+			memcpy(pathbuf, path, path_length);
+			pathbuf[path_length] = DEFAULT_DIR_SEPARATOR;
+			memcpy(pathbuf+path_length+1, exec_fname, exec_fname_length);
+			pathbuf[path_length + exec_fname_length +1] = '\0';
+		}
+	} else {
+		pathbuf = estrdup(path);
+	}
+
+	ptr = pathbuf;
+
+	while (ptr && *ptr) {
+		end = strchr(ptr, DEFAULT_DIR_SEPARATOR);
+		if (end != NULL) {
+			*end = '\0';
+			end++;
+		}
+		if (*ptr == '\0') {
+			goto stream_skip;
+		}
+		if (snprintf(trypath, MAXPATHLEN, "%s/%s", ptr, filename) >= MAXPATHLEN) {
+			php_error_docref(NULL, E_NOTICE, "%s/%s path was truncated to %d", ptr, filename, MAXPATHLEN);
+		}
+
+		if (((options & PTHREADS_STREAM_DISABLE_OPEN_BASEDIR) == 0) && php_check_open_basedir_ex(trypath, 0)) {
+			goto stream_skip;
+		}
+
+		threaded_stream = pthreads_stream_fopen(trypath, mode, opened_path, options);
+		if (threaded_stream) {
+			efree(pathbuf);
+			return threaded_stream;
+		}
+stream_skip:
+		ptr = end;
+	} /* end provided path */
+
+	efree(pathbuf);
+	return NULL;
+
+}
+/* }}} */
+
+
+#endif

--- a/src/streams/wrappers/plain_wrapper.h
+++ b/src/streams/wrappers/plain_wrapper.h
@@ -1,0 +1,58 @@
+/*
+  +----------------------------------------------------------------------+
+  | pthreads                                                             |
+  +----------------------------------------------------------------------+
+  | Copyright (c) Joe Watkins 2018                                       |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | http://www.php.net/license/3_01.txt                                  |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors: Bastian Schneider <b.schneider@badnoob.com>                 |
+  | Borrowed code from php-src                                           |
+  +----------------------------------------------------------------------+
+ */
+#ifndef HAVE_PTHREADS_STREAMS_WRAPPERS_PLAIN_WRAPPER_H
+#define HAVE_PTHREADS_STREAMS_WRAPPERS_PLAIN_WRAPPER_H
+
+/* definitions for the plain files wrapper */
+
+extern pthreads_stream_ops pthreads_stream_stdio_ops;
+extern const pthreads_stream_wrapper_ops pthreads_plain_files_wrapper_ops;
+
+/* like fopen, but returns a stream */
+pthreads_stream_t *_pthreads_stream_fopen(const char *filename, const char *mode, zend_string **opened_path, int options, zend_class_entry *ce);
+#define pthreads_stream_fopen(filename, mode, opened, options)	_pthreads_stream_fopen((filename), (mode), (opened), (options), NULL)
+
+pthreads_stream_t *_pthreads_stream_fopen_with_path(const char *filename, const char *mode, const char *path, zend_string **opened_path, int options);
+#define pthreads_stream_fopen_with_path(filename, mode, path, opened)	_pthreads_stream_fopen_with_path((filename), (mode), (path), (opened))
+
+pthreads_stream_t *_pthreads_stream_fopen_from_file(FILE *file, const char *mode);
+#define pthreads_stream_fopen_from_file(file, mode)	_pthreads_stream_fopen_from_file((file), (mode))
+
+pthreads_stream_t *_pthreads_stream_fopen_from_fd(int fd, const char *mode);
+#define pthreads_stream_fopen_from_fd(fd, mode)	_pthreads_stream_fopen_from_fd((fd), (mode))
+
+pthreads_stream_t *_pthreads_stream_fopen_from_pipe(FILE *file, const char *mode, zend_class_entry *ce);
+#define pthreads_stream_fopen_from_pipe(file, mode)	_pthreads_stream_fopen_from_pipe((file), (mode), NULL)
+
+pthreads_stream_t *_pthreads_stream_fopen_tmpfile(int dummy);
+#define pthreads_stream_fopen_tmpfile()	_pthreads_stream_fopen_tmpfile(0)
+
+pthreads_stream_t *_pthreads_stream_fopen_temporary_file(const char *dir, const char *pfx, zend_string **opened_path);
+#define pthreads_stream_fopen_temporary_file(dir, pfx, opened_path)	_pthreads_stream_fopen_temporary_file((dir), (pfx), (opened_path))
+
+/* This is a utility API for extensions that are opening a stream, converting it
+ * to a FILE* and then closing it again.  Be warned that fileno() on the result
+ * will most likely fail on systems with fopencookie. */
+FILE * _pthreads_stream_open_wrapper_as_file(char * path, char * mode, int options, zend_string **opened_path);
+#define pthreads_stream_open_wrapper_as_file(path, mode, options, opened_path) _pthreads_stream_open_wrapper_as_file((path), (mode), (options), (opened_path))
+
+/* parse standard "fopen" modes into open() flags */
+int pthreads_stream_parse_fopen_modes(const char *mode, int *open_flags);
+
+#endif

--- a/src/streams/wrappers/user_wrapper.c
+++ b/src/streams/wrappers/user_wrapper.c
@@ -1,0 +1,1503 @@
+/*
+  +----------------------------------------------------------------------+
+  | pthreads                                                             |
+  +----------------------------------------------------------------------+
+  | Copyright (c) Joe Watkins 2018                                       |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | http://www.php.net/license/3_01.txt                                  |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors: Bastian Schneider <b.schneider@badnoob.com>                 |
+  | Borrowed code from php-src                                           |
+  +----------------------------------------------------------------------+
+ */
+#ifndef HAVE_PTHREADS_STREAMS_WRAPPERS_USER_WRAPPER
+#define HAVE_PTHREADS_STREAMS_WRAPPERS_USER_WRAPPER
+
+#ifndef HAVE_PTHREADS_H
+#	include <src/pthreads.h>
+#endif
+
+#ifndef HAVE_PTHREADS_STREAM_H
+#	include <src/streams.h>
+#endif
+
+#include "php_globals.h"
+#include "ext/standard/file.h"
+#include "ext/standard/flock_compat.h"
+#ifdef HAVE_SYS_FILE_H
+#include <sys/file.h>
+#endif
+#include <stddef.h>
+
+#if HAVE_UTIME
+# ifdef PHP_WIN32
+#  include <sys/utime.h>
+# else
+#  include <utime.h>
+# endif
+#endif
+
+#ifndef HAVE_PTHREADS_STREAMS_WRAPPERS_USER_WRAPPER_H
+#	include <src/streams/wrappers/user_wrapper.h>
+#endif
+
+static pthreads_stream_t *pthreads_user_wrapper_opener(pthreads_stream_wrapper_t *threaded_wrapper,
+		const char *filename, const char *mode, int options, zend_string **opened_path, pthreads_stream_context_t *threaded_context, zend_class_entry *ce);
+static int pthreads_user_wrapper_stat_url(pthreads_stream_wrapper_t *threaded_wrapper, const char *url, int flags, pthreads_stream_statbuf *ssb, pthreads_stream_context_t *threaded_context);
+static int pthreads_user_wrapper_unlink(pthreads_stream_wrapper_t *threaded_wrapper, const char *url, int options, pthreads_stream_context_t *threaded_context);
+static int pthreads_user_wrapper_rename(pthreads_stream_wrapper_t *threaded_wrapper, const char *url_from, const char *url_to, int options, pthreads_stream_context_t *threaded_context);
+static int pthreads_user_wrapper_mkdir(pthreads_stream_wrapper_t *threaded_wrapper, const char *url, int mode, int options, pthreads_stream_context_t *threaded_context);
+static int pthreads_user_wrapper_rmdir(pthreads_stream_wrapper_t *threaded_wrapper, const char *url, int options, pthreads_stream_context_t *threaded_context);
+static int pthreads_user_wrapper_metadata(pthreads_stream_wrapper_t *threaded_wrapper, const char *url, int option, void *value, pthreads_stream_context_t *threaded_context);
+static pthreads_stream_t *pthreads_user_wrapper_opendir(pthreads_stream_wrapper_t *threaded_wrapper, const char *filename, const char *mode,
+		int options, zend_string **opened_path, pthreads_stream_context_t *threaded_context, zend_class_entry *ce);
+
+const pthreads_stream_wrapper_ops pthreads_user_stream_wops = {
+	pthreads_user_wrapper_opener,
+	NULL, /* close - the streams themselves know how */
+	NULL, /* stat - the streams themselves know how */
+	pthreads_user_wrapper_stat_url,
+	pthreads_user_wrapper_opendir,
+	"user-space",
+	pthreads_user_wrapper_unlink,
+	pthreads_user_wrapper_rename,
+	pthreads_user_wrapper_mkdir,
+	pthreads_user_wrapper_rmdir,
+	pthreads_user_wrapper_metadata
+};
+
+/* names of methods */
+#define PTHREADS_USERSTREAM_OPEN		"stream_open"
+#define PTHREADS_USERSTREAM_CLOSE		"stream_close"
+#define PTHREADS_USERSTREAM_READ		"stream_read"
+#define PTHREADS_USERSTREAM_WRITE		"stream_write"
+#define PTHREADS_USERSTREAM_FLUSH		"stream_flush"
+#define PTHREADS_USERSTREAM_SEEK		"stream_seek"
+#define PTHREADS_USERSTREAM_TELL		"stream_tell"
+#define PTHREADS_USERSTREAM_EOF			"stream_eof"
+#define PTHREADS_USERSTREAM_STAT		"stream_stat"
+#define PTHREADS_USERSTREAM_STATURL		"url_stat"
+#define PTHREADS_USERSTREAM_UNLINK		"unlink"
+#define PTHREADS_USERSTREAM_RENAME		"rename"
+#define PTHREADS_USERSTREAM_MKDIR		"mkdir"
+#define PTHREADS_USERSTREAM_RMDIR		"rmdir"
+#define PTHREADS_USERSTREAM_DIR_OPEN	"dir_opendir"
+#define PTHREADS_USERSTREAM_DIR_READ	"dir_readdir"
+#define PTHREADS_USERSTREAM_DIR_REWIND	"dir_rewinddir"
+#define PTHREADS_USERSTREAM_DIR_CLOSE	"dir_closedir"
+#define PTHREADS_USERSTREAM_LOCK     	"stream_lock"
+#define PTHREADS_USERSTREAM_CAST		"stream_cast"
+#define PTHREADS_USERSTREAM_SET_OPTION	"stream_set_option"
+#define PTHREADS_USERSTREAM_TRUNCATE	"stream_truncate"
+#define PTHREADS_USERSTREAM_METADATA	"stream_metadata"
+
+/* {{{ class should have methods like these:
+
+	function stream_open($path, $mode, $options, &$opened_path)
+	{
+	  	return true/false;
+	}
+
+	function stream_read($count)
+	{
+	   	return false on error;
+		else return string;
+	}
+
+	function stream_write($data)
+	{
+	   	return false on error;
+		else return count written;
+	}
+
+	function stream_close()
+	{
+	}
+
+	function stream_flush()
+	{
+		return true/false;
+	}
+
+	function stream_seek($offset, $whence)
+	{
+		return true/false;
+	}
+
+	function stream_tell()
+	{
+		return (int)$position;
+	}
+
+	function stream_eof()
+	{
+		return true/false;
+	}
+
+	function stream_stat()
+	{
+		return array( just like that returned by fstat() );
+	}
+
+	function stream_cast($castas)
+	{
+		if ($castas == STREAM_CAST_FOR_SELECT) {
+			return $this->underlying_stream;
+		}
+		return false;
+	}
+
+	function stream_set_option($option, $arg1, $arg2)
+	{
+		switch($option) {
+		case STREAM_OPTION_BLOCKING:
+			$blocking = $arg1;
+			...
+		case STREAM_OPTION_READ_TIMEOUT:
+			$sec = $arg1;
+			$usec = $arg2;
+			...
+		case STREAM_OPTION_WRITE_BUFFER:
+			$mode = $arg1;
+			$size = $arg2;
+			...
+		default:
+			return false;
+		}
+	}
+
+	function url_stat(string $url, int $flags)
+	{
+		return array( just like that returned by stat() );
+	}
+
+	function unlink(string $url)
+	{
+		return true / false;
+	}
+
+	function rename(string $from, string $to)
+	{
+		return true / false;
+	}
+
+	function mkdir($dir, $mode, $options)
+	{
+		return true / false;
+	}
+
+	function rmdir($dir, $options)
+	{
+		return true / false;
+	}
+
+	function dir_opendir(string $url, int $options)
+	{
+		return true / false;
+	}
+
+	function dir_readdir()
+	{
+		return string next filename in dir ;
+	}
+
+	function dir_closedir()
+	{
+		release dir related resources;
+	}
+
+	function dir_rewinddir()
+	{
+		reset to start of dir list;
+	}
+
+	function stream_lock($operation)
+	{
+		return true / false;
+	}
+
+ 	function stream_truncate($new_size)
+	{
+		return true / false;
+	}
+
+	}}} **/
+
+static void pthreads_user_stream_create_object(struct pthreads_user_stream_wrapper *uwrap, pthreads_stream_context_t *threaded_context, zval *object)
+{
+	zend_class_entry *ce = zend_lookup_class(uwrap->classname);
+
+	if(ce == NULL) {
+		php_error_docref(NULL, E_WARNING, "class '%s' is undefined", ZSTR_VAL(uwrap->classname));
+		return;
+	}
+
+	if (ce->ce_flags & (ZEND_ACC_INTERFACE|ZEND_ACC_TRAIT|ZEND_ACC_IMPLICIT_ABSTRACT_CLASS|ZEND_ACC_EXPLICIT_ABSTRACT_CLASS)) {
+		ZVAL_UNDEF(object);
+		return;
+	}
+
+	/* create an instance of our class */
+	object_init_ex(object, ce);
+
+	if (threaded_context) {
+		zval zcontext;
+		ZVAL_OBJ(&zcontext, PTHREADS_STD_P(threaded_context));
+		add_property_zval(object, "context", &zcontext);
+	} else {
+		add_property_null(object, "context");
+	}
+
+	if (ce->constructor) {
+		zend_fcall_info fci;
+		zend_fcall_info_cache fcc;
+		zval retval;
+
+		fci.size = sizeof(fci);
+		ZVAL_UNDEF(&fci.function_name);
+		fci.object = Z_OBJ_P(object);
+		fci.retval = &retval;
+		fci.param_count = 0;
+		fci.params = NULL;
+		fci.no_separation = 1;
+
+		fcc.function_handler = ce->constructor;
+		fcc.called_scope = Z_OBJCE_P(object);
+		fcc.object = Z_OBJ_P(object);
+
+		if (zend_call_function(&fci, &fcc) == FAILURE) {
+			php_error_docref(NULL, E_WARNING, "Could not execute %s::%s()", ZSTR_VAL(ce->name), ZSTR_VAL(ce->constructor->common.function_name));
+			zval_ptr_dtor(object);
+			ZVAL_UNDEF(object);
+		} else {
+			zval_ptr_dtor(&retval);
+		}
+	}
+}
+
+static pthreads_stream_t *pthreads_user_wrapper_opener(pthreads_stream_wrapper_t *threaded_wrapper, const char *filename, const char *mode,
+									   int options, zend_string **opened_path, pthreads_stream_context_t *threaded_context, zend_class_entry *ce) {
+	pthreads_stream_wrapper *wrapper = PTHREADS_FETCH_STREAMS_WRAPPER(threaded_wrapper);
+	pthreads_stream_wrapper *user_wrapper = NULL;
+	struct pthreads_user_stream_wrapper *uwrap = (struct pthreads_user_stream_wrapper*)wrapper->abstract;
+	pthreads_userstream_data_t *us;
+	zval zretval, zfuncname;
+	zval args[4];
+	int call_result;
+	pthreads_stream_t *threaded_stream = NULL;
+	pthreads_stream *stream = NULL;
+	zend_bool old_in_user_include;
+
+	/* Try to catch bad usage without preventing flexibility */
+	if (FG(user_stream_current_filename) != NULL && strcmp(filename, FG(user_stream_current_filename)) == 0) {
+		pthreads_stream_wrapper_log_error(threaded_wrapper, options, "infinite recursion prevented");
+		return NULL;
+	}
+	FG(user_stream_current_filename) = filename;
+
+	/* if the user stream was registered as local and we are in include context,
+		we add allow_url_include restrictions to allow_url_fopen ones */
+	/* we need only is_url == 0 here since if is_url == 1 and remote wrappers
+		were restricted we wouldn't get here */
+	old_in_user_include = PG(in_user_include);
+
+	user_wrapper = PTHREADS_FETCH_STREAMS_WRAPPER(uwrap->threaded_wrapper);
+	if(user_wrapper->is_url == 0 &&
+		(options & PTHREADS_STREAM_OPEN_FOR_INCLUDE) &&
+		!PG(allow_url_include)) {
+		PG(in_user_include) = 1;
+	}
+
+	us = malloc(sizeof(*us));
+	us->wrapper = uwrap;
+
+	pthreads_user_stream_create_object(uwrap, threaded_context, &us->object);
+
+	if (Z_TYPE(us->object) == IS_UNDEF) {
+		FG(user_stream_current_filename) = NULL;
+		PG(in_user_include) = old_in_user_include;
+		free(us);
+		return NULL;
+	}
+
+	/* call it's stream_open method - set up params first */
+	ZVAL_STRING(&args[0], filename);
+	ZVAL_STRING(&args[1], mode);
+	ZVAL_LONG(&args[2], options);
+	ZVAL_NEW_REF(&args[3], &EG(uninitialized_zval));
+
+	ZVAL_STRING(&zfuncname, PTHREADS_USERSTREAM_OPEN);
+
+	zend_try {
+		call_result = call_user_function_ex(NULL,
+				Z_ISUNDEF(us->object)? NULL : &us->object,
+				&zfuncname,
+				&zretval,
+				4, args,
+				0, NULL	);
+	} zend_catch {
+		FG(user_stream_current_filename) = NULL;
+		zend_bailout();
+	} zend_end_try();
+
+	if (call_result == SUCCESS && Z_TYPE(zretval) != IS_UNDEF && zval_is_true(&zretval)) {
+		/* the stream is now open! */
+		threaded_stream = PTHREADS_STREAM_CLASS_NEW(&pthreads_stream_userspace_ops, us, mode, ce);
+
+		/* if the opened path is set, copy it out */
+		if (Z_ISREF(args[3]) && Z_TYPE_P(Z_REFVAL(args[3])) == IS_STRING && opened_path) {
+			*opened_path = zend_string_copy(Z_STR_P(Z_REFVAL(args[3])));
+		}
+		/* set wrapper data to be a reference to our object */
+		pthreads_stream_set_wrapperdata(threaded_stream, PTHREADS_FETCH_FROM(Z_OBJ(us->object)));
+	} else {
+		pthreads_stream_wrapper_log_error(threaded_wrapper, options, "\"%s::" PTHREADS_USERSTREAM_OPEN "\" call failed",
+			ZSTR_VAL(us->wrapper->classname));
+	}
+
+	/* destroy everything else */
+	if (threaded_stream == NULL) {
+		zval_ptr_dtor(&us->object);
+		ZVAL_UNDEF(&us->object);
+		free(us);
+	}
+	zval_ptr_dtor(&zretval);
+	zval_ptr_dtor(&zfuncname);
+	zval_ptr_dtor(&args[3]);
+	zval_ptr_dtor(&args[2]);
+	zval_ptr_dtor(&args[1]);
+	zval_ptr_dtor(&args[0]);
+
+	FG(user_stream_current_filename) = NULL;
+
+	PG(in_user_include) = old_in_user_include;
+	return threaded_stream;
+}
+
+static pthreads_stream_t *pthreads_user_wrapper_opendir(pthreads_stream_wrapper_t *threaded_wrapper, const char *filename, const char *mode,
+		int options, zend_string **opened_path, pthreads_stream_context_t *threaded_context, zend_class_entry *ce) {
+	pthreads_stream_wrapper *wrapper = PTHREADS_FETCH_STREAMS_WRAPPER(threaded_wrapper);
+	struct pthreads_user_stream_wrapper *uwrap = (struct pthreads_user_stream_wrapper*)wrapper->abstract;
+	pthreads_userstream_data_t *us;
+	zval zretval, zfuncname;
+	zval args[2];
+	int call_result;
+	pthreads_stream_t *threaded_stream = NULL;
+	pthreads_stream *stream = NULL;
+
+	/* Try to catch bad usage without preventing flexibility */
+	if (FG(user_stream_current_filename) != NULL && strcmp(filename, FG(user_stream_current_filename)) == 0) {
+		pthreads_stream_wrapper_log_error(threaded_wrapper, options, "infinite recursion prevented");
+		return NULL;
+	}
+	FG(user_stream_current_filename) = filename;
+
+	us = malloc(sizeof(*us));
+	us->wrapper = uwrap;
+
+	pthreads_user_stream_create_object(uwrap, threaded_context, &us->object);
+	if (Z_TYPE(us->object) == IS_UNDEF) {
+		FG(user_stream_current_filename) = NULL;
+		free(us);
+		return NULL;
+	}
+
+	/* call it's dir_open method - set up params first */
+	ZVAL_STRING(&args[0], filename);
+	ZVAL_LONG(&args[1], options);
+
+	ZVAL_STRING(&zfuncname, PTHREADS_USERSTREAM_DIR_OPEN);
+
+	call_result = call_user_function_ex(NULL,
+			Z_ISUNDEF(us->object)? NULL : &us->object,
+			&zfuncname,
+			&zretval,
+			2, args,
+			0, NULL	);
+
+	if (call_result == SUCCESS && Z_TYPE(zretval) != IS_UNDEF && zval_is_true(&zretval)) {
+		/* the stream is now open! */
+		threaded_stream = PTHREADS_STREAM_CLASS_NEW(&pthreads_stream_userspace_dir_ops, us, mode, ce);
+
+		/* set wrapper data to be a reference to our object */
+		pthreads_stream_set_wrapperdata(threaded_stream, PTHREADS_FETCH_FROM(Z_OBJ(us->object)));
+	} else {
+		pthreads_stream_wrapper_log_error(threaded_wrapper, options, "\"%s::" PTHREADS_USERSTREAM_DIR_OPEN "\" call failed",
+			ZSTR_VAL(us->wrapper->classname));
+	}
+
+	/* destroy everything else */
+	if (threaded_stream == NULL) {
+		zval_ptr_dtor(&us->object);
+		ZVAL_UNDEF(&us->object);
+		free(us);
+	}
+	zval_ptr_dtor(&zretval);
+
+	zval_ptr_dtor(&zfuncname);
+	zval_ptr_dtor(&args[1]);
+	zval_ptr_dtor(&args[0]);
+
+	FG(user_stream_current_filename) = NULL;
+
+	return threaded_stream;
+}
+
+static size_t pthreads_userstreamop_write(pthreads_stream_t *threaded_stream, const char *buf, size_t count) {
+	pthreads_stream *stream = PTHREADS_FETCH_STREAMS_STREAM(threaded_stream);
+	zval func_name;
+	zval retval;
+	int call_result;
+	pthreads_userstream_data_t *us;
+	zval args[1];
+	size_t didwrite = 0;
+
+	if(stream_lock(threaded_stream)) {
+		us = (pthreads_userstream_data_t *)stream->abstract;
+
+		assert(us != NULL);
+
+		ZVAL_STRINGL(&func_name, PTHREADS_USERSTREAM_WRITE, sizeof(PTHREADS_USERSTREAM_WRITE)-1);
+
+		ZVAL_STRINGL(&args[0], (char*)buf, count);
+
+		call_result = call_user_function_ex(NULL,
+				Z_ISUNDEF(us->object)? NULL : &us->object,
+				&func_name,
+				&retval,
+				1, args,
+				0, NULL);
+
+		zval_ptr_dtor(&args[0]);
+		zval_ptr_dtor(&func_name);
+
+		stream_unlock(threaded_stream);
+	}
+
+	didwrite = 0;
+
+	if (EG(exception)) {
+		return 0;
+	}
+
+	if (call_result == SUCCESS && Z_TYPE(retval) != IS_UNDEF) {
+		convert_to_long(&retval);
+		didwrite = Z_LVAL(retval);
+	} else if (call_result == FAILURE) {
+		php_error_docref(NULL, E_WARNING, "%s::" PTHREADS_USERSTREAM_WRITE " is not implemented!",
+				ZSTR_VAL(us->wrapper->classname));
+	}
+
+	/* don't allow strange buffer overruns due to bogus return */
+	if (didwrite > count) {
+		php_error_docref(NULL, E_WARNING, "%s::" PTHREADS_USERSTREAM_WRITE " wrote " ZEND_LONG_FMT " bytes more data than requested (" ZEND_LONG_FMT " written, " ZEND_LONG_FMT " max)",
+				ZSTR_VAL(us->wrapper->classname),
+				(zend_long)(didwrite - count), (zend_long)didwrite, (zend_long)count);
+		didwrite = count;
+	}
+
+	zval_ptr_dtor(&retval);
+
+	return didwrite;
+}
+
+static size_t pthreads_userstreamop_read(pthreads_stream_t *threaded_stream, char *buf, size_t count) {
+	pthreads_stream *stream = PTHREADS_FETCH_STREAMS_STREAM(threaded_stream);
+	zval func_name;
+	zval retval;
+	zval args[1];
+	int call_result;
+	size_t didread = 0;
+	pthreads_userstream_data_t *us = (pthreads_userstream_data_t *)stream->abstract;
+
+	assert(us != NULL);
+
+	if(stream_lock(threaded_stream)) {
+
+		ZVAL_STRINGL(&func_name, PTHREADS_USERSTREAM_READ, sizeof(PTHREADS_USERSTREAM_READ)-1);
+
+		ZVAL_LONG(&args[0], count);
+
+		call_result = call_user_function_ex(NULL,
+				Z_ISUNDEF(us->object)? NULL : &us->object,
+				&func_name,
+				&retval,
+				1, args,
+				0, NULL);
+
+		zval_ptr_dtor(&args[0]);
+		zval_ptr_dtor(&func_name);
+
+		if (EG(exception)) {
+			stream_unlock(threaded_stream);
+			return -1;
+		}
+
+		if (call_result == SUCCESS && Z_TYPE(retval) != IS_UNDEF) {
+			convert_to_string(&retval);
+			didread = Z_STRLEN(retval);
+			if (didread > count) {
+				php_error_docref(NULL, E_WARNING, "%s::" PTHREADS_USERSTREAM_READ " - read " ZEND_LONG_FMT " bytes more data than requested (" ZEND_LONG_FMT " read, " ZEND_LONG_FMT " max) - excess data will be lost",
+						ZSTR_VAL(us->wrapper->classname), (zend_long)(didread - count), (zend_long)didread, (zend_long)count);
+				didread = count;
+			}
+			if (didread > 0)
+				memcpy(buf, Z_STRVAL(retval), didread);
+		} else if (call_result == FAILURE) {
+			php_error_docref(NULL, E_WARNING, "%s::" PTHREADS_USERSTREAM_READ " is not implemented!", ZSTR_VAL(us->wrapper->classname));
+		}
+
+		zval_ptr_dtor(&retval);
+		ZVAL_UNDEF(&retval);
+
+		/* since the user stream has no way of setting the eof flag directly, we need to ask it if we hit eof */
+
+		ZVAL_STRINGL(&func_name, PTHREADS_USERSTREAM_EOF, sizeof(PTHREADS_USERSTREAM_EOF)-1);
+
+		call_result = call_user_function(NULL,
+				Z_ISUNDEF(us->object)? NULL : &us->object,
+				&func_name,
+				&retval,
+				0, NULL);
+
+		if (call_result == SUCCESS && Z_TYPE(retval) != IS_UNDEF && zval_is_true(&retval)) {
+			stream->eof = 1;
+		} else if (call_result == FAILURE) {
+			php_error_docref(NULL, E_WARNING,
+					"%s::" PTHREADS_USERSTREAM_EOF " is not implemented! Assuming EOF", ZSTR_VAL(us->wrapper->classname));
+
+			stream->eof = 1;
+		}
+
+		zval_ptr_dtor(&retval);
+		zval_ptr_dtor(&func_name);
+
+		stream_unlock(threaded_stream);
+	}
+	return didread;
+}
+
+static int pthreads_userstreamop_close(pthreads_stream_t *threaded_stream, int close_handle) {
+	pthreads_stream *stream = PTHREADS_FETCH_STREAMS_STREAM(threaded_stream);
+	zval func_name;
+	zval retval;
+	pthreads_userstream_data_t *us = (pthreads_userstream_data_t *)stream->abstract;
+
+	assert(us != NULL);
+
+	ZVAL_STRINGL(&func_name, PTHREADS_USERSTREAM_CLOSE, sizeof(PTHREADS_USERSTREAM_CLOSE)-1);
+
+	call_user_function(NULL,
+			Z_ISUNDEF(us->object)? NULL : &us->object,
+			&func_name,
+			&retval,
+			0, NULL);
+
+	zval_ptr_dtor(&retval);
+	zval_ptr_dtor(&func_name);
+
+	return 0;
+}
+
+static void pthreads_userstreamop_free(pthreads_stream_t *threaded_stream, int close_handle) {
+	pthreads_stream *stream = PTHREADS_FETCH_STREAMS_STREAM(threaded_stream);
+	pthreads_userstream_data_t *us = (pthreads_userstream_data_t *)stream->abstract;
+
+	assert(us != NULL);
+
+	zval_ptr_dtor(&us->object);
+	ZVAL_UNDEF(&us->object);
+
+	free(us);
+}
+
+static int pthreads_userstreamop_flush(pthreads_stream_t *threaded_stream) {
+	pthreads_stream *stream = PTHREADS_FETCH_STREAMS_STREAM(threaded_stream);
+	zval func_name;
+	zval retval;
+	int call_result;
+	pthreads_userstream_data_t *us = (pthreads_userstream_data_t *)stream->abstract;
+
+	assert(us != NULL);
+
+	if(stream_lock(threaded_stream)) {
+		ZVAL_STRINGL(&func_name, PTHREADS_USERSTREAM_FLUSH, sizeof(PTHREADS_USERSTREAM_FLUSH)-1);
+
+		call_result = call_user_function(NULL,
+				Z_ISUNDEF(us->object)? NULL : &us->object,
+				&func_name,
+				&retval,
+				0, NULL);
+
+		if (call_result == SUCCESS && Z_TYPE(retval) != IS_UNDEF && zval_is_true(&retval))
+			call_result = 0;
+		else
+			call_result = -1;
+
+		zval_ptr_dtor(&retval);
+		zval_ptr_dtor(&func_name);
+
+		stream_unlock(threaded_stream);
+	}
+	return call_result;
+}
+
+static int pthreads_userstreamop_seek(pthreads_stream_t *threaded_stream, zend_off_t offset, int whence, zend_off_t *newoffs) {
+	pthreads_stream *stream = PTHREADS_FETCH_STREAMS_STREAM(threaded_stream);
+	zval func_name;
+	zval retval;
+	int call_result, ret;
+	pthreads_userstream_data_t *us = (pthreads_userstream_data_t *)stream->abstract;
+	zval args[2];
+
+	assert(us != NULL);
+
+	if(stream_lock(threaded_stream)) {
+		ZVAL_STRINGL(&func_name, PTHREADS_USERSTREAM_SEEK, sizeof(PTHREADS_USERSTREAM_SEEK)-1);
+
+		ZVAL_LONG(&args[0], offset);
+		ZVAL_LONG(&args[1], whence);
+
+		call_result = call_user_function_ex(NULL,
+				Z_ISUNDEF(us->object)? NULL : &us->object,
+				&func_name,
+				&retval,
+				2, args,
+				0, NULL);
+
+		zval_ptr_dtor(&args[0]);
+		zval_ptr_dtor(&args[1]);
+		zval_ptr_dtor(&func_name);
+
+		if (call_result == FAILURE) {
+			/* stream_seek is not implemented, so disable seeks for this stream */
+			stream->flags |= PTHREADS_STREAM_FLAG_NO_SEEK;
+			/* there should be no retval to clean up */
+
+			zval_ptr_dtor(&retval);
+			stream_unlock(threaded_stream);
+
+			return -1;
+		} else if (call_result == SUCCESS && Z_TYPE(retval) != IS_UNDEF && zval_is_true(&retval)) {
+			ret = 0;
+		} else {
+			ret = -1;
+		}
+
+		zval_ptr_dtor(&retval);
+		ZVAL_UNDEF(&retval);
+
+		if (ret) {
+			stream_unlock(threaded_stream);
+			return ret;
+		}
+
+		/* now determine where we are */
+		ZVAL_STRINGL(&func_name, PTHREADS_USERSTREAM_TELL, sizeof(PTHREADS_USERSTREAM_TELL)-1);
+
+		call_result = call_user_function(NULL,
+			Z_ISUNDEF(us->object)? NULL : &us->object,
+			&func_name,
+			&retval,
+			0, NULL);
+
+		if (call_result == SUCCESS && Z_TYPE(retval) == IS_LONG) {
+			*newoffs = Z_LVAL(retval);
+			ret = 0;
+		} else if (call_result == FAILURE) {
+			php_error_docref(NULL, E_WARNING, "%s::" PTHREADS_USERSTREAM_TELL " is not implemented!", ZSTR_VAL(us->wrapper->classname));
+			ret = -1;
+		} else {
+			ret = -1;
+		}
+
+		zval_ptr_dtor(&retval);
+		zval_ptr_dtor(&func_name);
+
+		stream_unlock(threaded_stream);
+	}
+	return ret;
+}
+
+/* parse the return value from one of the stat functions and store the
+ * relevant fields into the statbuf provided */
+static int statbuf_from_array(zval *array, pthreads_stream_statbuf *ssb)
+{
+	zval *elem;
+
+#define STAT_PROP_ENTRY_EX(name, name2)                        \
+	if (NULL != (elem = zend_hash_str_find(Z_ARRVAL_P(array), #name, sizeof(#name)-1))) {     \
+		ssb->sb.st_##name2 = zval_get_long(elem);                                                      \
+	}
+
+#define STAT_PROP_ENTRY(name) STAT_PROP_ENTRY_EX(name,name)
+
+	memset(ssb, 0, sizeof(pthreads_stream_statbuf));
+	STAT_PROP_ENTRY(dev);
+	STAT_PROP_ENTRY(ino);
+	STAT_PROP_ENTRY(mode);
+	STAT_PROP_ENTRY(nlink);
+	STAT_PROP_ENTRY(uid);
+	STAT_PROP_ENTRY(gid);
+#if HAVE_STRUCT_STAT_ST_RDEV
+	STAT_PROP_ENTRY(rdev);
+#endif
+	STAT_PROP_ENTRY(size);
+	STAT_PROP_ENTRY(atime);
+	STAT_PROP_ENTRY(mtime);
+	STAT_PROP_ENTRY(ctime);
+#ifdef HAVE_STRUCT_STAT_ST_BLKSIZE
+	STAT_PROP_ENTRY(blksize);
+#endif
+#ifdef HAVE_ST_BLOCKS
+	STAT_PROP_ENTRY(blocks);
+#endif
+
+#undef STAT_PROP_ENTRY
+#undef STAT_PROP_ENTRY_EX
+	return SUCCESS;
+}
+
+static int pthreads_userstreamop_stat(pthreads_stream_t *threaded_stream, pthreads_stream_statbuf *ssb) {
+	pthreads_stream *stream = PTHREADS_FETCH_STREAMS_STREAM(threaded_stream);
+	zval func_name;
+	zval retval;
+	int call_result;
+	pthreads_userstream_data_t *us = (pthreads_userstream_data_t *)stream->abstract;
+	int ret = -1;
+
+	if(stream_lock(threaded_stream)) {
+		ZVAL_STRINGL(&func_name, PTHREADS_USERSTREAM_STAT, sizeof(PTHREADS_USERSTREAM_STAT)-1);
+
+		call_result = call_user_function(NULL,
+				Z_ISUNDEF(us->object)? NULL : &us->object,
+				&func_name,
+				&retval,
+				0, NULL);
+
+		if (call_result == SUCCESS && Z_TYPE(retval) == IS_ARRAY) {
+			if (SUCCESS == statbuf_from_array(&retval, ssb))
+				ret = 0;
+		} else {
+			if (call_result == FAILURE) {
+				php_error_docref(NULL, E_WARNING, "%s::" PTHREADS_USERSTREAM_STAT " is not implemented!",
+						ZSTR_VAL(us->wrapper->classname));
+			}
+		}
+
+		zval_ptr_dtor(&retval);
+		zval_ptr_dtor(&func_name);
+
+		stream_unlock(threaded_stream);
+	}
+	return ret;
+}
+
+
+static int pthreads_userstreamop_set_option(pthreads_stream_t *threaded_stream, int option, int value, void *ptrparam) {
+	pthreads_stream *stream = PTHREADS_FETCH_STREAMS_STREAM(threaded_stream);
+	zval func_name;
+	zval retval;
+	int call_result;
+	pthreads_userstream_data_t *us = (pthreads_userstream_data_t *)stream->abstract;
+	int ret = PTHREADS_STREAM_OPTION_RETURN_NOTIMPL;
+	zval args[3];
+
+	if(stream_lock(threaded_stream)) {
+		switch (option) {
+			case PTHREADS_STREAM_OPTION_CHECK_LIVENESS:
+				ZVAL_STRINGL(&func_name, PTHREADS_USERSTREAM_EOF, sizeof(PTHREADS_USERSTREAM_EOF)-1);
+				call_result = call_user_function(NULL, Z_ISUNDEF(us->object)? NULL : &us->object, &func_name, &retval, 0, NULL);
+				if (call_result == SUCCESS && (Z_TYPE(retval) == IS_FALSE || Z_TYPE(retval) == IS_TRUE)) {
+					ret = zval_is_true(&retval) ? PTHREADS_STREAM_OPTION_RETURN_ERR : PTHREADS_STREAM_OPTION_RETURN_OK;
+				} else {
+					ret = PTHREADS_STREAM_OPTION_RETURN_ERR;
+					php_error_docref(NULL, E_WARNING,
+							"%s::" PTHREADS_USERSTREAM_EOF " is not implemented! Assuming EOF",
+							ZSTR_VAL(us->wrapper->classname));
+				}
+				zval_ptr_dtor(&retval);
+				zval_ptr_dtor(&func_name);
+				break;
+
+			case PTHREADS_STREAM_OPTION_LOCKING:
+				ZVAL_LONG(&args[0], 0);
+
+				if (value & LOCK_NB) {
+					Z_LVAL_P(&args[0]) |= PHP_LOCK_NB;
+				}
+				switch(value & ~LOCK_NB) {
+				case LOCK_SH:
+					Z_LVAL_P(&args[0]) |= PHP_LOCK_SH;
+					break;
+				case LOCK_EX:
+					Z_LVAL_P(&args[0]) |= PHP_LOCK_EX;
+					break;
+				case LOCK_UN:
+					Z_LVAL_P(&args[0]) |= PHP_LOCK_UN;
+					break;
+				}
+
+				/* TODO wouldblock */
+				ZVAL_STRINGL(&func_name, PTHREADS_USERSTREAM_LOCK, sizeof(PTHREADS_USERSTREAM_LOCK)-1);
+
+				call_result = call_user_function_ex(NULL,
+								Z_ISUNDEF(us->object)? NULL : &us->object,
+								&func_name,
+								&retval,
+								1, args, 0, NULL);
+
+				if (call_result == SUCCESS && (Z_TYPE(retval) == IS_FALSE || Z_TYPE(retval) == IS_TRUE)) {
+					ret = (Z_TYPE(retval) == IS_FALSE);
+				} else if (call_result == FAILURE) {
+					if (value == 0) {
+						/* lock support test (TODO: more check) */
+						ret = PTHREADS_STREAM_OPTION_RETURN_OK;
+					} else {
+						php_error_docref(NULL, E_WARNING, "%s::" PTHREADS_USERSTREAM_LOCK " is not implemented!",
+								ZSTR_VAL(us->wrapper->classname));
+						ret = PTHREADS_STREAM_OPTION_RETURN_ERR;
+					}
+				}
+
+				zval_ptr_dtor(&retval);
+				zval_ptr_dtor(&func_name);
+				zval_ptr_dtor(&args[0]);
+				break;
+
+			case PTHREADS_STREAM_OPTION_TRUNCATE_API:
+				ZVAL_STRINGL(&func_name, PTHREADS_USERSTREAM_TRUNCATE, sizeof(PTHREADS_USERSTREAM_TRUNCATE)-1);
+
+				switch (value) {
+				case PTHREADS_STREAM_TRUNCATE_SUPPORTED:
+					if (zend_is_callable_ex(&func_name,
+							Z_ISUNDEF(us->object)? NULL : Z_OBJ(us->object),
+							IS_CALLABLE_CHECK_SILENT, NULL, NULL, NULL))
+						ret = PTHREADS_STREAM_OPTION_RETURN_OK;
+					else
+						ret = PTHREADS_STREAM_OPTION_RETURN_ERR;
+					break;
+
+				case PTHREADS_STREAM_TRUNCATE_SET_SIZE: {
+					ptrdiff_t new_size = *(ptrdiff_t*) ptrparam;
+					if (new_size >= 0 && new_size <= (ptrdiff_t)LONG_MAX) {
+						ZVAL_LONG(&args[0], (zend_long)new_size);
+						call_result = call_user_function_ex(NULL,
+										Z_ISUNDEF(us->object)? NULL : &us->object,
+										&func_name,
+										&retval,
+										1, args, 0, NULL);
+						if (call_result == SUCCESS && Z_TYPE(retval) != IS_UNDEF) {
+							if (Z_TYPE(retval) == IS_FALSE || Z_TYPE(retval) == IS_TRUE) {
+								ret = (Z_TYPE(retval) == IS_TRUE) ? PTHREADS_STREAM_OPTION_RETURN_OK :
+										PTHREADS_STREAM_OPTION_RETURN_ERR;
+							} else {
+								php_error_docref(NULL, E_WARNING,
+										"%s::" PTHREADS_USERSTREAM_TRUNCATE " did not return a boolean!",
+										ZSTR_VAL(us->wrapper->classname));
+							}
+						} else {
+							php_error_docref(NULL, E_WARNING,
+									"%s::" PTHREADS_USERSTREAM_TRUNCATE " is not implemented!",
+									ZSTR_VAL(us->wrapper->classname));
+						}
+						zval_ptr_dtor(&retval);
+						zval_ptr_dtor(&args[0]);
+					} else { /* bad new size */
+						ret = PTHREADS_STREAM_OPTION_RETURN_ERR;
+					}
+					break;
+				}
+				}
+				zval_ptr_dtor(&func_name);
+				break;
+
+			case PTHREADS_STREAM_OPTION_READ_BUFFER:
+			case PTHREADS_STREAM_OPTION_WRITE_BUFFER:
+			case PTHREADS_STREAM_OPTION_READ_TIMEOUT:
+			case PTHREADS_STREAM_OPTION_BLOCKING: {
+
+				ZVAL_STRINGL(&func_name, PTHREADS_USERSTREAM_SET_OPTION, sizeof(PTHREADS_USERSTREAM_SET_OPTION)-1);
+
+				ZVAL_LONG(&args[0], option);
+				ZVAL_NULL(&args[1]);
+				ZVAL_NULL(&args[2]);
+
+				switch(option) {
+				case PTHREADS_STREAM_OPTION_READ_BUFFER:
+				case PTHREADS_STREAM_OPTION_WRITE_BUFFER:
+					ZVAL_LONG(&args[1], value);
+					if (ptrparam) {
+						ZVAL_LONG(&args[2], *(long *)ptrparam);
+					} else {
+						ZVAL_LONG(&args[2], BUFSIZ);
+					}
+					break;
+				case PTHREADS_STREAM_OPTION_READ_TIMEOUT: {
+					struct timeval tv = *(struct timeval*)ptrparam;
+					ZVAL_LONG(&args[1], tv.tv_sec);
+					ZVAL_LONG(&args[2], tv.tv_usec);
+					break;
+					}
+				case PTHREADS_STREAM_OPTION_BLOCKING:
+					ZVAL_LONG(&args[1], value);
+					break;
+				default:
+					break;
+				}
+
+				call_result = call_user_function_ex(NULL,
+					Z_ISUNDEF(us->object)? NULL : &us->object,
+					&func_name,
+					&retval,
+					3, args, 0, NULL);
+
+				if (call_result == FAILURE) {
+					php_error_docref(NULL, E_WARNING, "%s::" PTHREADS_USERSTREAM_SET_OPTION " is not implemented!",
+							ZSTR_VAL(us->wrapper->classname));
+					ret = PTHREADS_STREAM_OPTION_RETURN_ERR;
+				} else if (zend_is_true(&retval)) {
+					ret = PTHREADS_STREAM_OPTION_RETURN_OK;
+				} else {
+					ret = PTHREADS_STREAM_OPTION_RETURN_ERR;
+				}
+
+				zval_ptr_dtor(&retval);
+				zval_ptr_dtor(&args[2]);
+				zval_ptr_dtor(&args[1]);
+				zval_ptr_dtor(&args[0]);
+				zval_ptr_dtor(&func_name);
+
+				break;
+			}
+		}
+		stream_unlock(threaded_stream);
+	}
+
+	return ret;
+}
+
+
+static int pthreads_user_wrapper_unlink(pthreads_stream_wrapper_t *threaded_wrapper, const char *url, int options, pthreads_stream_context_t *threaded_context) {
+	pthreads_stream_wrapper *wrapper = PTHREADS_FETCH_STREAMS_WRAPPER(threaded_wrapper);
+	struct pthreads_user_stream_wrapper *uwrap = (struct pthreads_user_stream_wrapper*)wrapper->abstract;
+	zval zfuncname, zretval;
+	zval args[1];
+	int call_result;
+	zval object;
+	int ret = 0;
+
+	if(MONITOR_LOCK(threaded_wrapper)) {
+		/* create an instance of our class */
+		pthreads_user_stream_create_object(uwrap, threaded_context, &object);
+		if (Z_TYPE(object) == IS_UNDEF) {
+			MONITOR_UNLOCK(threaded_wrapper);
+			return ret;
+		}
+
+		/* call the unlink method */
+		ZVAL_STRING(&args[0], url);
+
+		ZVAL_STRING(&zfuncname, PTHREADS_USERSTREAM_UNLINK);
+
+		call_result = call_user_function_ex(NULL,
+				&object,
+				&zfuncname,
+				&zretval,
+				1, args,
+				0, NULL	);
+
+		if (call_result == SUCCESS && (Z_TYPE(zretval) == IS_FALSE || Z_TYPE(zretval) == IS_TRUE)) {
+			ret = (Z_TYPE(zretval) == IS_TRUE);
+		} else if (call_result == FAILURE) {
+			php_error_docref(NULL, E_WARNING, "%s::" PTHREADS_USERSTREAM_UNLINK " is not implemented!", ZSTR_VAL(uwrap->classname));
+		}
+
+		/* clean up */
+		zval_ptr_dtor(&object);
+		zval_ptr_dtor(&zretval);
+		zval_ptr_dtor(&zfuncname);
+
+		zval_ptr_dtor(&args[0]);
+
+		MONITOR_UNLOCK(threaded_wrapper);
+	}
+	return ret;
+}
+
+static int pthreads_user_wrapper_rename(pthreads_stream_wrapper_t *threaded_wrapper, const char *url_from, const char *url_to,
+							   int options, pthreads_stream_context_t *threaded_context) {
+	pthreads_stream_wrapper *wrapper = PTHREADS_FETCH_STREAMS_WRAPPER(threaded_wrapper);
+	struct pthreads_user_stream_wrapper *uwrap = (struct pthreads_user_stream_wrapper*)wrapper->abstract;
+	zval zfuncname, zretval;
+	zval args[2];
+	int call_result;
+	zval object;
+	int ret = 0;
+
+	if(MONITOR_LOCK(threaded_wrapper)) {
+		/* create an instance of our class */
+		pthreads_user_stream_create_object(uwrap, threaded_context, &object);
+		if (Z_TYPE(object) == IS_UNDEF) {
+			MONITOR_UNLOCK(threaded_wrapper);
+			return ret;
+		}
+
+		/* call the rename method */
+		ZVAL_STRING(&args[0], url_from);
+		ZVAL_STRING(&args[1], url_to);
+
+		ZVAL_STRING(&zfuncname, PTHREADS_USERSTREAM_RENAME);
+
+		call_result = call_user_function_ex(NULL,
+				&object,
+				&zfuncname,
+				&zretval,
+				2, args,
+				0, NULL	);
+
+		if (call_result == SUCCESS && (Z_TYPE(zretval) == IS_FALSE || Z_TYPE(zretval) == IS_TRUE)) {
+			ret = (Z_TYPE(zretval) == IS_TRUE);
+		} else if (call_result == FAILURE) {
+			php_error_docref(NULL, E_WARNING, "%s::" PTHREADS_USERSTREAM_RENAME " is not implemented!", ZSTR_VAL(uwrap->classname));
+		}
+
+		/* clean up */
+		zval_ptr_dtor(&object);
+		zval_ptr_dtor(&zretval);
+
+		zval_ptr_dtor(&zfuncname);
+		zval_ptr_dtor(&args[1]);
+		zval_ptr_dtor(&args[0]);
+
+		MONITOR_UNLOCK(threaded_wrapper);
+	}
+	return ret;
+}
+
+static int pthreads_user_wrapper_mkdir(pthreads_stream_wrapper_t *threaded_wrapper, const char *url, int mode,
+							  int options, pthreads_stream_context_t *threaded_context) {
+	pthreads_stream_wrapper *wrapper = PTHREADS_FETCH_STREAMS_WRAPPER(threaded_wrapper);
+	struct pthreads_user_stream_wrapper *uwrap = (struct pthreads_user_stream_wrapper*)wrapper->abstract;
+	zval zfuncname, zretval;
+	zval args[3];
+	int call_result;
+	zval object;
+	int ret = 0;
+
+	if(MONITOR_LOCK(threaded_wrapper)) {
+		/* create an instance of our class */
+		pthreads_user_stream_create_object(uwrap, threaded_context, &object);
+		if (Z_TYPE(object) == IS_UNDEF) {
+			return ret;
+		}
+
+		/* call the mkdir method */
+		ZVAL_STRING(&args[0], url);
+		ZVAL_LONG(&args[1], mode);
+		ZVAL_LONG(&args[2], options);
+
+		ZVAL_STRING(&zfuncname, PTHREADS_USERSTREAM_MKDIR);
+
+		call_result = call_user_function_ex(NULL,
+				&object,
+				&zfuncname,
+				&zretval,
+				3, args,
+				0, NULL	);
+
+		if (call_result == SUCCESS && (Z_TYPE(zretval) == IS_FALSE || Z_TYPE(zretval) == IS_TRUE)) {
+			ret = (Z_TYPE(zretval) == IS_TRUE);
+		} else if (call_result == FAILURE) {
+			php_error_docref(NULL, E_WARNING, "%s::" PTHREADS_USERSTREAM_MKDIR " is not implemented!", ZSTR_VAL(uwrap->classname));
+		}
+
+		/* clean up */
+		zval_ptr_dtor(&object);
+		zval_ptr_dtor(&zretval);
+
+		zval_ptr_dtor(&zfuncname);
+		zval_ptr_dtor(&args[2]);
+		zval_ptr_dtor(&args[1]);
+		zval_ptr_dtor(&args[0]);
+
+		MONITOR_UNLOCK(threaded_wrapper);
+	}
+	return ret;
+}
+
+static int pthreads_user_wrapper_rmdir(pthreads_stream_wrapper_t *threaded_wrapper, const char *url,
+							  int options, pthreads_stream_context_t *threaded_context) {
+	pthreads_stream_wrapper *wrapper = PTHREADS_FETCH_STREAMS_WRAPPER(threaded_wrapper);
+	struct pthreads_user_stream_wrapper *uwrap = (struct pthreads_user_stream_wrapper*)wrapper->abstract;
+	zval zfuncname, zretval;
+	zval args[2];
+	int call_result;
+	zval object;
+	int ret = 0;
+
+	if(MONITOR_LOCK(threaded_wrapper)) {
+		/* create an instance of our class */
+		pthreads_user_stream_create_object(uwrap, threaded_context, &object);
+		if (Z_TYPE(object) == IS_UNDEF) {
+			MONITOR_UNLOCK(threaded_wrapper);
+			return ret;
+		}
+
+		/* call the rmdir method */
+		ZVAL_STRING(&args[0], url);
+		ZVAL_LONG(&args[1], options);
+
+		ZVAL_STRING(&zfuncname, PTHREADS_USERSTREAM_RMDIR);
+
+		call_result = call_user_function_ex(NULL,
+				&object,
+				&zfuncname,
+				&zretval,
+				2, args,
+				0, NULL	);
+
+		if (call_result == SUCCESS && (Z_TYPE(zretval) == IS_FALSE || Z_TYPE(zretval) == IS_TRUE)) {
+			ret = (Z_TYPE(zretval) == IS_TRUE);
+		} else if (call_result == FAILURE) {
+			php_error_docref(NULL, E_WARNING, "%s::" PTHREADS_USERSTREAM_RMDIR " is not implemented!", ZSTR_VAL(uwrap->classname));
+		}
+
+		/* clean up */
+		zval_ptr_dtor(&object);
+		zval_ptr_dtor(&zretval);
+
+		zval_ptr_dtor(&zfuncname);
+		zval_ptr_dtor(&args[1]);
+		zval_ptr_dtor(&args[0]);
+
+		MONITOR_UNLOCK(threaded_wrapper);
+	}
+	return ret;
+}
+
+static int pthreads_user_wrapper_metadata(pthreads_stream_wrapper_t *threaded_wrapper, const char *url, int option,
+								 void *value, pthreads_stream_context_t *threaded_context) {
+	pthreads_stream_wrapper *wrapper = PTHREADS_FETCH_STREAMS_WRAPPER(threaded_wrapper);
+	struct pthreads_user_stream_wrapper *uwrap = (struct pthreads_user_stream_wrapper*)wrapper->abstract;
+	zval zfuncname, zretval;
+	zval args[3];
+	int call_result;
+	zval object;
+	int ret = 0;
+
+	if(MONITOR_LOCK(threaded_wrapper)) {
+		switch(option) {
+			case PTHREADS_STREAM_META_TOUCH:
+				array_init(&args[2]);
+				if(value) {
+					struct utimbuf *newtime = (struct utimbuf *)value;
+					add_index_long(&args[2], 0, newtime->modtime);
+					add_index_long(&args[2], 1, newtime->actime);
+				}
+				break;
+			case PTHREADS_STREAM_META_GROUP:
+			case PTHREADS_STREAM_META_OWNER:
+			case PTHREADS_STREAM_META_ACCESS:
+				ZVAL_LONG(&args[2], *(long *)value);
+				break;
+			case PTHREADS_STREAM_META_GROUP_NAME:
+			case PTHREADS_STREAM_META_OWNER_NAME:
+				ZVAL_STRING(&args[2], value);
+				break;
+			default:
+				php_error_docref(NULL, E_WARNING, "Unknown option %d for " PTHREADS_USERSTREAM_METADATA, option);
+				zval_ptr_dtor(&args[2]);
+				MONITOR_UNLOCK(threaded_wrapper);
+				return ret;
+		}
+
+		/* create an instance of our class */
+		pthreads_user_stream_create_object(uwrap, threaded_context, &object);
+		if (Z_TYPE(object) == IS_UNDEF) {
+			zval_ptr_dtor(&args[2]);
+			MONITOR_UNLOCK(threaded_wrapper);
+			return ret;
+		}
+
+		/* call the mkdir method */
+		ZVAL_STRING(&args[0], url);
+		ZVAL_LONG(&args[1], option);
+
+		ZVAL_STRING(&zfuncname, PTHREADS_USERSTREAM_METADATA);
+
+		call_result = call_user_function_ex(NULL,
+				&object,
+				&zfuncname,
+				&zretval,
+				3, args,
+				0, NULL	);
+
+		if (call_result == SUCCESS && (Z_TYPE(zretval) == IS_FALSE || Z_TYPE(zretval) == IS_TRUE)) {
+			ret = Z_TYPE(zretval) == IS_TRUE;
+		} else if (call_result == FAILURE) {
+			php_error_docref(NULL, E_WARNING, "%s::" PTHREADS_USERSTREAM_METADATA " is not implemented!", ZSTR_VAL(uwrap->classname));
+		}
+
+		/* clean up */
+		zval_ptr_dtor(&object);
+		zval_ptr_dtor(&zretval);
+
+		zval_ptr_dtor(&zfuncname);
+		zval_ptr_dtor(&args[0]);
+		zval_ptr_dtor(&args[1]);
+		zval_ptr_dtor(&args[2]);
+
+		MONITOR_UNLOCK(threaded_wrapper);
+	}
+	return ret;
+}
+
+
+static int pthreads_user_wrapper_stat_url(pthreads_stream_wrapper_t *threaded_wrapper, const char *url, int flags,
+								 pthreads_stream_statbuf *ssb, pthreads_stream_context_t *threaded_context) {
+	pthreads_stream_wrapper *wrapper = PTHREADS_FETCH_STREAMS_WRAPPER(threaded_wrapper);
+	struct pthreads_user_stream_wrapper *uwrap = (struct pthreads_user_stream_wrapper*)wrapper->abstract;
+	zval zfuncname, zretval;
+	zval args[2];
+	int call_result;
+	zval object;
+	int ret = -1;
+
+	if(MONITOR_LOCK(threaded_wrapper)) {
+		/* create an instance of our class */
+		pthreads_user_stream_create_object(uwrap, threaded_context, &object);
+		if (Z_TYPE(object) == IS_UNDEF) {
+			MONITOR_UNLOCK(threaded_wrapper);
+			return ret;
+		}
+
+		/* call it's stat_url method - set up params first */
+		ZVAL_STRING(&args[0], url);
+		ZVAL_LONG(&args[1], flags);
+
+		ZVAL_STRING(&zfuncname, PTHREADS_USERSTREAM_STATURL);
+
+		call_result = call_user_function_ex(NULL,
+				&object,
+				&zfuncname,
+				&zretval,
+				2, args,
+				0, NULL	);
+
+		if (call_result == SUCCESS && Z_TYPE(zretval) == IS_ARRAY) {
+			/* We got the info we needed */
+			if (SUCCESS == statbuf_from_array(&zretval, ssb))
+				ret = 0;
+		} else {
+			if (call_result == FAILURE) {
+				php_error_docref(NULL, E_WARNING, "%s::" PTHREADS_USERSTREAM_STATURL " is not implemented!",
+						ZSTR_VAL(uwrap->classname));
+			}
+		}
+
+		/* clean up */
+		zval_ptr_dtor(&object);
+		zval_ptr_dtor(&zretval);
+
+		zval_ptr_dtor(&zfuncname);
+		zval_ptr_dtor(&args[1]);
+		zval_ptr_dtor(&args[0]);
+
+		MONITOR_UNLOCK(threaded_wrapper);
+	}
+	return ret;
+
+}
+
+static size_t pthreads_userstreamop_readdir(pthreads_stream_t *threaded_stream, char *buf, size_t count) {
+	pthreads_stream *stream = PTHREADS_FETCH_STREAMS_STREAM(threaded_stream);
+	zval func_name;
+	zval retval;
+	int call_result;
+	size_t didread = 0;
+	pthreads_userstream_data_t *us = (pthreads_userstream_data_t *)stream->abstract;
+	pthreads_stream_dirent *ent = (pthreads_stream_dirent*)buf;
+
+	/* avoid problems if someone mis-uses the stream */
+	if (count != sizeof(pthreads_stream_dirent))
+		return 0;
+
+	if(stream_lock(threaded_stream)) {
+		ZVAL_STRINGL(&func_name, PTHREADS_USERSTREAM_DIR_READ, sizeof(PTHREADS_USERSTREAM_DIR_READ)-1);
+
+		call_result = call_user_function(NULL,
+				Z_ISUNDEF(us->object)? NULL : &us->object,
+				&func_name,
+				&retval,
+				0, NULL);
+
+		if (call_result == SUCCESS && Z_TYPE(retval) != IS_FALSE && Z_TYPE(retval) != IS_TRUE) {
+			convert_to_string(&retval);
+			PHP_STRLCPY(ent->d_name, Z_STRVAL(retval), sizeof(ent->d_name), Z_STRLEN(retval));
+
+			didread = sizeof(pthreads_stream_dirent);
+		} else if (call_result == FAILURE) {
+			php_error_docref(NULL, E_WARNING, "%s::" PTHREADS_USERSTREAM_DIR_READ " is not implemented!",
+					ZSTR_VAL(us->wrapper->classname));
+		}
+
+		zval_ptr_dtor(&retval);
+		zval_ptr_dtor(&func_name);
+
+		stream_unlock(threaded_stream);
+	}
+	return didread;
+}
+
+static int pthreads_userstreamop_closedir(pthreads_stream_t *threaded_stream, int close_handle) {
+	pthreads_stream *stream = PTHREADS_FETCH_STREAMS_STREAM(threaded_stream);
+	zval func_name;
+	zval retval;
+	pthreads_userstream_data_t *us = (pthreads_userstream_data_t *)stream->abstract;
+
+	assert(us != NULL);
+
+	ZVAL_STRINGL(&func_name, PTHREADS_USERSTREAM_DIR_CLOSE, sizeof(PTHREADS_USERSTREAM_DIR_CLOSE)-1);
+
+	call_user_function(NULL,
+			Z_ISUNDEF(us->object)? NULL : &us->object,
+			&func_name,
+			&retval,
+			0, NULL);
+
+	zval_ptr_dtor(&retval);
+	zval_ptr_dtor(&func_name);
+
+	return 0;
+}
+
+static void pthreads_userstreamop_freedir(pthreads_stream_t *threaded_stream, int close_handle) {
+	pthreads_stream *stream = PTHREADS_FETCH_STREAMS_STREAM(threaded_stream);
+	pthreads_userstream_data_t *us = (pthreads_userstream_data_t *)stream->abstract;
+
+	assert(us != NULL);
+
+	zval_ptr_dtor(&us->object);
+	ZVAL_UNDEF(&us->object);
+
+	free(us);
+}
+
+static int pthreads_userstreamop_rewinddir(pthreads_stream_t *threaded_stream, zend_off_t offset, int whence, zend_off_t *newoffs) {
+	pthreads_stream *stream = PTHREADS_FETCH_STREAMS_STREAM(threaded_stream);
+	zval func_name;
+	zval retval;
+	pthreads_userstream_data_t *us = (pthreads_userstream_data_t *)stream->abstract;
+
+	if(stream_lock(threaded_stream)) {
+		ZVAL_STRINGL(&func_name, PTHREADS_USERSTREAM_DIR_REWIND, sizeof(PTHREADS_USERSTREAM_DIR_REWIND)-1);
+
+		call_user_function(NULL,
+				Z_ISUNDEF(us->object)? NULL : &us->object,
+				&func_name,
+				&retval,
+				0, NULL);
+
+		zval_ptr_dtor(&retval);
+		zval_ptr_dtor(&func_name);
+
+		stream_unlock(threaded_stream);
+	}
+	return 0;
+
+}
+
+static int pthreads_userstreamop_cast(pthreads_stream_t *threaded_stream, int castas, void **retptr) {
+	pthreads_stream *stream = PTHREADS_FETCH_STREAMS_STREAM(threaded_stream);
+	pthreads_stream_t *intstream = NULL;
+	pthreads_userstream_data_t *us = (pthreads_userstream_data_t *)stream->abstract;
+	zval func_name;
+	zval retval;
+	zval args[1];
+	int call_result;
+	int ret = FAILURE;
+
+	if(stream_lock(threaded_stream)) {
+		ZVAL_STRINGL(&func_name, PTHREADS_USERSTREAM_CAST, sizeof(PTHREADS_USERSTREAM_CAST)-1);
+
+		switch(castas) {
+		case PTHREADS_STREAM_AS_FD_FOR_SELECT:
+			ZVAL_LONG(&args[0], PTHREADS_STREAM_AS_FD_FOR_SELECT);
+			break;
+		default:
+			ZVAL_LONG(&args[0], PTHREADS_STREAM_AS_STDIO);
+			break;
+		}
+
+		call_result = call_user_function_ex(NULL,
+				Z_ISUNDEF(us->object)? NULL : &us->object,
+				&func_name,
+				&retval,
+				1, args, 0, NULL);
+
+		do {
+			if (call_result == FAILURE) {
+				php_error_docref(NULL, E_WARNING, "%s::" PTHREADS_USERSTREAM_CAST " is not implemented!",
+						ZSTR_VAL(us->wrapper->classname));
+				break;
+			}
+			if (!zend_is_true(&retval)) {
+				break;
+			}
+			if(!IS_PTHREADS_OBJECT(&retval)) {
+				php_error_docref(NULL, E_WARNING, "%s::" PTHREADS_USERSTREAM_CAST " must return a stream object",
+						ZSTR_VAL(us->wrapper->classname));
+				break;
+			}
+			intstream = PTHREADS_FETCH_FROM(Z_OBJ_P(&retval));
+
+			if (intstream == threaded_stream) {
+				php_error_docref(NULL, E_WARNING, "%s::" PTHREADS_USERSTREAM_CAST " must not return itself",
+						ZSTR_VAL(us->wrapper->classname));
+				intstream = NULL;
+				break;
+			}
+			ret = pthreads_stream_cast(intstream, castas, retptr, 1);
+		} while (0);
+
+		zval_ptr_dtor(&retval);
+		zval_ptr_dtor(&func_name);
+		zval_ptr_dtor(&args[0]);
+
+		stream_unlock(threaded_stream);
+	}
+	return ret;
+}
+
+const pthreads_stream_ops pthreads_stream_userspace_ops = {
+	pthreads_userstreamop_write, pthreads_userstreamop_read,
+	pthreads_userstreamop_close, pthreads_userstreamop_free,
+	pthreads_userstreamop_flush,
+	"user-space",
+	pthreads_userstreamop_seek,
+	pthreads_userstreamop_cast,
+	pthreads_userstreamop_stat,
+	pthreads_userstreamop_set_option,
+};
+
+const pthreads_stream_ops pthreads_stream_userspace_dir_ops = {
+	NULL, /* write */
+	pthreads_userstreamop_readdir,
+	pthreads_userstreamop_closedir,
+	pthreads_userstreamop_freedir,
+	NULL, /* flush */
+	"user-space-dir",
+	pthreads_userstreamop_rewinddir,
+	NULL, /* cast */
+	NULL, /* stat */
+	NULL  /* set_option */
+};
+
+#endif

--- a/src/streams/wrappers/user_wrapper.h
+++ b/src/streams/wrappers/user_wrapper.h
@@ -1,0 +1,40 @@
+/*
+  +----------------------------------------------------------------------+
+  | pthreads                                                             |
+  +----------------------------------------------------------------------+
+  | Copyright (c) Joe Watkins 2018                                       |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | http://www.php.net/license/3_01.txt                                  |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors: Bastian Schneider <b.schneider@badnoob.com>                 |
+  | Borrowed code from php-src                                           |
+  +----------------------------------------------------------------------+
+ */
+#ifndef HAVE_PTHREADS_STREAMS_WRAPPERS_USER_WRAPPER_H
+#define HAVE_PTHREADS_STREAMS_WRAPPERS_USER_WRAPPER_H
+
+struct pthreads_user_stream_wrapper {
+	char * protoname;
+	zend_string *classname;
+	pthreads_stream_wrapper_t *threaded_wrapper;
+};
+
+struct _pthreads_userstream_data {
+	struct pthreads_user_stream_wrapper *wrapper;
+	zval object;
+};
+typedef struct _pthreads_userstream_data pthreads_userstream_data_t;
+
+extern const pthreads_stream_wrapper_ops pthreads_user_stream_wops;
+extern const pthreads_stream_ops pthreads_stream_userspace_ops;
+extern const pthreads_stream_ops pthreads_stream_userspace_dir_ops;
+#define PTHREADS_STREAM_IS_USERSPACE &pthreads_stream_userspace_ops
+#define PTHREADS_STREAM_IS_USERSPACE_DIR &pthreads_stream_userspace_dir_ops
+
+#endif

--- a/src/streams/xp_socket.c
+++ b/src/streams/xp_socket.c
@@ -1,0 +1,926 @@
+/*
+  +----------------------------------------------------------------------+
+  | pthreads                                                             |
+  +----------------------------------------------------------------------+
+  | Copyright (c) Joe Watkins 2018                                       |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | http://www.php.net/license/3_01.txt                                  |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors: Bastian Schneider <b.schneider@badnoob.com>                 |
+  | Borrowed code from php-src                                           |
+  +----------------------------------------------------------------------+
+ */
+#ifndef HAVE_PTHREADS_STREAMS_XP_SOCKET
+#define HAVE_PTHREADS_STREAMS_XP_SOCKET
+
+#ifndef HAVE_PTHREADS_H
+#	include <src/pthreads.h>
+#endif
+
+#ifndef HAVE_PTHREADS_STREAM_H
+#	include <src/streams.h>
+#endif
+
+#ifndef HAVE_PTHREADS_NETWORK_H
+#	include <src/network.h> // defines php_netstream_data_t
+#endif
+
+#ifndef FILE_H
+#	include <ext/standard/file.h>
+#endif
+
+#ifdef PHP_WIN32
+/* send/recv family on windows expects int */
+# define PTHREADS_XP_SOCK_BUF_SIZE(sz) (((sz) > INT_MAX) ? INT_MAX : (int)(sz))
+#else
+# define PTHREADS_XP_SOCK_BUF_SIZE(sz) (sz)
+#endif
+
+const pthreads_stream_ops pthreads_stream_generic_socket_ops;
+const pthreads_stream_ops pthreads_stream_socket_ops;
+const pthreads_stream_ops pthreads_stream_udp_socket_ops;
+#ifdef AF_UNIX
+const pthreads_stream_ops pthreads_stream_unix_socket_ops;
+const pthreads_stream_ops pthreads_stream_unixdg_socket_ops;
+#endif
+
+static int pthreads_tcp_sockop_set_option(pthreads_stream_t *threaded_stream, int option, int value, void *ptrparam);
+
+/* {{{ Generic socket stream operations */
+static size_t pthreads_sockop_write(pthreads_stream_t *threaded_stream, const char *buf, size_t count) {
+	pthreads_stream *stream = PTHREADS_FETCH_STREAMS_STREAM(threaded_stream);
+	pthreads_netstream_data_t *sock = (pthreads_netstream_data_t*)stream->abstract;
+	int didwrite;
+	struct timeval *ptimeout;
+
+	if (!sock || sock->socket == -1) {
+		return 0;
+	}
+
+	if (sock->timeout.tv_sec == -1)
+		ptimeout = NULL;
+	else
+		ptimeout = &sock->timeout;
+
+retry:
+	didwrite = send(sock->socket, buf, PTHREADS_XP_SOCK_BUF_SIZE(count), (sock->is_blocked && ptimeout) ? MSG_DONTWAIT : 0);
+
+	if (didwrite <= 0) {
+		int err = php_socket_errno();
+		char *estr;
+
+		if (sock->is_blocked && (err == EWOULDBLOCK || err == EAGAIN)) {
+			int retval;
+
+			sock->timeout_event = 0;
+
+			do {
+				retval = php_pollfd_for(sock->socket, POLLOUT, ptimeout);
+
+				if (retval == 0) {
+					sock->timeout_event = 1;
+					break;
+				}
+
+				if (retval > 0) {
+					/* writable now; retry */
+					goto retry;
+				}
+
+				err = php_socket_errno();
+			} while (err == EINTR);
+		}
+		estr = php_socket_strerror(err, NULL, 0);
+		php_error_docref(NULL, E_NOTICE, "send of " ZEND_LONG_FMT " bytes failed with errno=%d %s",
+				(zend_long)count, err, estr);
+		efree(estr);
+	}
+
+	if (didwrite > 0) {
+		pthreads_stream_notify_progress_increment(pthreads_stream_get_context(threaded_stream), didwrite, 0);
+	}
+
+	if (didwrite < 0) {
+		didwrite = 0;
+	}
+
+	return didwrite;
+}
+
+static void pthreads_sock_stream_wait_for_data(pthreads_stream_t *threaded_stream, pthreads_netstream_data_t *sock)
+{
+	int retval;
+	struct timeval *ptimeout;
+
+	if (!sock || sock->socket == -1) {
+		return;
+	}
+
+	sock->timeout_event = 0;
+
+	if (sock->timeout.tv_sec == -1)
+		ptimeout = NULL;
+	else
+		ptimeout = &sock->timeout;
+
+	while(1) {
+		retval = php_pollfd_for(sock->socket, PHP_POLLREADABLE, ptimeout);
+
+		if (retval == 0)
+			sock->timeout_event = 1;
+
+		if (retval >= 0)
+			break;
+
+		if (php_socket_errno() != EINTR)
+			break;
+	}
+}
+
+static size_t pthreads_sockop_read(pthreads_stream_t *threaded_stream, char *buf, size_t count) {
+	pthreads_stream *stream = PTHREADS_FETCH_STREAMS_STREAM(threaded_stream);
+	pthreads_netstream_data_t *sock = (pthreads_netstream_data_t*)stream->abstract;
+	ssize_t nr_bytes = 0;
+	int err;
+
+	if (!sock || sock->socket == -1) {
+		return 0;
+	}
+
+	if (sock->is_blocked) {
+		pthreads_sock_stream_wait_for_data(threaded_stream, sock);
+		if (sock->timeout_event)
+			return 0;
+	}
+
+	nr_bytes = recv(sock->socket, buf, PTHREADS_XP_SOCK_BUF_SIZE(count), (sock->is_blocked && sock->timeout.tv_sec != -1) ? MSG_DONTWAIT : 0);
+	err = php_socket_errno();
+
+	stream->eof = (nr_bytes == 0 || (nr_bytes == -1 && err != EWOULDBLOCK && err != EAGAIN));
+
+	if (nr_bytes > 0) {
+		pthreads_stream_notify_progress_increment(pthreads_stream_get_context(threaded_stream), nr_bytes, 0);
+	}
+
+	if (nr_bytes < 0) {
+		nr_bytes = 0;
+	}
+
+	return nr_bytes;
+}
+
+
+static int pthreads_sockop_close(pthreads_stream_t *threaded_stream, int close_handle) {
+	pthreads_stream *stream = PTHREADS_FETCH_STREAMS_STREAM(threaded_stream);
+	pthreads_netstream_data_t *sock = (pthreads_netstream_data_t*)stream->abstract;
+#ifdef PHP_WIN32
+	int n;
+#endif
+
+	if (!sock) {
+		return 0;
+	}
+
+	if (close_handle) {
+
+#ifdef PHP_WIN32
+		if (sock->socket == -1)
+			sock->socket = SOCK_ERR;
+#endif
+		if (sock->socket != SOCK_ERR) {
+#ifdef PHP_WIN32
+			/* prevent more data from coming in */
+			shutdown(sock->socket, PTHREADS_SHUT_RD);
+
+			/* try to make sure that the OS sends all data before we close the connection.
+			 * Essentially, we are waiting for the socket to become writeable, which means
+			 * that all pending data has been sent.
+			 * We use a small timeout which should encourage the OS to send the data,
+			 * but at the same time avoid hanging indefinitely.
+			 * */
+			do {
+				n = php_pollfd_for_ms(sock->socket, POLLOUT, 500);
+			} while (n == -1 && php_socket_errno() == EINTR);
+#endif
+			closesocket(sock->socket);
+			sock->socket = SOCK_ERR;
+		}
+	}
+	return 0;
+}
+
+static void pthreads_sockop_free(pthreads_stream_t *threaded_stream, int close_handle) {
+	pthreads_stream *stream = PTHREADS_FETCH_STREAMS_STREAM(threaded_stream);
+	pthreads_netstream_data_t *sock = (pthreads_netstream_data_t*)stream->abstract;
+
+	if (!sock) {
+		return;
+	}
+	free(sock);
+}
+
+static int pthreads_sockop_flush(pthreads_stream_t *threaded_stream) {
+#if 0
+	pthreads_stream *stream = PTHREADS_FETCH_STREAMS_STREAM(threaded_stream);
+	pthreads_netstream_data_t *sock = (pthreads_netstream_data_t*)stream->abstract;
+	return fsync(sock->socket);
+#endif
+	return 0;
+}
+
+static int pthreads_sockop_stat(pthreads_stream_t *threaded_stream, pthreads_stream_statbuf *ssb)
+{
+#if ZEND_WIN32
+	return 0;
+#else
+	pthreads_stream *stream = PTHREADS_FETCH_STREAMS_STREAM(threaded_stream);
+	pthreads_netstream_data_t *sock = (pthreads_netstream_data_t*)stream->abstract;
+
+	return zend_fstat(sock->socket, &ssb->sb);
+#endif
+}
+
+static inline int sock_sendto(pthreads_netstream_data_t *sock, const char *buf, size_t buflen, int flags,
+		struct sockaddr *addr, socklen_t addrlen
+		)
+{
+	int ret;
+	if (addr) {
+		ret = sendto(sock->socket, buf, PTHREADS_XP_SOCK_BUF_SIZE(buflen), flags, addr, PTHREADS_XP_SOCK_BUF_SIZE(addrlen));
+
+		return (ret == SOCK_CONN_ERR) ? -1 : ret;
+	}
+#ifdef PHP_WIN32
+	return ((ret = send(sock->socket, buf, buflen > INT_MAX ? INT_MAX : (int)buflen, flags)) == SOCK_CONN_ERR) ? -1 : ret;
+#else
+	return ((ret = send(sock->socket, buf, buflen, flags)) == SOCK_CONN_ERR) ? -1 : ret;
+#endif
+}
+
+static inline int sock_recvfrom(pthreads_netstream_data_t *sock, char *buf, size_t buflen, int flags,
+		zend_string **textaddr,
+		struct sockaddr **addr, socklen_t *addrlen
+		)
+{
+	int ret;
+	int want_addr = textaddr || addr;
+
+	if (want_addr) {
+		php_sockaddr_storage sa;
+		socklen_t sl = sizeof(sa);
+		ret = recvfrom(sock->socket, buf, PTHREADS_XP_SOCK_BUF_SIZE(buflen), flags, (struct sockaddr*)&sa, &sl);
+		ret = (ret == SOCK_CONN_ERR) ? -1 : ret;
+		if (sl) {
+			php_network_populate_name_from_sockaddr((struct sockaddr*)&sa, sl,
+					textaddr, addr, addrlen);
+		} else {
+			if (textaddr) {
+				*textaddr = ZSTR_EMPTY_ALLOC();
+			}
+			if (addr) {
+				*addr = NULL;
+				*addrlen = 0;
+			}
+		}
+	} else {
+		ret = recv(sock->socket, buf, PTHREADS_XP_SOCK_BUF_SIZE(buflen), flags);
+		ret = (ret == SOCK_CONN_ERR) ? -1 : ret;
+	}
+
+	return ret;
+}
+
+static int pthreads_sockop_set_option(pthreads_stream_t *threaded_stream, int option, int value, void *ptrparam){
+	int oldmode, flags;
+	pthreads_stream *stream = PTHREADS_FETCH_STREAMS_STREAM(threaded_stream);
+	pthreads_netstream_data_t *sock = (pthreads_netstream_data_t*)stream->abstract;
+	pthreads_stream_xport_param *xparam;
+
+	if (!sock) {
+		return PTHREADS_STREAM_OPTION_RETURN_NOTIMPL;
+	}
+
+	switch(option) {
+		case PTHREADS_STREAM_OPTION_CHECK_LIVENESS:
+			{
+				struct timeval tv;
+				char buf;
+				int alive = 1;
+
+				if (value == -1) {
+					if (sock->timeout.tv_sec == -1) {
+						tv.tv_sec = FG(default_socket_timeout);
+						tv.tv_usec = 0;
+					} else {
+						tv = sock->timeout;
+					}
+				} else {
+					tv.tv_sec = value;
+					tv.tv_usec = 0;
+				}
+
+				if (sock->socket == -1) {
+					alive = 0;
+				} else if (php_pollfd_for(sock->socket, PHP_POLLREADABLE|POLLPRI, &tv) > 0) {
+#ifdef PHP_WIN32
+					int ret;
+#else
+					ssize_t ret;
+#endif
+					int err;
+
+					ret = recv(sock->socket, &buf, sizeof(buf), MSG_PEEK);
+					err = php_socket_errno();
+
+					if (0 == ret || /* the counterpart did properly shutdown*/
+						(0 > ret && err != EWOULDBLOCK && err != EAGAIN && err != EMSGSIZE)) { /* there was an unrecoverable error */
+						alive = 0;
+					}
+				}
+				return alive ? PTHREADS_STREAM_OPTION_RETURN_OK : PTHREADS_STREAM_OPTION_RETURN_ERR;
+			}
+
+		case PTHREADS_STREAM_OPTION_BLOCKING:
+			oldmode = sock->is_blocked;
+			if (SUCCESS == php_set_sock_blocking(sock->socket, value)) {
+				sock->is_blocked = value;
+				return oldmode;
+			}
+			return PTHREADS_STREAM_OPTION_RETURN_ERR;
+
+		case PTHREADS_STREAM_OPTION_READ_TIMEOUT:
+			sock->timeout = *(struct timeval*)ptrparam;
+			sock->timeout_event = 0;
+			return PTHREADS_STREAM_OPTION_RETURN_OK;
+
+		case PTHREADS_STREAM_OPTION_META_DATA_API:
+			add_assoc_bool((zval *)ptrparam, "timed_out", sock->timeout_event);
+			add_assoc_bool((zval *)ptrparam, "blocked", sock->is_blocked);
+			add_assoc_bool((zval *)ptrparam, "eof", stream->eof);
+			return PTHREADS_STREAM_OPTION_RETURN_OK;
+
+		case PTHREADS_STREAM_OPTION_XPORT_API:
+			xparam = (pthreads_stream_xport_param *)ptrparam;
+
+			switch (xparam->op) {
+				case PTHREADS_STREAM_XPORT_OP_LISTEN:
+					xparam->outputs.returncode = (listen(sock->socket, xparam->inputs.backlog) == 0) ?  0: -1;
+					return PTHREADS_STREAM_OPTION_RETURN_OK;
+
+				case PTHREADS_STREAM_XPORT_OP_GET_NAME:
+					xparam->outputs.returncode = php_network_get_sock_name(sock->socket,
+							xparam->want_textaddr ? &xparam->outputs.textaddr : NULL,
+							xparam->want_addr ? &xparam->outputs.addr : NULL,
+							xparam->want_addr ? &xparam->outputs.addrlen : NULL
+							);
+					return PTHREADS_STREAM_OPTION_RETURN_OK;
+
+				case PTHREADS_STREAM_XPORT_OP_GET_PEER_NAME:
+					xparam->outputs.returncode = php_network_get_peer_name(sock->socket,
+							xparam->want_textaddr ? &xparam->outputs.textaddr : NULL,
+							xparam->want_addr ? &xparam->outputs.addr : NULL,
+							xparam->want_addr ? &xparam->outputs.addrlen : NULL
+							);
+					return PTHREADS_STREAM_OPTION_RETURN_OK;
+
+				case PTHREADS_STREAM_XPORT_OP_SEND:
+					flags = 0;
+					if ((xparam->inputs.flags & PTHREADS_STREAM_OOB) == PTHREADS_STREAM_OOB) {
+						flags |= MSG_OOB;
+					}
+					xparam->outputs.returncode = sock_sendto(sock,
+							xparam->inputs.buf, xparam->inputs.buflen,
+							flags,
+							xparam->inputs.addr,
+							xparam->inputs.addrlen);
+					if (xparam->outputs.returncode == -1) {
+						char *err = php_socket_strerror(php_socket_errno(), NULL, 0);
+						php_error_docref(NULL, E_WARNING,
+						   	"%s\n", err);
+						efree(err);
+					}
+					return PTHREADS_STREAM_OPTION_RETURN_OK;
+
+				case PTHREADS_STREAM_XPORT_OP_RECV:
+					flags = 0;
+					if ((xparam->inputs.flags & PTHREADS_STREAM_OOB) == PTHREADS_STREAM_OOB) {
+						flags |= MSG_OOB;
+					}
+					if ((xparam->inputs.flags & PTHREADS_STREAM_PEEK) == PTHREADS_STREAM_PEEK) {
+						flags |= MSG_PEEK;
+					}
+					xparam->outputs.returncode = sock_recvfrom(sock,
+							xparam->inputs.buf, xparam->inputs.buflen,
+							flags,
+							xparam->want_textaddr ? &xparam->outputs.textaddr : NULL,
+							xparam->want_addr ? &xparam->outputs.addr : NULL,
+							xparam->want_addr ? &xparam->outputs.addrlen : NULL
+							);
+					return PTHREADS_STREAM_OPTION_RETURN_OK;
+
+
+#ifdef HAVE_SHUTDOWN
+# ifndef SHUT_RD
+#  define SHUT_RD 0
+# endif
+# ifndef SHUT_WR
+#  define SHUT_WR 1
+# endif
+# ifndef SHUT_RDWR
+#  define SHUT_RDWR 2
+# endif
+				case PTHREADS_STREAM_XPORT_OP_SHUTDOWN: {
+					static const int shutdown_how[] = {SHUT_RD, SHUT_WR, SHUT_RDWR};
+
+					xparam->outputs.returncode = shutdown(sock->socket, shutdown_how[xparam->how]);
+					return PTHREADS_STREAM_OPTION_RETURN_OK;
+				}
+#endif
+
+				default:
+					return PTHREADS_STREAM_OPTION_RETURN_NOTIMPL;
+			}
+
+		default:
+			return PTHREADS_STREAM_OPTION_RETURN_NOTIMPL;
+	}
+}
+
+static int pthreads_sockop_cast(pthreads_stream_t *threaded_stream, int castas, void **ret) {
+	pthreads_stream *stream = PTHREADS_FETCH_STREAMS_STREAM(threaded_stream);
+	pthreads_netstream_data_t *sock = (pthreads_netstream_data_t*)stream->abstract;
+
+	if (!sock) {
+		return FAILURE;
+	}
+
+	switch(castas)	{
+		case PTHREADS_STREAM_AS_STDIO:
+			if (ret)	{
+				*(FILE**)ret = fdopen(sock->socket, stream->mode);
+				if (*ret)
+					return SUCCESS;
+				return FAILURE;
+			}
+			return SUCCESS;
+		case PTHREADS_STREAM_AS_FD_FOR_SELECT:
+		case PTHREADS_STREAM_AS_FD:
+		case PTHREADS_STREAM_AS_SOCKETD:
+			if (ret)
+				*(php_socket_t *)ret = sock->socket;
+			return SUCCESS;
+		default:
+			return FAILURE;
+	}
+}
+/* }}} */
+
+/* These may look identical, but we need them this way so that
+ * we can determine which type of socket we are dealing with
+ * by inspecting stream->ops.
+ * A "useful" side-effect is that the user's scripts can then
+ * make similar decisions using stream_get_meta_data.
+ * */
+const pthreads_stream_ops pthreads_stream_generic_socket_ops = {
+	pthreads_sockop_write, pthreads_sockop_read,
+	pthreads_sockop_close, pthreads_sockop_free,
+	pthreads_sockop_flush,
+	"generic_socket",
+	NULL, /* seek */
+	pthreads_sockop_cast,
+	pthreads_sockop_stat,
+	pthreads_sockop_set_option,
+};
+
+const pthreads_stream_ops pthreads_stream_socket_ops = {
+	pthreads_sockop_write, pthreads_sockop_read,
+	pthreads_sockop_close, pthreads_sockop_free,
+	pthreads_sockop_flush,
+	"tcp_socket",
+	NULL, /* seek */
+	pthreads_sockop_cast,
+	pthreads_sockop_stat,
+	pthreads_tcp_sockop_set_option,
+};
+
+const pthreads_stream_ops pthreads_stream_udp_socket_ops = {
+	pthreads_sockop_write, pthreads_sockop_read,
+	pthreads_sockop_close, pthreads_sockop_free,
+	pthreads_sockop_flush,
+	"udp_socket",
+	NULL, /* seek */
+	pthreads_sockop_cast,
+	pthreads_sockop_stat,
+	pthreads_tcp_sockop_set_option,
+};
+
+#ifdef AF_UNIX
+const pthreads_stream_ops pthreads_stream_unix_socket_ops = {
+	pthreads_sockop_write, pthreads_sockop_read,
+	pthreads_sockop_close, pthreads_sockop_free,
+	pthreads_sockop_flush,
+	"unix_socket",
+	NULL, /* seek */
+	pthreads_sockop_cast,
+	pthreads_sockop_stat,
+	pthreads_tcp_sockop_set_option,
+};
+
+const pthreads_stream_ops pthreads_stream_unixdg_socket_ops = {
+	pthreads_sockop_write, pthreads_sockop_read,
+	pthreads_sockop_close, pthreads_sockop_free,
+	pthreads_sockop_flush,
+	"udg_socket",
+	NULL, /* seek */
+	pthreads_sockop_cast,
+	pthreads_sockop_stat,
+	pthreads_tcp_sockop_set_option,
+};
+#endif
+
+
+/* network socket operations */
+
+#ifdef AF_UNIX
+static inline int parse_unix_address(pthreads_stream_xport_param *xparam, struct sockaddr_un *unix_addr)
+{
+	memset(unix_addr, 0, sizeof(*unix_addr));
+	unix_addr->sun_family = AF_UNIX;
+
+	/* we need to be binary safe on systems that support an abstract
+	 * namespace */
+	if (xparam->inputs.namelen >= sizeof(unix_addr->sun_path)) {
+		/* On linux, when the path begins with a NUL byte we are
+		 * referring to an abstract namespace.  In theory we should
+		 * allow an extra byte below, since we don't need the NULL.
+		 * BUT, to get into this branch of code, the name is too long,
+		 * so we don't care. */
+		xparam->inputs.namelen = sizeof(unix_addr->sun_path) - 1;
+		php_error_docref(NULL, E_NOTICE,
+			"socket path exceeded the maximum allowed length of %lu bytes "
+			"and was truncated", (unsigned long)sizeof(unix_addr->sun_path));
+	}
+
+	memcpy(unix_addr->sun_path, xparam->inputs.name, xparam->inputs.namelen);
+
+	return 1;
+}
+#endif
+
+static inline char *parse_ip_address_ex(const char *str, size_t str_len, int *portno, int get_err, zend_string **err)
+{
+	char *colon;
+	char *host = NULL;
+
+#ifdef HAVE_IPV6
+	char *p;
+
+	if (*(str) == '[' && str_len > 1) {
+		/* IPV6 notation to specify raw address with port (i.e. [fe80::1]:80) */
+		p = memchr(str + 1, ']', str_len - 2);
+		if (!p || *(p + 1) != ':') {
+			if (get_err) {
+				*err = strpprintf(0, "Failed to parse IPv6 address \"%s\"", str);
+			}
+			return NULL;
+		}
+		*portno = atoi(p + 2);
+		return estrndup(str + 1, p - str - 1);
+	}
+#endif
+	if (str_len) {
+		colon = memchr(str, ':', str_len - 1);
+	} else {
+		colon = NULL;
+	}
+	if (colon) {
+		*portno = atoi(colon + 1);
+		host = estrndup(str, colon - str);
+	} else {
+		if (get_err) {
+			*err = strpprintf(0, "Failed to parse address \"%s\"", str);
+		}
+		return NULL;
+	}
+
+	return host;
+}
+
+static inline char *parse_ip_address(pthreads_stream_xport_param *xparam, int *portno) {
+	return parse_ip_address_ex(xparam->inputs.name, xparam->inputs.namelen, portno, xparam->want_errortext, &xparam->outputs.error_text);
+}
+
+static inline int pthreads_tcp_sockop_bind(pthreads_stream_t *threaded_stream, pthreads_netstream_data_t *sock, pthreads_stream_xport_param *xparam) {
+	pthreads_stream *stream = PTHREADS_FETCH_STREAMS_STREAM(threaded_stream);
+	char *host = NULL;
+	int portno, err;
+	long sockopts = PTHREADS_STREAM_SOCKOP_NONE;
+	zval *tmpzval = NULL;
+
+#ifdef AF_UNIX
+	if (stream->ops == &pthreads_stream_unix_socket_ops || stream->ops == &pthreads_stream_unixdg_socket_ops) {
+		struct sockaddr_un unix_addr;
+
+		sock->socket = socket(PF_UNIX, stream->ops == &pthreads_stream_unix_socket_ops ? SOCK_STREAM : SOCK_DGRAM, 0);
+
+		if (sock->socket == SOCK_ERR) {
+			if (xparam->want_errortext) {
+				xparam->outputs.error_text = strpprintf(0, "Failed to create unix%s socket %s",
+						stream->ops == &pthreads_stream_unix_socket_ops ? "" : "datagram",
+						strerror(errno));
+			}
+			return -1;
+		}
+
+		parse_unix_address(xparam, &unix_addr);
+
+		return bind(sock->socket, (const struct sockaddr *)&unix_addr,
+			(socklen_t) XtOffsetOf(struct sockaddr_un, sun_path) + xparam->inputs.namelen);
+	}
+#endif
+
+	host = parse_ip_address(xparam, &portno);
+
+	if (host == NULL) {
+		return -1;
+	}
+
+#ifdef IPV6_V6ONLY
+	if (pthreads_stream_get_context(threaded_stream)
+		&& (tmpzval = pthreads_stream_context_get_option(pthreads_stream_get_context(threaded_stream), "socket", "ipv6_v6only")) != NULL
+		&& Z_TYPE_P(tmpzval) != IS_NULL
+	) {
+		sockopts |= STREAM_SOCKOP_IPV6_V6ONLY;
+		sockopts |= STREAM_SOCKOP_IPV6_V6ONLY_ENABLED * zend_is_true(tmpzval);
+	}
+#endif
+
+#ifdef SO_REUSEPORT
+	if (pthreads_stream_get_context(threaded_stream)
+		&& (tmpzval = pthreads_stream_context_get_option(pthreads_stream_get_context(threaded_stream), "socket", "so_reuseport")) != NULL
+		&& zend_is_true(tmpzval)
+	) {
+		sockopts |= STREAM_SOCKOP_SO_REUSEPORT;
+	}
+#endif
+
+#ifdef SO_BROADCAST
+	if (stream->ops == &pthreads_stream_udp_socket_ops /* SO_BROADCAST is only applicable for UDP */
+		&& pthreads_stream_get_context(threaded_stream)
+		&& (tmpzval = pthreads_stream_context_get_option(pthreads_stream_get_context(threaded_stream), "socket", "so_broadcast")) != NULL
+		&& zend_is_true(tmpzval)
+	) {
+		sockopts |= STREAM_SOCKOP_SO_BROADCAST;
+	}
+#endif
+
+	sock->socket = php_network_bind_socket_to_local_addr(host, portno,
+			stream->ops == &pthreads_stream_udp_socket_ops ? SOCK_DGRAM : SOCK_STREAM,
+			sockopts,
+			xparam->want_errortext ? &xparam->outputs.error_text : NULL,
+			&err
+			);
+
+	if (host) {
+		efree(host);
+	}
+
+	return sock->socket == -1 ? -1 : 0;
+}
+
+static inline int pthreads_tcp_sockop_connect(pthreads_stream_t *threaded_stream, pthreads_netstream_data_t *sock, pthreads_stream_xport_param *xparam)
+{
+	pthreads_stream *stream = PTHREADS_FETCH_STREAMS_STREAM(threaded_stream);
+	char *host = NULL, *bindto = NULL;
+	int portno, bindport = 0;
+	int err = 0;
+	int ret;
+	zval *tmpzval = NULL;
+	long sockopts = STREAM_SOCKOP_NONE;
+
+#ifdef AF_UNIX
+	if (stream->ops == &pthreads_stream_unix_socket_ops || stream->ops == &pthreads_stream_unixdg_socket_ops) {
+		struct sockaddr_un unix_addr;
+
+		sock->socket = socket(PF_UNIX, stream->ops == &pthreads_stream_unix_socket_ops ? SOCK_STREAM : SOCK_DGRAM, 0);
+
+		if (sock->socket == SOCK_ERR) {
+			if (xparam->want_errortext) {
+				xparam->outputs.error_text = strpprintf(0, "Failed to create unix socket");
+			}
+			return -1;
+		}
+
+		parse_unix_address(xparam, &unix_addr);
+
+		ret = php_network_connect_socket(sock->socket,
+				(const struct sockaddr *)&unix_addr, (socklen_t) XtOffsetOf(struct sockaddr_un, sun_path) + xparam->inputs.namelen,
+				xparam->op == PTHREADS_STREAM_XPORT_OP_CONNECT_ASYNC, xparam->inputs.timeout,
+				xparam->want_errortext ? &xparam->outputs.error_text : NULL,
+				&err);
+
+		xparam->outputs.error_code = err;
+
+		goto out;
+	}
+#endif
+
+	host = parse_ip_address(xparam, &portno);
+
+	if (host == NULL) {
+		return -1;
+	}
+
+	if (pthreads_stream_get_context(threaded_stream) && (tmpzval = pthreads_stream_context_get_option(pthreads_stream_get_context(threaded_stream), "socket", "bindto")) != NULL) {
+		if (Z_TYPE_P(tmpzval) != IS_STRING) {
+			if (xparam->want_errortext) {
+				xparam->outputs.error_text = strpprintf(0, "local_addr context option is not a string.");
+			}
+			efree(host);
+			return -1;
+		}
+		bindto = parse_ip_address_ex(Z_STRVAL_P(tmpzval), Z_STRLEN_P(tmpzval), &bindport, xparam->want_errortext, &xparam->outputs.error_text);
+	}
+
+#ifdef SO_BROADCAST
+	if (stream->ops == &pthreads_stream_udp_socket_ops /* SO_BROADCAST is only applicable for UDP */
+		&& pthreads_stream_get_context(threaded_stream)
+		&& (tmpzval = pthreads_stream_context_get_option(pthreads_stream_get_context(threaded_stream), "socket", "so_broadcast")) != NULL
+		&& zend_is_true(tmpzval)
+	) {
+		sockopts |= STREAM_SOCKOP_SO_BROADCAST;
+	}
+#endif
+
+	if (stream->ops != &pthreads_stream_udp_socket_ops /* TCP_NODELAY is only applicable for TCP */
+#ifdef AF_UNIX
+		&& stream->ops != &pthreads_stream_unix_socket_ops
+		&& stream->ops != &pthreads_stream_unixdg_socket_ops
+#endif
+		&& pthreads_stream_get_context(threaded_stream)
+		&& (tmpzval = pthreads_stream_context_get_option(pthreads_stream_get_context(threaded_stream), "socket", "tcp_nodelay")) != NULL
+		&& zend_is_true(tmpzval)
+	) {
+		sockopts |= STREAM_SOCKOP_TCP_NODELAY;
+	}
+
+	/* Note: the test here for pthreads_stream_udp_socket_ops is important, because we
+	 * want the default to be TCP sockets so that the openssl extension can
+	 * re-use this code. */
+
+	sock->socket = php_network_connect_socket_to_host(host, portno,
+			stream->ops == &pthreads_stream_udp_socket_ops ? SOCK_DGRAM : SOCK_STREAM,
+			xparam->op == PTHREADS_STREAM_XPORT_OP_CONNECT_ASYNC,
+			xparam->inputs.timeout,
+			xparam->want_errortext ? &xparam->outputs.error_text : NULL,
+			&err,
+			bindto,
+			bindport,
+			sockopts
+			);
+
+	ret = sock->socket == -1 ? -1 : 0;
+	xparam->outputs.error_code = err;
+
+	if (host) {
+		efree(host);
+	}
+	if (bindto) {
+		efree(bindto);
+	}
+
+#ifdef AF_UNIX
+out:
+#endif
+
+	if (ret >= 0 && xparam->op == PTHREADS_STREAM_XPORT_OP_CONNECT_ASYNC && err == EINPROGRESS) {
+		/* indicates pending connection */
+		return 1;
+	}
+
+	return ret;
+}
+
+static inline int pthreads_tcp_sockop_accept(pthreads_stream_t *threaded_stream, pthreads_netstream_data_t *sock, pthreads_stream_xport_param *xparam) {
+	pthreads_stream *stream = PTHREADS_FETCH_STREAMS_STREAM(threaded_stream);
+	pthreads_stream *client_stream = NULL;
+	int clisock;
+	zend_bool nodelay = 0;
+	zval *tmpzval = NULL;
+
+	xparam->outputs.client = NULL;
+
+	if ((NULL != pthreads_stream_get_context(threaded_stream)) &&
+		(tmpzval = pthreads_stream_context_get_option(pthreads_stream_get_context(threaded_stream), "socket", "tcp_nodelay")) != NULL &&
+		zend_is_true(tmpzval)) {
+		nodelay = 1;
+	}
+
+	clisock = php_network_accept_incoming(sock->socket,
+		xparam->want_textaddr ? &xparam->outputs.textaddr : NULL,
+		xparam->want_addr ? &xparam->outputs.addr : NULL,
+		xparam->want_addr ? &xparam->outputs.addrlen : NULL,
+		xparam->inputs.timeout,
+		xparam->want_errortext ? &xparam->outputs.error_text : NULL,
+		&xparam->outputs.error_code,
+		nodelay);
+
+	if (clisock >= 0) {
+		pthreads_netstream_data_t *clisockdata = (pthreads_netstream_data_t*) malloc(sizeof(*clisockdata));
+
+		memcpy(clisockdata, sock, sizeof(*clisockdata));
+		clisockdata->socket = clisock;
+
+		xparam->outputs.client = PTHREADS_STREAM_NEW(stream->ops, clisockdata, "r+");
+		if (xparam->outputs.client) {
+			pthreads_stream_set_context(xparam->outputs.client, pthreads_stream_get_context(threaded_stream));
+		}
+	}
+
+	return xparam->outputs.client == NULL ? -1 : 0;
+}
+
+static int pthreads_tcp_sockop_set_option(pthreads_stream_t *threaded_stream, int option, int value, void *ptrparam) {
+	pthreads_stream *stream = PTHREADS_FETCH_STREAMS_STREAM(threaded_stream);
+	pthreads_netstream_data_t *sock = (pthreads_netstream_data_t*)stream->abstract;
+	pthreads_stream_xport_param *xparam;
+
+	switch(option) {
+		case PTHREADS_STREAM_OPTION_XPORT_API:
+			xparam = (pthreads_stream_xport_param *)ptrparam;
+
+			switch(xparam->op) {
+				case PTHREADS_STREAM_XPORT_OP_CONNECT:
+				case PTHREADS_STREAM_XPORT_OP_CONNECT_ASYNC:
+					xparam->outputs.returncode = pthreads_tcp_sockop_connect(threaded_stream, sock, xparam);
+					return PTHREADS_STREAM_OPTION_RETURN_OK;
+
+				case PTHREADS_STREAM_XPORT_OP_BIND:
+					xparam->outputs.returncode = pthreads_tcp_sockop_bind(threaded_stream, sock, xparam);
+					return PTHREADS_STREAM_OPTION_RETURN_OK;
+
+				case PTHREADS_STREAM_XPORT_OP_ACCEPT:
+					xparam->outputs.returncode = pthreads_tcp_sockop_accept(threaded_stream, sock, xparam);
+					return PTHREADS_STREAM_OPTION_RETURN_OK;
+				default:
+					/* fall through */
+					;
+			}
+	}
+	return pthreads_sockop_set_option(threaded_stream, option, value, ptrparam);
+}
+
+pthreads_stream_t *pthreads_stream_generic_socket_factory(const char *proto, size_t protolen,
+		const char *resourcename, size_t resourcenamelen,
+		int options, int flags, struct timeval *timeout,
+		pthreads_stream_context_t *threaded_context)
+{
+	pthreads_stream_t *threaded_stream = NULL;
+	pthreads_netstream_data_t *sock;
+	const pthreads_stream_ops *ops;
+
+	/* which type of socket ? */
+	if (strncmp(proto, "tcp", protolen) == 0) {
+		ops = &pthreads_stream_socket_ops;
+	} else if (strncmp(proto, "udp", protolen) == 0) {
+		ops = &pthreads_stream_udp_socket_ops;
+	}
+#ifdef AF_UNIX
+	else if (strncmp(proto, "unix", protolen) == 0) {
+		ops = &pthreads_stream_unix_socket_ops;
+	} else if (strncmp(proto, "udg", protolen) == 0) {
+		ops = &pthreads_stream_unixdg_socket_ops;
+	}
+#endif
+	else {
+		/* should never happen */
+		return NULL;
+	}
+
+	sock = malloc(sizeof(pthreads_netstream_data_t));
+	memset(sock, 0, sizeof(pthreads_netstream_data_t));
+
+	sock->is_blocked = 1;
+	sock->timeout.tv_sec = FG(default_socket_timeout);
+	sock->timeout.tv_usec = 0;
+
+	/* we don't know the socket until we have determined if we are binding or connecting */
+	sock->socket = -1;
+
+	threaded_stream = PTHREADS_STREAM_CLASS_NEW(ops, sock, "r+", pthreads_socket_stream_entry);
+
+	if (threaded_stream == NULL)	{
+		free(sock);
+		return NULL;
+	}
+
+	return threaded_stream;
+}
+
+#endif

--- a/src/url.c
+++ b/src/url.c
@@ -1,0 +1,310 @@
+/*
+  +----------------------------------------------------------------------+
+  | pthreads                                                             |
+  +----------------------------------------------------------------------+
+  | Copyright (c) Joe Watkins 2018                                       |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | http://www.php.net/license/3_01.txt                                  |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors: Bastian Schneider <b.schneider@badnoob.com>                 |
+  | Borrowed code from php-src                                           |
+  +----------------------------------------------------------------------+
+ */
+#ifndef HAVE_PTHREADS_URL
+#define HAVE_PTHREADS_URL
+
+#ifdef HAVE_CONFIG_H
+# include "config.h"
+#endif
+
+#ifndef HAVE_PTHREADS_H
+#	include <src/pthreads.h>
+#endif
+
+#ifndef HAVE_PTHREADS_STREAM_H
+#	include <src/streams.h>
+#endif
+
+#ifndef HAVE_PTHREADS_URL_H
+#	include <src/url.h>
+#endif
+
+/* {{{ free_url */
+void pthreads_url_free(pthreads_url *theurl) {
+	if (theurl->scheme)
+		zend_string_release(theurl->scheme);
+	if (theurl->user)
+		zend_string_release(theurl->user);
+	if (theurl->pass)
+		zend_string_release(theurl->pass);
+	if (theurl->host)
+		zend_string_release(theurl->host);
+	if (theurl->path)
+		zend_string_release(theurl->path);
+	if (theurl->query)
+		zend_string_release(theurl->query);
+	if (theurl->fragment)
+		zend_string_release(theurl->fragment);
+	efree(theurl);
+}
+/* }}} */
+
+/* {{{ pthreads_replace_controlchars */
+char *pthreads_replace_controlchars_ex(char *str, size_t len) {
+	unsigned char *s = (unsigned char *)str;
+	unsigned char *e = (unsigned char *)str + len;
+
+	if (!str) {
+		return (NULL);
+	}
+
+	while (s < e) {
+
+		if (iscntrl(*s)) {
+			*s='_';
+		}
+		s++;
+	}
+
+	return (str);
+}
+/* }}} */
+
+pthreads_url *pthreads_url_parse(char const *str) {
+	return pthreads_url_parse_ex(str, strlen(str));
+}
+
+/* {{{ php_url_parse */
+pthreads_url *pthreads_url_parse_ex(char const *str, size_t length) {
+	char port_buf[6];
+	pthreads_url *ret = ecalloc(1, sizeof(pthreads_url));
+	char const *s, *e, *p, *pp, *ue;
+
+	s = str;
+	ue = s + length;
+
+	/* parse scheme */
+	if ((e = memchr(s, ':', length)) && e != s) {
+		/* validate scheme */
+		p = s;
+		while (p < e) {
+			/* scheme = 1*[ lowalpha | digit | "+" | "-" | "." ] */
+			if (!isalpha(*p) && !isdigit(*p) && *p != '+' && *p != '.' && *p != '-') {
+				if (e + 1 < ue && e < s + strcspn(s, "?#")) {
+					goto parse_port;
+				} else if (s + 1 < ue && *s == '/' && *(s + 1) == '/') { /* relative-scheme URL */
+					s += 2;
+					e = 0;
+					goto parse_host;
+				} else {
+					goto just_path;
+				}
+			}
+			p++;
+		}
+
+		if (e + 1 == ue) { /* only scheme is available */
+			ret->scheme = zend_string_init(s, (e - s), 0);
+			pthreads_replace_controlchars_ex(ZSTR_VAL(ret->scheme), ZSTR_LEN(ret->scheme));
+			return ret;
+		}
+
+		/*
+		 * certain schemas like mailto: and zlib: may not have any / after them
+		 * this check ensures we support those.
+		 */
+		if (*(e+1) != '/') {
+			/* check if the data we get is a port this allows us to
+			 * correctly parse things like a.com:80
+			 */
+			p = e + 1;
+			while (p < ue && isdigit(*p)) {
+				p++;
+			}
+
+			if ((p == ue || *p == '/') && (p - e) < 7) {
+				goto parse_port;
+			}
+
+			ret->scheme = zend_string_init(s, (e-s), 0);
+			pthreads_replace_controlchars_ex(ZSTR_VAL(ret->scheme), ZSTR_LEN(ret->scheme));
+
+			s = e + 1;
+			goto just_path;
+		} else {
+			ret->scheme = zend_string_init(s, (e-s), 0);
+			pthreads_replace_controlchars_ex(ZSTR_VAL(ret->scheme), ZSTR_LEN(ret->scheme));
+
+			if (e + 2 < ue && *(e + 2) == '/') {
+				s = e + 3;
+				if (zend_string_equals_literal_ci(ret->scheme, "file")) {
+					if (e + 3 < ue && *(e + 3) == '/') {
+						/* support windows drive letters as in:
+						   file:///c:/somedir/file.txt
+						*/
+						if (e + 5 < ue && *(e + 5) == ':') {
+							s = e + 4;
+						}
+						goto just_path;
+					}
+				}
+			} else {
+				s = e + 1;
+				goto just_path;
+			}
+		}
+	} else if (e) { /* no scheme; starts with colon: look for port */
+		parse_port:
+		p = e + 1;
+		pp = p;
+
+		while (pp < ue && pp - p < 6 && isdigit(*pp)) {
+			pp++;
+		}
+
+		if (pp - p > 0 && pp - p < 6 && (pp == ue || *pp == '/')) {
+			zend_long port;
+			memcpy(port_buf, p, (pp - p));
+			port_buf[pp - p] = '\0';
+			port = ZEND_STRTOL(port_buf, NULL, 10);
+			if (port > 0 && port <= 65535) {
+				ret->port = (unsigned short) port;
+				if (s + 1 < ue && *s == '/' && *(s + 1) == '/') { /* relative-scheme URL */
+				    s += 2;
+				}
+			} else {
+				php_url_free(ret);
+				return NULL;
+			}
+		} else if (p == pp && pp == ue) {
+			pthreads_url_free(ret);
+			return NULL;
+		} else if (s + 1 < ue && *s == '/' && *(s + 1) == '/') { /* relative-scheme URL */
+			s += 2;
+		} else {
+			goto just_path;
+		}
+	} else if (s + 1 < ue && *s == '/' && *(s + 1) == '/') { /* relative-scheme URL */
+		s += 2;
+	} else {
+		goto just_path;
+	}
+
+	parse_host:
+	/* Binary-safe strcspn(s, "/?#") */
+	e = ue;
+	if ((p = memchr(s, '/', e - s))) {
+		e = p;
+	}
+	if ((p = memchr(s, '?', e - s))) {
+		e = p;
+	}
+	if ((p = memchr(s, '#', e - s))) {
+		e = p;
+	}
+
+	/* check for login and password */
+	if ((p = zend_memrchr(s, '@', (e-s)))) {
+		if ((pp = memchr(s, ':', (p-s)))) {
+			ret->user = zend_string_init(s, (pp-s), 0);
+			pthreads_replace_controlchars_ex(ZSTR_VAL(ret->user), ZSTR_LEN(ret->user));
+
+			pp++;
+			ret->pass = zend_string_init(pp, (p-pp), 0);
+			pthreads_replace_controlchars_ex(ZSTR_VAL(ret->pass), ZSTR_LEN(ret->pass));
+		} else {
+			ret->user = zend_string_init(s, (p-s), 0);
+			pthreads_replace_controlchars_ex(ZSTR_VAL(ret->user), ZSTR_LEN(ret->user));
+		}
+
+		s = p + 1;
+	}
+
+	/* check for port */
+	if (s < ue && *s == '[' && *(e-1) == ']') {
+		/* Short circuit portscan,
+		   we're dealing with an
+		   IPv6 embedded address */
+		p = NULL;
+	} else {
+		p = zend_memrchr(s, ':', (e-s));
+	}
+
+	if (p) {
+		if (!ret->port) {
+			p++;
+			if (e-p > 5) { /* port cannot be longer then 5 characters */
+				pthreads_url_free(ret);
+				return NULL;
+			} else if (e - p > 0) {
+				zend_long port;
+				memcpy(port_buf, p, (e - p));
+				port_buf[e - p] = '\0';
+				port = ZEND_STRTOL(port_buf, NULL, 10);
+				if (port > 0 && port <= 65535) {
+					ret->port = (unsigned short)port;
+				} else {
+					pthreads_url_free(ret);
+					return NULL;
+				}
+			}
+			p--;
+		}
+	} else {
+		p = e;
+	}
+
+	/* check if we have a valid host, if we don't reject the string as url */
+	if ((p-s) < 1) {
+		pthreads_url_free(ret);
+		return NULL;
+	}
+
+	ret->host = zend_string_init(s, (p-s), 0);
+	pthreads_replace_controlchars_ex(ZSTR_VAL(ret->host), ZSTR_LEN(ret->host));
+
+	if (e == ue) {
+		return ret;
+	}
+
+	s = e;
+
+	just_path:
+
+	e = ue;
+	p = memchr(s, '#', (e - s));
+	if (p) {
+		p++;
+		if (p < e) {
+			ret->fragment = zend_string_init(p, (e - p), 0);
+			pthreads_replace_controlchars_ex(ZSTR_VAL(ret->fragment), ZSTR_LEN(ret->fragment));
+		}
+		e = p-1;
+	}
+
+	p = memchr(s, '?', (e - s));
+	if (p) {
+		p++;
+		if (p < e) {
+			ret->query = zend_string_init(p, (e - p), 0);
+			pthreads_replace_controlchars_ex(ZSTR_VAL(ret->query), ZSTR_LEN(ret->query));
+		}
+		e = p-1;
+	}
+
+	if (s < e || s == ue) {
+		ret->path = zend_string_init(s, (e - s), 0);
+		pthreads_replace_controlchars_ex(ZSTR_VAL(ret->path), ZSTR_LEN(ret->path));
+	}
+
+	return ret;
+}
+/* }}} */
+
+#endif

--- a/src/url.h
+++ b/src/url.h
@@ -1,0 +1,38 @@
+/*
+  +----------------------------------------------------------------------+
+  | pthreads                                                             |
+  +----------------------------------------------------------------------+
+  | Copyright (c) Joe Watkins 2018                                       |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | http://www.php.net/license/3_01.txt                                  |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors: Bastian Schneider <b.schneider@badnoob.com>                 |
+  | Borrowed code from php-src                                           |
+  +----------------------------------------------------------------------+
+ */
+#ifndef HAVE_PTHREADS_URL_H
+#define HAVE_PTHREADS_URL_H
+
+typedef struct _pthreads_url {
+	zend_string *scheme;
+	zend_string *user;
+	zend_string *pass;
+	zend_string *host;
+	unsigned short port;
+	zend_string *path;
+	zend_string *query;
+	zend_string *fragment;
+} pthreads_url;
+
+void pthreads_url_free(pthreads_url *theurl);
+pthreads_url *pthreads_url_parse(char const *str);
+pthreads_url *pthreads_url_parse_ex(char const *str, size_t length);
+char *pthreads_replace_controlchars_ex(char *str, size_t len);
+
+#endif

--- a/src/utils.c
+++ b/src/utils.c
@@ -1,0 +1,156 @@
+/*
+  +----------------------------------------------------------------------+
+  | pthreads                                                             |
+  +----------------------------------------------------------------------+
+  | Copyright (c) Joe Watkins 2018                                       |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | http://www.php.net/license/3_01.txt                                  |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors: Bastian Schneider <b.schneider@badnoob.com>                 |
+  | Borrowed code from php-src                                           |
+  +----------------------------------------------------------------------+
+ */
+#ifndef HAVE_PTHREADS_UTILS
+#define HAVE_PTHREADS_UTILS
+
+#ifndef HAVE_PTHREADS_H
+#	include <src/pthreads.h>
+#endif
+
+#ifndef HAVE_PTHREADS_UTILS_H
+#	include <src/utils.h>
+#endif
+
+#include "php.h"
+
+zend_string *pthreads_addslashes(zend_string *str)
+{
+	/* maximum string length, worst case situation */
+	char *target;
+	const char *source, *end;
+	size_t offset;
+	zend_string *new_str;
+
+	if (!str) {
+		return ZSTR_EMPTY_ALLOC();
+	}
+
+	source = ZSTR_VAL(str);
+	end = source + ZSTR_LEN(str);
+
+	while (source < end) {
+		switch (*source) {
+			case '\0':
+			case '\'':
+			case '\"':
+			case '\\':
+				goto do_escape;
+			default:
+				source++;
+				break;
+		}
+	}
+
+	return zend_string_copy(str);
+
+do_escape:
+	offset = source - (char *)ZSTR_VAL(str);
+	new_str = zend_string_safe_alloc(2, ZSTR_LEN(str) - offset, offset, 0);
+	memcpy(ZSTR_VAL(new_str), ZSTR_VAL(str), offset);
+	target = ZSTR_VAL(new_str) + offset;
+
+	while (source < end) {
+		switch (*source) {
+			case '\0':
+				*target++ = '\\';
+				*target++ = '0';
+				break;
+			case '\'':
+			case '\"':
+			case '\\':
+				*target++ = '\\';
+				/* break is missing *intentionally* */
+			default:
+				*target++ = *source;
+				break;
+		}
+		source++;
+	}
+
+	*target = '\0';
+
+	if (ZSTR_LEN(new_str) - (target - ZSTR_VAL(new_str)) > 16) {
+		new_str = zend_string_truncate(new_str, target - ZSTR_VAL(new_str), 0);
+	} else {
+		ZSTR_LEN(new_str) = target - ZSTR_VAL(new_str);
+	}
+
+	return new_str;
+}
+
+zend_string* zval_get_string_func(zval *op) /* {{{ */
+{
+try_again:
+	switch (Z_TYPE_P(op)) {
+		case IS_UNDEF:
+		case IS_NULL:
+		case IS_FALSE:
+			return ZSTR_EMPTY_ALLOC();
+		case IS_TRUE:
+			return ZSTR_CHAR('1');
+		case IS_RESOURCE: {
+			return zend_strpprintf(0, "Resource id #" ZEND_LONG_FMT, (zend_long)Z_RES_HANDLE_P(op));
+		}
+		case IS_LONG: {
+			return zend_long_to_str(Z_LVAL_P(op));
+		}
+		case IS_DOUBLE: {
+			return zend_strpprintf(0, "%.*G", (int) EG(precision), Z_DVAL_P(op));
+		}
+		case IS_ARRAY:
+			zend_error(E_NOTICE, "Array to string conversion");
+			return zend_string_init("Array", sizeof("Array")-1, 0);
+		case IS_OBJECT: {
+			zval tmp;
+			if (Z_OBJ_HT_P(op)->cast_object) {
+				if (Z_OBJ_HT_P(op)->cast_object(op, &tmp, IS_STRING) == SUCCESS) {
+					return Z_STR(tmp);
+				}
+			} else if (Z_OBJ_HT_P(op)->get) {
+				zval *z = Z_OBJ_HT_P(op)->get(op, &tmp);
+				if (Z_TYPE_P(z) != IS_OBJECT) {
+					zend_string *str = zval_get_string(z);
+					zval_ptr_dtor(z);
+					return str;
+				}
+				zval_ptr_dtor(z);
+			}
+			zend_error(EG(exception) ? E_ERROR : E_RECOVERABLE_ERROR, "Object of class %s could not be converted to string", ZSTR_VAL(Z_OBJCE_P(op)->name));
+			return ZSTR_EMPTY_ALLOC();
+		}
+		case IS_REFERENCE:
+			op = Z_REFVAL_P(op);
+			goto try_again;
+		case IS_STRING:
+			return zend_string_copy(Z_STR_P(op));
+		EMPTY_SWITCH_DEFAULT_CASE()
+	}
+	return NULL;
+}
+
+zend_string *zval_get_tmp_string(zval *op, zend_string **tmp) {
+	if (EXPECTED(Z_TYPE_P(op) == IS_STRING)) {
+		*tmp = NULL;
+		return Z_STR_P(op);
+	} else {
+		return *tmp = zval_get_string_func(op);
+	}
+}
+
+#endif

--- a/src/utils.h
+++ b/src/utils.h
@@ -1,0 +1,26 @@
+/*
+  +----------------------------------------------------------------------+
+  | pthreads                                                             |
+  +----------------------------------------------------------------------+
+  | Copyright (c) Joe Watkins 2018                                       |
+  +----------------------------------------------------------------------+
+  | This source file is subject to version 3.01 of the PHP license,      |
+  | that is bundled with this package in the file LICENSE, and is        |
+  | available through the world-wide-web at the following url:           |
+  | http://www.php.net/license/3_01.txt                                  |
+  | If you did not receive a copy of the PHP license and are unable to   |
+  | obtain it through the world-wide-web, please send a note to          |
+  | license@php.net so we can mail you a copy immediately.               |
+  +----------------------------------------------------------------------+
+  | Authors: Bastian Schneider <b.schneider@badnoob.com>                 |
+  | Borrowed code from php-src                                           |
+  +----------------------------------------------------------------------+
+ */
+#ifndef HAVE_PTHREADS_UTILS_H
+#define HAVE_PTHREADS_UTILS_H
+
+zend_string *pthreads_addslashes(zend_string *str);
+zend_string* zval_get_string_func(zval *op);
+zend_string *zval_get_tmp_string(zval *op, zend_string **tmp);
+
+#endif

--- a/tests/complex-statics-set-null.phpt
+++ b/tests/complex-statics-set-null.phpt
@@ -2,17 +2,17 @@
 Test NULLing ressources in arrays
 --FILE--
 <?php
-class file {
+class DummyFile {
 	public static $fps;
 
 	public static function __callstatic($method, $args) {
 		$tid = Thread::getCurrentThreadId();
 		if (isset(self::$fps[$tid])) {
-			return call_user_func_array(array("file", "_{$method}"), array_merge($args, array($tid)));
+			return call_user_func_array(array("DummyFile", "_{$method}"), array_merge($args, array($tid)));
 		} else {
 			self::$fps[$tid] = fopen(__FILE__, "r+");
 			if (isset(self::$fps[$tid]))
-				return call_user_func_array(array("file", "_{$method}"), array_merge($args, array($tid)));
+				return call_user_func_array(array("DummyFile", "_{$method}"), array_merge($args, array($tid)));
 		}
 	}
 	
@@ -26,38 +26,38 @@ class UserThread extends Thread {
 	public function run () {
 		/* execute calls */
 		$i = 2;
-		file::get("something".(++$i));
-		file::get("something".(++$i));
+		DummyFile::get("something".(++$i));
+		DummyFile::get("something".(++$i));
 		
 	}
 }
 
 $i = 0;
 
-file::get("something".(++$i));
-file::get("something".(++$i));
+DummyFile::get("something".(++$i));
+DummyFile::get("something".(++$i));
 
 $thread = new UserThread();
 $thread->start();
 $thread->join();
 ?>
 --EXPECTF--
-file::_get: something1
+DummyFile::_get: something1
 array(1) {
   [%i]=>
   resource(5) of type (stream)
 }
-file::_get: something2
+DummyFile::_get: something2
 array(1) {
   [%i]=>
   resource(5) of type (stream)
 }
-file::_get: something3
+DummyFile::_get: something3
 array(1) {
   [%i]=>
   resource(2) of type (stream)
 }
-file::_get: something4
+DummyFile::_get: something4
 array(1) {
   [%i]=>
   resource(2) of type (stream)

--- a/tests/doc-comments.phpt
+++ b/tests/doc-comments.phpt
@@ -42,7 +42,7 @@ var_dump($reflect->getDocComment());
 
 ?>
 --EXPECTF--
-object(ReflectionMethod)#2 (2) {
+object(ReflectionMethod)#%d (2) {
   ["name"]=>
   string(3) "run"
   ["class"]=>
@@ -54,7 +54,7 @@ string(%d) "/**
     * @package package
     * @subpackage subpackage
     */"
-object(ReflectionMethod)#2 (2) {
+object(ReflectionMethod)#%d (2) {
   ["name"]=>
   string(3) "run"
   ["class"]=>

--- a/tests/inherited-anon-class-outside-context.phpt
+++ b/tests/inherited-anon-class-outside-context.phpt
@@ -49,8 +49,8 @@ while(true) {
 	}
 }
 $test->join();
---EXPECT--
-object(class@anonymous)#2 (3) {
+--EXPECTF--
+object(class@anonymous)#%d (3) {
   ["pubProp"]=>
   NULL
   ["protProp"]=>
@@ -59,7 +59,7 @@ object(class@anonymous)#2 (3) {
   NULL
 }
 string(13) "anonymous run"
-object(class@anonymous)#2 (4) {
+object(class@anonymous)#%d (4) {
   ["pubProp"]=>
   NULL
   ["protProp"]=>

--- a/tests/isset-unset.phpt
+++ b/tests/isset-unset.phpt
@@ -20,8 +20,8 @@ for($i = 0; $i < 10; $i ++) {
     printf("\n");
 }
 ?>
---EXPECT--
-object(Storage)#1 (10) {
+--EXPECTF--
+object(Storage)#%d (10) {
   [0]=>
   int(1)
   [1]=>

--- a/tests/merging-members.phpt
+++ b/tests/merging-members.phpt
@@ -28,8 +28,8 @@ $stores[0]->merge($stores[1], false);
 
 var_dump($stores[0]);
 ?>
---EXPECT--
-object(Store)#1 (3) {
+--EXPECTF--
+object(Store)#%d (3) {
   ["test"]=>
   string(3) "two"
   ["other"]=>
@@ -37,7 +37,7 @@ object(Store)#1 (3) {
   ["next"]=>
   float(0.01)
 }
-object(Store)#1 (3) {
+object(Store)#%d (3) {
   ["test"]=>
   string(3) "one"
   ["other"]=>

--- a/tests/null-member-crash.phpt
+++ b/tests/null-member-crash.phpt
@@ -12,7 +12,7 @@ $test = new Test();
 var_dump($test);
 ?>
 --EXPECTF--
-object(Test)#1 (1) {
+object(Test)#%d (1) {
   [0]=>
   string(4) "what"
 }

--- a/tests/object-cast.phpt
+++ b/tests/object-cast.phpt
@@ -39,10 +39,10 @@ $test->start() && $test->join();
 
 var_dump($thing);
 ?>
---EXPECT--
-object(Threaded)#1 (1) {
+--EXPECTF--
+object(Threaded)#%d (1) {
   ["member"]=>
-  object(Threaded)#2 (0) {
+  object(Threaded)#%d (0) {
   }
 }
 

--- a/tests/recv-overload.phpt
+++ b/tests/recv-overload.phpt
@@ -34,10 +34,10 @@ $test->start() && $test->join();
 
 var_dump($test);
 ?>
---EXPECT--
-object(Test)#2 (1) {
+--EXPECTF--
+object(Test)#%d (1) {
   ["member"]=>
-  object(Custom)#1 (0) {
+  object(Custom)#%d (0) {
   }
 }
 

--- a/tests/shift-pop.phpt
+++ b/tests/shift-pop.phpt
@@ -23,22 +23,22 @@ while (($next = $s->pop())) {
     var_dump($next);
 }
 ?>
---EXPECT--
-object(S)#1 (1) {
+--EXPECTF--
+object(S)#%d (1) {
   [0]=>
   string(4) "help"
 }
 string(4) "help"
-object(S)#1 (0) {
+object(S)#%d (0) {
 }
-object(S)#1 (1) {
+object(S)#%d (1) {
   [1]=>
   string(4) "next"
 }
 string(4) "next"
-object(S)#1 (0) {
+object(S)#%d (0) {
 }
-object(S)#1 (100) {
+object(S)#%d (100) {
   [1]=>
   int(1)
   [2]=>

--- a/tests/statics-thorn-in-other-side.phpt
+++ b/tests/statics-thorn-in-other-side.phpt
@@ -33,26 +33,26 @@ echo "\n";
 BEFORE:
 array(2) {
   [0]=>
-  object(StaticClass)#1 (0) {
+  object(StaticClass)#%d (0) {
   }
   [1]=>
-  object(StaticClass)#2 (0) {
+  object(StaticClass)#%d (0) {
   }
 }
 string(11) "randomvalue"
-object(StaticClass)#2 (0) {
+object(StaticClass)#%d (0) {
 }
 
 AFTER
 array(2) {
   [0]=>
-  object(StaticClass)#1 (0) {
+  object(StaticClass)#%d (0) {
   }
   [1]=>
-  object(StaticClass)#2 (0) {
+  object(StaticClass)#%d (0) {
   }
 }
 string(11) "randomvalue"
-object(StaticClass)#2 (0) {
+object(StaticClass)#%d (0) {
 }
 

--- a/tests/streams/streams_get_wrappers.phpt
+++ b/tests/streams/streams_get_wrappers.phpt
@@ -1,0 +1,25 @@
+--TEST--
+array Streams::getWrappers ( void );
+--FILE--
+<?php
+var_dump(Streams::getWrappers());
+class Foo extends Threaded { }
+Streams::registerWrapper("foo", "Foo");
+var_dump(in_array("foo", Streams::getWrappers()));
+?>
+--EXPECT--
+array(6) {
+  [0]=>
+  string(3) "php"
+  [1]=>
+  string(4) "file"
+  [2]=>
+  string(4) "glob"
+  [3]=>
+  string(4) "data"
+  [4]=>
+  string(4) "http"
+  [5]=>
+  string(3) "ftp"
+}
+bool(true)

--- a/tests/verify-overload.phpt
+++ b/tests/verify-overload.phpt
@@ -44,8 +44,8 @@ $custom = new Custom();
 $test = new Test($custom);
 $test->start() && $test->join();
 ?>
---EXPECT--
-object(Custom)#1 (0) {
+--EXPECTF--
+object(Custom)#%d (0) {
 }
 int(1)
 string(1) "1"


### PR DESCRIPTION
This is a thread-safe port of the php streams layer, including wrappers, transports and filters. Resources were replaced by objects and the following new classes introduced.

* `Streams`
* `File`
* `Stream`
* `StreamContext`
* `StreamWrapper`
* `StreamFilter`
* `StreamBucket`
* `StreamBucketBrigade`
* `pthreads_user_filter`
* `FileStream`
* `SocketStream`

See [stub.php](https://github.com/krakjoe/pthreads/blob/6a88bdcdc5b439568b3708e2b81be1c406046f16/examples/stub.php). A `File` class definition in global scope will be a huge BC break though. Maybe we will find another name or introduce a namespace, whatever that looks like.

Predefined wrappers
* php
  * temp
  * memory
  * output
  * stdin
  * stdout
  * stderr
  * fd/
  * filter/
* file
* glob
* data
* ftp
* http

Predefined filters
* `string.rot13`
* `string.toupper`
* `string.tolower`

Todo
* I've no idea why travis fails. Maybe you have an idea.
* Tests
* more Tests
* Windows build and testing

What's next? Removal of Todos for sure. I would like to publish this in a timely manner as prerelease in a separate branch to get audience and feedback. Possibly with other BC breaking changes like #906 and the behavior of static members initialization.

On top of this PR a port of the openssl "ssl" wrapper will follow.

@tpunt @dktapps Thoughts, questions?

**Big thanks to the team behind php-src!**