### PR TITLE
Added support for igbinary serializer

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -7,6 +7,9 @@ PHP_ARG_WITH(pthreads-sanitize, whether to enable AddressSanitizer for pthreads,
 PHP_ARG_WITH(pthreads-dmalloc, whether to enable dmalloc for pthreads,
 [  --with-pthreads-dmalloc   Enable dmalloc for pthreads], no, no)
 
+PHP_ARG_WITH(pthreads-igbinary, whether to enable igbinary support for pthreads,
+[  --with-pthreads-igbinary   Enable igbinary serializer for pthreads], no, no)
+
 if test "$PHP_PTHREADS" != "no"; then
 	AC_MSG_CHECKING([for ZTS])   
 	if test "$PHP_THREAD_SAFETY" != "no"; then
@@ -28,6 +31,10 @@ if test "$PHP_PTHREADS" != "no"; then
 	fi
 
 	PHP_NEW_EXTENSION(pthreads, php_pthreads.c src/monitor.c src/stack.c src/globals.c src/prepare.c src/store.c src/resources.c src/handlers.c src/object.c src/socket.c, $ext_shared,, -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1)
+	if test "$PHP_PTHREADS_IGBINARY" != "no"; then
+		PHP_ADD_EXTENSION_DEP(pthreads, igbinary)
+		AC_DEFINE(HAVE_PTHREADS_IGBINARY, 1, [Whether pthreads has igbinary support])
+	fi
 	PHP_ADD_BUILD_DIR($ext_builddir/src, 1)
 	PHP_ADD_INCLUDE($ext_builddir)
 	PHP_SUBST(PTHREADS_SHARED_LIBADD)

--- a/config.w32
+++ b/config.w32
@@ -6,6 +6,7 @@ var PTHREADS_EXT_FLAGS="/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1 /I" + configure_modu
 var PTHREADS_EXT_DEP="pthreadVC2.lib";
 /* --------------------------------------------------------------------- */
 ARG_WITH("pthreads", "for pthreads support", "no");
+ARG_WITH("pthreads-igbinary", "for igbinary support in pthreads", "no");
 
 if (PHP_PTHREADS != "no") {
 	if(CHECK_HEADER_ADD_INCLUDE("pthread.h", "CFLAGS_PTHREADS", PHP_PTHREADS + ";" + configure_module_dirname) &&    
@@ -19,6 +20,10 @@ if (PHP_PTHREADS != "no") {
 			PTHREADS_EXT_SRC, 
 			PTHREADS_EXT_NAME
 		);
+		if(PHP_PTHREADS_IGBINARY != "no"){
+			ADD_EXTENSION_DEP(PTHREADS_EXT_NAME, 'igbinary');
+			AC_DEFINE('HAVE_PTHREADS_IGBINARY', 1, 'Whether pthreads has igbinary support', false);
+		}
 	} else {
 		WARNING("pthreads not enabled; libraries and headers not found");
 	}

--- a/php_pthreads.c
+++ b/php_pthreads.c
@@ -51,8 +51,17 @@
 #	include <src/copy.h>
 #endif
 
+const static zend_module_dep pthreads_module_deps[] = {
+#ifdef HAVE_PTHREADS_IGBINARY
+	ZEND_MOD_REQUIRED("igbinary")
+#endif
+	ZEND_MOD_END
+};
+
 zend_module_entry pthreads_module_entry = {
-  STANDARD_MODULE_HEADER,
+  STANDARD_MODULE_HEADER_EX,
+  NULL,
+  pthreads_module_deps,
   PHP_PTHREADS_EXTNAME,
   NULL,
   PHP_MINIT(pthreads),
@@ -880,6 +889,11 @@ PHP_MINFO_FUNCTION(pthreads)
 {
 	php_info_print_table_start();
 	php_info_print_table_row(2, "Version", PHP_PTHREADS_VERSION);
+#ifdef HAVE_PTHREADS_IGBINARY
+	php_info_print_table_row(2, "Serializer", "igbinary");
+#else
+	php_info_print_table_row(2, "Serializer", "standard");
+#endif
 	php_info_print_table_end();
 }
 

--- a/src/store.c
+++ b/src/store.c
@@ -42,6 +42,9 @@
 #	include <src/store.h>
 #endif
 
+#ifdef HAVE_PTHREADS_IGBINARY
+#include "ext/igbinary/igbinary.h"
+#endif
 
 #define PTHREADS_STORAGE_EMPTY {0, 0, 0, 0, NULL}
 
@@ -788,15 +791,36 @@ static inline int pthreads_store_remove_complex(zval *pzval) {
 	return ZEND_HASH_APPLY_KEEP;
 } /* }}} */
 
+#ifdef HAVE_PTHREADS_IGBINARY
+/* {{{ igbinary memory manager wrappers */
+static inline void* pthreads_igbinary_malloc(size_t size, void *context) {
+	(void)context;
+	return malloc(size);
+}
+
+static inline void* pthreads_igbinary_realloc(void *ptr, size_t new_size, void *context) {
+	(void)context;
+	return realloc(ptr, new_size);
+}
+
+static inline void pthreads_igbinary_free(void *ptr, void *context) {
+	(void)context;
+	free(ptr);
+}
+/* }}} */
+#endif
+
 /* {{{ */
 static int pthreads_store_tostring(zval *pzval, char **pstring, size_t *slength, zend_bool complex) {
 	int result = FAILURE;
 	if (pzval && (Z_TYPE_P(pzval) != IS_NULL)) {
-		smart_str smart;
 		HashTable *tmp = NULL;
 		zval ztmp;
+#ifndef HAVE_PTHREADS_IGBINARY
+		smart_str smart;
 
 		memset(&smart, 0, sizeof(smart_str));
+#endif
 
 		if (Z_TYPE_P(pzval) == IS_ARRAY && !complex) {
 			tmp = zend_array_dup(Z_ARRVAL_P(pzval));
@@ -809,14 +833,28 @@ static int pthreads_store_tostring(zval *pzval, char **pstring, size_t *slength,
 
 		if ((Z_TYPE_P(pzval) != IS_OBJECT) ||
 			(Z_OBJCE_P(pzval)->serialize != zend_class_serialize_deny)) {
+			int ret = 0;
+#ifdef HAVE_PTHREADS_IGBINARY
+			struct igbinary_memory_manager manager = {
+				pthreads_igbinary_malloc,
+				pthreads_igbinary_realloc,
+				pthreads_igbinary_free,
+				NULL
+			};
+
+			ret = igbinary_serialize_ex((uint8_t **) pstring, slength, pzval, &manager);
+#else
 			php_serialize_data_t vars;
 
 			PHP_VAR_SERIALIZE_INIT(vars);
 			php_var_serialize(&smart, pzval, &vars);
 			PHP_VAR_SERIALIZE_DESTROY(vars);
+#endif
 
-			if (EG(exception)) {
+			if (EG(exception) || ret != 0) {
+#ifndef HAVE_PTHREADS_IGBINARY
 				smart_str_free(&smart);
+#endif
 
 				if (tmp) {
 					zval_dtor(&ztmp);
@@ -832,6 +870,9 @@ static int pthreads_store_tostring(zval *pzval, char **pstring, size_t *slength,
 			zval_dtor(&ztmp);
 		}
 
+#ifdef HAVE_PTHREADS_IGBINARY
+		result = SUCCESS;
+#else
 		if (smart.s) {
 			*slength = smart.s->len;
 			if (*slength) {
@@ -845,8 +886,9 @@ static int pthreads_store_tostring(zval *pzval, char **pstring, size_t *slength,
 				}
 			} else *pstring = NULL;
 		}
-		
-		smart_str_free(&smart);	
+
+		smart_str_free(&smart);
+#endif
 	} else {
 	    *slength = 0;
 	    *pstring = NULL;
@@ -859,6 +901,7 @@ static int pthreads_store_tozval(zval *pzval, char *pstring, size_t slength) {
 	int result = SUCCESS;
 	
 	if (pstring) {
+#ifndef HAVE_PTHREADS_IGBINARY
 		const unsigned char* pointer = (const unsigned char*) pstring;
 
 		if (pointer) {
@@ -870,6 +913,13 @@ static int pthreads_store_tozval(zval *pzval, char *pstring, size_t slength) {
 			}
 			PHP_VAR_UNSERIALIZE_DESTROY(vars);
 		} else result = FAILURE;
+#else
+		const uint8_t * pointer = (const uint8_t *)pstring;
+
+		if (!pointer || igbinary_unserialize(pointer, slength, pzval) != 0) {
+			result = FAILURE;
+		}
+#endif
 	} else result = FAILURE;
 	
 	return result;

--- a/src/store.c
+++ b/src/store.c
@@ -807,6 +807,13 @@ static inline void pthreads_igbinary_free(void *ptr, void *context) {
 	(void)context;
 	free(ptr);
 }
+
+static const struct igbinary_memory_manager igbinary_mem_manager = {
+	pthreads_igbinary_malloc,
+	pthreads_igbinary_realloc,
+	pthreads_igbinary_free,
+	NULL
+};
 /* }}} */
 #endif
 
@@ -835,14 +842,7 @@ static int pthreads_store_tostring(zval *pzval, char **pstring, size_t *slength,
 			(Z_OBJCE_P(pzval)->serialize != zend_class_serialize_deny)) {
 			int ret = 0;
 #ifdef HAVE_PTHREADS_IGBINARY
-			struct igbinary_memory_manager manager = {
-				pthreads_igbinary_malloc,
-				pthreads_igbinary_realloc,
-				pthreads_igbinary_free,
-				NULL
-			};
-
-			ret = igbinary_serialize_ex((uint8_t **) pstring, slength, pzval, &manager);
+			ret = igbinary_serialize_ex((uint8_t **) pstring, slength, pzval, &igbinary_mem_manager);
 #else
 			php_serialize_data_t vars;
 


### PR DESCRIPTION
[igbinary](https://github.com/igbinary/igbinary) is faster and uses less memory, at the cost of readability. This is perfect for pthreads.

This code is not very pretty and could probably use some cosmetic enhancement. However, this works fine (apart from some behavioural quirks) so I'm pulling this to get feedback.

Pass `--with-pthreads-igbinary` at compile-time to enable it.

CI does not currently test with igbinary enabled - that's a TODO.

This closes #834 .