### PR TITLE
Remove HAVE_SPL

### DIFF
--- a/php_pthreads.c
+++ b/php_pthreads.c
@@ -79,12 +79,6 @@ zend_object_handlers pthreads_socket_handlers;
 zend_object_handlers *zend_handlers;
 void ***pthreads_instance = NULL;
 
-#ifndef HAVE_SPL
-zend_class_entry *spl_ce_InvalidArgumentException;
-zend_class_entry *spl_ce_Countable;
-zend_class_entry *spl_ce_RuntimeException;
-#endif
-
 #ifndef HAVE_PTHREADS_OBJECT_H
 #	include <src/object.h>
 #endif
@@ -803,12 +797,6 @@ PHP_MINIT_FUNCTION(pthreads)
 		*/
 		pthreads_instance = TSRMLS_CACHE;
 	}
-
-#ifndef HAVE_SPL
-	spl_ce_InvalidArgumentException = zend_exception_get_default();
-	spl_ce_Countable                = zend_exception_get_default();
-	spl_ce_RuntimeException		= zend_exception_get_default();
-#endif
 
 	zend_set_user_opcode_handler(ZEND_RECV, php_pthreads_recv);
 	zend_set_user_opcode_handler(ZEND_VERIFY_RETURN_TYPE, php_pthreads_verify_return_type);

--- a/src/pthreads.h
+++ b/src/pthreads.h
@@ -52,14 +52,8 @@
 #include <ext/standard/info.h>
 #include <ext/standard/basic_functions.h>
 #include <ext/standard/php_var.h>
-#ifdef HAVE_SPL
 #include <ext/spl/spl_exceptions.h>
 #include <ext/spl/spl_iterators.h>
-#else
-extern zend_class_entry *spl_ce_InvalidArgumentException;
-extern zend_class_entry *spl_ce_Countable;
-#endif
-
 #include <Zend/zend.h>
 #include <Zend/zend_closures.h>
 #include <Zend/zend_compile.h>


### PR DESCRIPTION
The HAVE_SPL symbol is defined in PHP to indicate the presence of the spl extension. Since PHP 5.3 the spl extension is always available and since PHP-7.4 the HAVE_SPL symbol has also been removed.