### PR TITLE
String constants created by define() are not always interned

### DIFF
--- a/src/prepare.c
+++ b/src/prepare.c
@@ -614,7 +614,7 @@ static inline void pthreads_prepare_constants(pthreads_object_t* thread) {
 						} break;
 						case IS_DOUBLE: Z_DVAL(constant.value)=Z_DVAL(zconstant->value); break;
 						case IS_STRING: {
-							ZVAL_NEW_STR(&constant.value, zend_string_new(Z_STR(zconstant->value)));
+							ZVAL_STR(&constant.value, zend_string_new(Z_STR(zconstant->value)));
 						} break;
 						case IS_ARRAY: {
 							pthreads_store_separate(&zconstant->value, &constant.value, 1);

--- a/src/prepare.c
+++ b/src/prepare.c
@@ -614,7 +614,7 @@ static inline void pthreads_prepare_constants(pthreads_object_t* thread) {
 						} break;
 						case IS_DOUBLE: Z_DVAL(constant.value)=Z_DVAL(zconstant->value); break;
 						case IS_STRING: {
-							Z_STR(constant.value) = zend_string_new(Z_STR(zconstant->value));
+							ZVAL_NEW_STR(&constant.value, zend_string_new(Z_STR(zconstant->value)));
 						} break;
 						case IS_ARRAY: {
 							pthreads_store_separate(&zconstant->value, &constant.value, 1);


### PR DESCRIPTION
A premature optimization was introduced to constant string copying in a473944746b778b41c70b7fb25037dd97e10ff0d and worsened in de5d8f2c973890187ba23c6f7e7547e99b602fac, which caused faults with string copying of constants created using define().

For example, [this string](https://github.com/pmmp/PocketMine-MP/blob/adb78679c56f06a33f8ca1bd1f7fbf903af6fa5d/src/pocketmine/level/format/SubChunk.php#L37) is allocated using str_repeat() and is not interned. This caused faults later on when modifying a copy of this string assigned to a variable (copy on write issues).

I do not have a test case for this fault, but it was identified with VS debugger and noting that the type_info of the copied zval did not match the original (refcount flag was missing).