### PR TITLE
inherit argc/argv

### DIFF
--- a/src/prepare.c
+++ b/src/prepare.c
@@ -750,6 +750,10 @@ int pthreads_prepared_startup(pthreads_object_t* thread, pthreads_monitor_t *rea
 		SG(server_context) = 
 			PTHREADS_SG(thread->creator.ls, server_context);
 
+		SG(request_info).argc = PTHREADS_SG(thread->creator.ls, request_info).argc;
+
+		SG(request_info).argv = PTHREADS_SG(thread->creator.ls, request_info).argv;
+
 		PG(expose_php) = 0;
 		PG(auto_globals_jit) = 0;
 

--- a/tests/argc-argv.phpt
+++ b/tests/argc-argv.phpt
@@ -1,0 +1,26 @@
+--TEST--
+Test argc/argv inheritance
+--DESCRIPTION--
+Verifies that argc and argv are present and correct on threads.
+--INI--
+register_argc_argv=1
+--ARGS--
+--test=1
+--FILE--
+<?php
+$t = new class extends Thread{
+	public function run() : void{
+		global $argc, $argv;
+		var_dump($argc, $argv);
+	}
+};
+$t->start();
+?>
+--EXPECTF--
+int(2)
+array(2) {
+  [0]=>
+  string(%d) "%s"
+  [1]=>
+  string(8) "--test=1"
+}

--- a/tests/getopt.phpt
+++ b/tests/getopt.phpt
@@ -1,0 +1,55 @@
+--TEST--
+Test getopt() works as desired on threads
+--ARGS--
+--arg value --arg=value -avalue -a=value -a value
+--INI--
+register_argc_argv=On
+variables_order=GPS
+--FILE--
+<?php
+var_dump(getopt("a:", array("arg:")));
+
+$t = new class extends Thread{
+	public function run() : void{
+		var_dump(getopt("a:", array("arg:")));
+	}
+};
+$t->start() && $t->join();
+?>
+--EXPECT--
+array(2) {
+  ["arg"]=>
+  array(2) {
+    [0]=>
+    string(5) "value"
+    [1]=>
+    string(5) "value"
+  }
+  ["a"]=>
+  array(3) {
+    [0]=>
+    string(5) "value"
+    [1]=>
+    string(5) "value"
+    [2]=>
+    string(5) "value"
+  }
+}
+array(2) {
+  ["arg"]=>
+  array(2) {
+    [0]=>
+    string(5) "value"
+    [1]=>
+    string(5) "value"
+  }
+  ["a"]=>
+  array(3) {
+    [0]=>
+    string(5) "value"
+    [1]=>
+    string(5) "value"
+    [2]=>
+    string(5) "value"
+  }
+}


### PR DESCRIPTION
As far as I understand there are no thread safety problems with this, although if there are then it would be trivial to duplicate `argv`.

This change fixes functions such as `getopt()` not working on threads, as well as the globals `$argc` and `$argv` being missing.

Tests are TBD. I pulled this to get third party review in case I missed some obvious problem with the code changes.