### PR TITLE
fix superglobals JIT

### DIFF
--- a/tests/superglobals.phpt
+++ b/tests/superglobals.phpt
@@ -1,0 +1,25 @@
+--TEST--
+Test JIT superglobals
+--DESCRIPTION--
+This test verifies that superglobals which are JIT-inited are properly registered
+--INI--
+auto_globals_jit=1
+variables_order=ES
+--FILE--
+<?php
+
+class TestThread extends Thread {
+	public function run() {
+		var_dump(is_array($GLOBALS));
+		var_dump(is_array($_SERVER));
+		var_dump(is_array($_ENV));
+	}
+}
+
+$thread = new TestThread();
+$thread->start();
+?>
+--EXPECT--
+bool(true)
+bool(true)
+bool(true)


### PR DESCRIPTION
Superglobals referenced in copied code are not initialized because they are JIT-initialized when compiled. This can be worked around by setting `auto_globals_jit` to `0` or with this code.

Ideally we would manually JIT these from copied functions like parallel, but this solution is simpler and works well enough as a stopgap for now.